### PR TITLE
Implemented by-type and by-template route-generator

### DIFF
--- a/Admin/ArticleJsConfig.php
+++ b/Admin/ArticleJsConfig.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Admin;
 
 use Sulu\Bundle\AdminBundle\Admin\JsConfigInterface;
-use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\ArticleBundle\Metadata\ArticleTypeTrait;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 
 /**
@@ -20,7 +20,7 @@ use Sulu\Component\Content\Compat\StructureManagerInterface;
  */
 class ArticleJsConfig implements JsConfigInterface
 {
-    use TypeTrait;
+    use ArticleTypeTrait;
 
     /**
      * @var StructureManagerInterface

--- a/Controller/TemplateController.php
+++ b/Controller/TemplateController.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Controller;
 
-use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\ArticleBundle\Metadata\ArticleTypeTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class TemplateController extends Controller
 {
-    use TypeTrait;
+    use ArticleTypeTrait;
 
     /**
      * Returns template for given article type.

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -17,7 +17,7 @@ use Sulu\Bundle\ArticleBundle\Document\ArticleOngrDocument;
 use Sulu\Bundle\ArticleBundle\Document\ExcerptOngrObject;
 use Sulu\Bundle\ArticleBundle\Document\MediaCollectionOngrObject;
 use Sulu\Bundle\ArticleBundle\Document\SeoOngrObject;
-use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\ArticleBundle\Metadata\ArticleTypeTrait;
 use Sulu\Bundle\SecurityBundle\UserManager\UserManager;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
@@ -27,7 +27,7 @@ use Sulu\Component\Content\Compat\StructureManagerInterface;
  */
 class ArticleIndexer implements IndexerInterface
 {
-    use TypeTrait;
+    use ArticleTypeTrait;
 
     /**
      * @var StructureManagerInterface

--- a/Document/Serializer/TypeSubscriber.php
+++ b/Document/Serializer/TypeSubscriber.php
@@ -15,7 +15,7 @@ use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
-use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\ArticleBundle\Metadata\ArticleTypeTrait;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 
 /**
@@ -23,7 +23,7 @@ use Sulu\Component\Content\Compat\StructureManagerInterface;
  */
 class TypeSubscriber implements EventSubscriberInterface
 {
-    use TypeTrait;
+    use ArticleTypeTrait;
 
     /**
      * @var StructureManagerInterface

--- a/Exception/RouteSchemaNotFoundException.php
+++ b/Exception/RouteSchemaNotFoundException.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Exception;
+
+/**
+ * Will be thrown when the requested schema is not configured
+ */
+class RouteSchemaNotFoundException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $requested;
+
+    /**
+     * @var string[]
+     */
+    private $available;
+
+    /**
+     * @param string $requested
+     * @param string[] $available
+     */
+    public function __construct($requested, array $available)
+    {
+        parent::__construct(
+            sprintf('Route-schema for "%s" not configured. Available: ["%s"]', $requested, implode('","', $available))
+        );
+
+        $this->requested = $requested;
+        $this->available = $available;
+    }
+
+    /**
+     * Returns requested.
+     *
+     * @return string
+     */
+    public function getRequested()
+    {
+        return $this->requested;
+    }
+
+    /**
+     * Returns requested.
+     *
+     * @return string[]
+     */
+    public function getAvailable()
+    {
+        return $this->available;
+    }
+}

--- a/Exception/RouteSchemaNotFoundException.php
+++ b/Exception/RouteSchemaNotFoundException.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Exception;
 
 /**
- * Will be thrown when the requested schema is not configured
+ * Will be thrown when the requested schema is not configured.
  */
 class RouteSchemaNotFoundException extends \Exception
 {

--- a/Metadata/ArticleTypeTrait.php
+++ b/Metadata/ArticleTypeTrait.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ArticleBundle\Util;
+namespace Sulu\Bundle\ArticleBundle\Metadata;
 
 use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
 use Sulu\Component\Content\Metadata\StructureMetadata;
@@ -17,7 +17,7 @@ use Sulu\Component\Content\Metadata\StructureMetadata;
 /**
  * Encapsulates function to extract the type from structure-metadata.
  */
-trait TypeTrait
+trait ArticleTypeTrait
 {
     /**
      * Returns type for given structure-metadata.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -87,13 +87,13 @@
             <argument type="service" id="route.generator.route_generator"/>
             <argument type="service" id="sulu_content.structure.factory"/>
 
-            <tag name="sulu.route_generator" alias="by_type"/>
+            <tag name="sulu.route_generator" alias="type"/>
         </service>
         <service id="sulu_article.route_generator.by_template"
                  class="Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByTemplate">
             <argument type="service" id="route.generator.route_generator"/>
 
-            <tag name="sulu.route_generator" alias="by_template"/>
+            <tag name="sulu.route_generator" alias="template"/>
         </service>
 
         <!-- content -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -84,14 +84,14 @@
         <!-- route-generator -->
         <service id="sulu_article.route_generator.by_type"
                  class="Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByType">
-            <argument type="service" id="route.generator.route_generator"/>
+            <argument type="service" id="sulu_route.generator.route_generator"/>
             <argument type="service" id="sulu_content.structure.factory"/>
 
             <tag name="sulu.route_generator" alias="type"/>
         </service>
         <service id="sulu_article.route_generator.by_template"
                  class="Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByTemplate">
-            <argument type="service" id="route.generator.route_generator"/>
+            <argument type="service" id="sulu_route.generator.route_generator"/>
 
             <tag name="sulu.route_generator" alias="template"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -81,6 +81,17 @@
             <tag name="sulu_route.defaults_provider"/>
         </service>
 
+        <!-- route-generator -->
+        <service id="sulu_article.route_generator.by_type"
+                 class="Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByType">
+            <argument type="service" id="sulu_route.route_generator.by_schema"/>
+            <argument type="service" id="sulu_content.structure.factory"/>
+        </service>
+        <service id="sulu_article.route_generator.by_template"
+                 class="Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByTemplate">
+            <argument type="service" id="sulu_route.route_generator.by_schema"/>
+        </service>
+
         <!-- content -->
         <service id="sulu_article.content.data_provider.proxy_factory"
                  class="ProxyManager\Factory\LazyLoadingValueHolderFactory"/>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -84,12 +84,16 @@
         <!-- route-generator -->
         <service id="sulu_article.route_generator.by_type"
                  class="Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByType">
-            <argument type="service" id="sulu_route.route_generator.by_schema"/>
+            <argument type="service" id="route.generator.route_generator"/>
             <argument type="service" id="sulu_content.structure.factory"/>
+
+            <tag name="sulu.route_generator" alias="by_type"/>
         </service>
         <service id="sulu_article.route_generator.by_template"
                  class="Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByTemplate">
-            <argument type="service" id="sulu_route.route_generator.by_schema"/>
+            <argument type="service" id="route.generator.route_generator"/>
+
+            <tag name="sulu.route_generator" alias="by_template"/>
         </service>
 
         <!-- content -->

--- a/Routing/ArticleRouteGeneratorByTemplate.php
+++ b/Routing/ArticleRouteGeneratorByTemplate.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Routing;
 
+use Sulu\Bundle\ArticleBundle\Exception\RouteSchemaNotFoundException;
 use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -43,7 +44,7 @@ class ArticleRouteGeneratorByTemplate implements RouteGeneratorInterface
         $template = $entity->getStructureType();
 
         if (!array_key_exists($template, $options)) {
-            throw new \Exception(sprintf('Route-schema for template "%s" not configured!', $template));
+            throw new RouteSchemaNotFoundException($template, array_keys($options));
         }
 
         return $this->routeGenerator->generate($entity, ['route_schema' => $options[$template]]);

--- a/Routing/ArticleRouteGeneratorByTemplate.php
+++ b/Routing/ArticleRouteGeneratorByTemplate.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Routing;
 
 use Sulu\Bundle\ArticleBundle\Exception\RouteSchemaNotFoundException;
-use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\ArticleBundle\Metadata\ArticleTypeTrait;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ArticleRouteGeneratorByTemplate implements RouteGeneratorInterface
 {
-    use TypeTrait;
+    use ArticleTypeTrait;
 
     /**
      * @var RouteGeneratorInterface

--- a/Routing/ArticleRouteGeneratorByTemplate.php
+++ b/Routing/ArticleRouteGeneratorByTemplate.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Routing;
+
+use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Generate route for articles by type.
+ */
+class ArticleRouteGeneratorByTemplate implements RouteGeneratorInterface
+{
+    use TypeTrait;
+
+    /**
+     * @var RouteGeneratorInterface
+     */
+    private $routeGenerator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(RouteGeneratorInterface $routeGenerator)
+    {
+        $this->routeGenerator = $routeGenerator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($entity, array $options)
+    {
+        $template = $entity->getStructureType();
+
+        if (!array_key_exists($template, $options)) {
+            throw new \Exception(sprintf('Route-schema for template "%s" not configured!', $template));
+        }
+
+        return $this->routeGenerator->generate($entity, ['route_schema' => $options[$template]]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptionsResolver(array $options)
+    {
+        return (new OptionsResolver())->setDefined(array_keys($options));
+    }
+}

--- a/Routing/ArticleRouteGeneratorByType.php
+++ b/Routing/ArticleRouteGeneratorByType.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Routing;
 
 use Sulu\Bundle\ArticleBundle\Exception\RouteSchemaNotFoundException;
-use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\ArticleBundle\Metadata\ArticleTypeTrait;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ArticleRouteGeneratorByType implements RouteGeneratorInterface
 {
-    use TypeTrait;
+    use ArticleTypeTrait;
 
     /**
      * @var RouteGeneratorInterface

--- a/Routing/ArticleRouteGeneratorByType.php
+++ b/Routing/ArticleRouteGeneratorByType.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Routing;
 
+use Sulu\Bundle\ArticleBundle\Exception\RouteSchemaNotFoundException;
 use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
 use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
@@ -54,7 +55,7 @@ class ArticleRouteGeneratorByType implements RouteGeneratorInterface
         );
 
         if (!array_key_exists($type, $options)) {
-            throw new \Exception(sprintf('Route-schema for type "%s" not configured!', $type));
+            throw new RouteSchemaNotFoundException($type, array_keys($options));
         }
 
         return $this->routeGenerator->generate($entity, ['route_schema' => $options[$type]]);

--- a/Routing/ArticleRouteGeneratorByType.php
+++ b/Routing/ArticleRouteGeneratorByType.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Routing;
+
+use Sulu\Bundle\ArticleBundle\Util\TypeTrait;
+use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Generate route for articles by type.
+ */
+class ArticleRouteGeneratorByType implements RouteGeneratorInterface
+{
+    use TypeTrait;
+
+    /**
+     * @var RouteGeneratorInterface
+     */
+    private $routeGenerator;
+
+    /**
+     * @var StructureMetadataFactoryInterface
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        RouteGeneratorInterface $routeGenerator,
+        StructureMetadataFactoryInterface $structureMetadataFactory
+    ) {
+        $this->routeGenerator = $routeGenerator;
+        $this->structureMetadataFactory = $structureMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($entity, array $options)
+    {
+        $type = $this->getType(
+            $this->structureMetadataFactory->getStructureMetadata('article', $entity->getStructureType())
+        );
+
+        if (!array_key_exists($type, $options)) {
+            throw new \Exception(sprintf('Route-schema for type "%s" not configured!', $type));
+        }
+
+        return $this->routeGenerator->generate($entity, ['route_schema' => $options[$type]]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptionsResolver(array $options)
+    {
+        return (new OptionsResolver())->setDefined(array_keys($options));
+    }
+}

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -80,7 +80,6 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent(), true);
-
         foreach ($article as $name => $value) {
             $this->assertEquals($value, $response[$name]);
         }

--- a/Tests/Unit/Routing/ArticleRouteGeneratorByTemplateTest.php
+++ b/Tests/Unit/Routing/ArticleRouteGeneratorByTemplateTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Routing;
+
+use Sulu\Bundle\ArticleBundle\Exception\RouteSchemaNotFoundException;
+use Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByTemplate;
+use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
+
+class ArticleRouteGeneratorByTemplateTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RouteGeneratorInterface
+     */
+    private $generatorBySchema;
+
+    /**
+     * @var RouteGeneratorInterface
+     */
+    private $generatorByTemplate;
+
+    private $config = ['test1' => '/test1/{entity.getTitle()', 'test2' => '/test2/{entity.getTitle()'];
+
+    public function setUp()
+    {
+        $this->generatorBySchema = $this->prophesize(RouteGeneratorInterface::class);
+        $this->generatorByTemplate = new ArticleRouteGeneratorByTemplate($this->generatorBySchema->reveal());
+    }
+
+    public function testGenerate()
+    {
+        $entity = $this->prophesize(StructureBehavior::class);
+        $entity->getStructureType()->willReturn('test1');
+
+        $this->generatorByTemplate->generate($entity->reveal(), $this->config);
+
+        $this->generatorBySchema->generate($entity->reveal(), ['route_schema' => '/test1/{entity.getTitle()'])
+            ->shouldBeCalled();
+    }
+
+    public function testGenerateNotConfigured()
+    {
+        $this->setExpectedException(RouteSchemaNotFoundException::class);
+
+        $entity = $this->prophesize(StructureBehavior::class);
+        $entity->getStructureType()->willReturn('test3');
+
+        $this->generatorByTemplate->generate($entity->reveal(), $this->config);
+    }
+}

--- a/Tests/Unit/Routing/ArticleRouteGeneratorByTypeTest.php
+++ b/Tests/Unit/Routing/ArticleRouteGeneratorByTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Routing;
+
+use Sulu\Bundle\ArticleBundle\Exception\RouteSchemaNotFoundException;
+use Sulu\Bundle\ArticleBundle\Routing\ArticleRouteGeneratorByType;
+use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorInterface;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\Content\Metadata\StructureMetadata;
+
+class ArticleRouteGeneratorByTypeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RouteGeneratorInterface
+     */
+    private $generatorBySchema;
+
+    /**
+     * @var RouteGeneratorInterface
+     */
+    private $generatorByTemplate;
+
+    /**
+     * @var StructureMetadataFactoryInterface
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * @var array
+     */
+    private $config = ['type1' => '/test1/{entity.getTitle()', 'type2' => '/test2/{entity.getTitle()'];
+
+    public function setUp()
+    {
+        $this->generatorBySchema = $this->prophesize(RouteGeneratorInterface::class);
+        $this->structureMetadataFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+
+        $this->generatorByTemplate = new ArticleRouteGeneratorByType(
+            $this->generatorBySchema->reveal(),
+            $this->structureMetadataFactory->reveal()
+        );
+    }
+
+    public function testGenerate()
+    {
+        $metadata = new StructureMetadata();
+        $metadata->tags[] = ['name' => 'sulu.type', 'attributes' => ['type' => 'type1']];
+
+        $this->structureMetadataFactory->getStructureMetadata('article', 'test1')->willReturn($metadata);
+
+        $entity = $this->prophesize(StructureBehavior::class);
+        $entity->getStructureType()->willReturn('test1');
+
+        $this->generatorByTemplate->generate($entity->reveal(), $this->config);
+
+        $this->generatorBySchema->generate($entity->reveal(), ['route_schema' => '/test1/{entity.getTitle()'])
+            ->shouldBeCalled();
+    }
+
+    public function testGenerateNotConfigured()
+    {
+        $this->setExpectedException(RouteSchemaNotFoundException::class);
+
+        $metadata = new StructureMetadata();
+        $metadata->tags[] = ['name' => 'sulu.type', 'attributes' => ['type' => 'type3']];
+
+        $this->structureMetadataFactory->getStructureMetadata('article', 'test3')->willReturn($metadata);
+
+        $entity = $this->prophesize(StructureBehavior::class);
+        $entity->getStructureType()->willReturn('test3');
+
+        $this->generatorByTemplate->generate($entity->reveal(), $this->config);
+    }
+}

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -27,4 +27,6 @@ ongr_elasticsearch:
 sulu_route:
     mappings:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            route_schema: /articles/{object.getTitle()}
+            service_id: sulu_route.route_generator.by_schema
+            options:
+                route_schema: /articles/{object.getTitle()}

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -27,6 +27,6 @@ ongr_elasticsearch:
 sulu_route:
     mappings:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            generator: by_schema
+            generator: schema
             options:
                 route_schema: /articles/{object.getTitle()}

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -27,6 +27,6 @@ ongr_elasticsearch:
 sulu_route:
     mappings:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            service_id: sulu_route.route_generator.by_schema
+            generator: by_schema
             options:
                 route_schema: /articles/{object.getTitle()}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu/pull/2820
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR implements a by-type and by-template route-generator to individualize the generation of routes per-type or per-template.

#### Example Usage

~~~yml
sulu_route:
    mappings:
        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
            generator: schema
            options:
                article: /article/{object.getTitle()}
                lexicon: /lexicon/{object.getTitle()}
~~~

#### To Do

- [x] Tests

