### PR TITLE
Fix media ids in ongr media collection document

### DIFF
--- a/Document/MediaCollectionOngrObject.php
+++ b/Document/MediaCollectionOngrObject.php
@@ -66,7 +66,7 @@ class MediaCollectionOngrObject implements \Iterator, \ArrayAccess
         $this->medias = new Collection();
 
         foreach ($medias as $media) {
-            $this->ids = $media->getId();
+            $this->ids[] = $media->getId();
 
             $mediaObject = new MediaOngrObject();
             $mediaObject->setData($media);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

fixed error on first access because ids not contain the media ids.