### PR TITLE
[BUGFIX] Fixed sort order in elasstic serach with camelcase

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -86,7 +86,9 @@ class ArticleController extends RestController implements ClassResourceInterface
 
         if (!empty($searchPattern = $restHelper->getSearchPattern())) {
             foreach ($restHelper->getSearchFields() as $searchField) {
-                $search->addQuery(new WildcardQuery($searchField, '*' . strtolower($searchPattern) . '*'));
+                $search->addQuery(
+                    new WildcardQuery($this->uncamelize($searchField), '*' . strtolower($searchPattern) . '*')
+                );
             }
         }
 
@@ -101,7 +103,9 @@ class ArticleController extends RestController implements ClassResourceInterface
         $count = $repository->count($search);
 
         if (null !== $restHelper->getSortColumn()) {
-            $search->addSort(new FieldSort($restHelper->getSortColumn(), $restHelper->getSortOrder()));
+            $search->addSort(
+                new FieldSort($this->uncamelize($restHelper->getSortColumn()), $restHelper->getSortOrder())
+            );
         }
 
         $limit = (int) $restHelper->getLimit();
@@ -343,5 +347,22 @@ class ArticleController extends RestController implements ClassResourceInterface
                 $this->getDocumentManager()->publish($document, $locale);
                 break;
         }
+    }
+
+    /**
+     * Converts camel case string into normalized string with underscore.
+     *
+     * @param string $camel
+     *
+     * @return string
+     */
+    private function uncamelize($camel) {
+        $camel = preg_replace(
+            '/(?!^)[[:upper:]][[:lower:]]/',
+            '$0',
+            preg_replace('/(?!^)[[:upper:]]+/', '_$0', $camel)
+        );
+
+        return strtolower($camel);
     }
 }

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -356,7 +356,8 @@ class ArticleController extends RestController implements ClassResourceInterface
      *
      * @return string
      */
-    private function uncamelize($camel) {
+    private function uncamelize($camel)
+    {
         $camel = preg_replace(
             '/(?!^)[[:upper:]][[:lower:]]/',
             '$0',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixed order in list when column is camel case.

#### Why?

Order by column in camel case crashes the search in elastic search, because the names of the columns are normalized in elastic search.

