### PR TITLE
Allow stable sulu (1.4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^5.5 || ^7.0",
-        "sulu/sulu": "dev-develop",
+        "sulu/sulu": "dev-develop || ^1.4",
         "sulu/document-manager": "@dev",
         "massive/search-bundle": "@dev",
         "ongr/elasticsearch-bundle": "~1.0"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | n/a
| Related issues/PRs | n/a
| License | MIT
| Documentation PR | n/a

#### What's in this PR?

It allows to install the article bundle in a project with a stable Sulu, although there is no release of this bundle yet

#### Why?

Because now it is hard to start using the article bundle in a project. One has to provide version aliases.

