### PR TITLE
Fixed smart-content query for categories and tags

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,3 +11,4 @@ disabled:
     - phpdoc_indent
     - phpdoc_to_comment
     - blankline_after_open_tag
+    - single_line_class_definition

--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -175,14 +175,14 @@ class ArticleDataProvider implements DataProviderInterface
 
         $queriesCount = 0;
         $operator = $this->getFilter($filters, 'tagOperator', 'or');
-        $this->addBoolQuery('tags', $filters, 'excerpt.tags', $operator, $query, $queriesCount);
+        $this->addBoolQuery('tags', $filters, 'excerpt.tags.id', $operator, $query, $queriesCount);
         $operator = $this->getFilter($filters, 'websiteTagsOperator', 'or');
-        $this->addBoolQuery('websiteTags', $filters, 'excerpt.tags', $operator, $query, $queriesCount);
+        $this->addBoolQuery('websiteTags', $filters, 'excerpt.tags.id', $operator, $query, $queriesCount);
 
         $operator = $this->getFilter($filters, 'categoryOperator', 'or');
-        $this->addBoolQuery('categories', $filters, 'excerpt.categories', $operator, $query, $queriesCount);
+        $this->addBoolQuery('categories', $filters, 'excerpt.categories.id', $operator, $query, $queriesCount);
         $operator = $this->getFilter($filters, 'websiteCategoriesOperator', 'or');
-        $this->addBoolQuery('websiteCategories', $filters, 'excerpt.categories', $operator, $query, $queriesCount);
+        $this->addBoolQuery('websiteCategories', $filters, 'excerpt.categories.id', $operator, $query, $queriesCount);
 
         if (array_key_exists('type', $filters)) {
             $query->add(new TermQuery('type', $filters['type']));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

We have introduced objects in search-index and in the smart-content data-provider it was missing.