### PR TITLE
Moved installation notes to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,50 @@
 # SuluArticleBundle
 
+[![Build Status](https://travis-ci.org/sulu/SuluArticleBundle.svg?branch=master)](https://travis-ci.org/sulu/SuluArticleBundle)
+[![StyleCI](https://styleci.io/repos/61883398/shield?branch=develop)](https://styleci.io/repos/61883398)
+
+The SuluArticleBundle adds support for managing articles in Sulu. Articles can be used in a lot of different ways to
+manage unstructured data with an own URL in an admin-list. Most of the features, which can be used in pages, can also
+be used on articles - like templates, versioning, drafting, publishing and automation.
+
+Additional features included:
+
+* Build in view-layer with elasticsearch
+* Segmentation of article-templates (called article-types)
+* Define URL schemas per type
+
+## Status
+
+This repository will become version 1.0 of SuluArticleBundle. It is under **heavy development** and currently its APIs
+and code are not stable yet (pre 1.0).
+
+## Requirements
+
+* Composer
+* PHP `^5.5 || ^7.0`
+* Sulu `^1.4`
+* Elasticsearch `^2.2`
+
+For detailed requirements see [composer.json](https://github.com/sulu/SuluArticleBundle/blob/master/composer.json).
+
+## Documentation
+
+The the Documentation is stored in the
+[Resources/doc/](https://github.com/sulu/SuluArticleBundle/blob/master/Resources/doc) folder.
+
 ## Installation
 
-Install ElasticSearch
+All the installation instructions are located in the 
+[Documentation](https://github.com/sulu/SuluArticleBundle/blob/master/Resources/doc/installation.md).
 
-Install bundle over composer:
+## License
 
-```bash
-composer require sulu/article-bundle
-```
+This bundle is under the MIT license. See the complete license [in the bundle](LICENSE)
 
-Possible bundle configurations:
+## Reporting an issue or a feature request
 
-```yml
-sulu_article:
-    documents:
-        article:
-            view: Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument
-    types:
+Issues and feature requests are tracked in the [Github issue tracker](https://github.com/Sulu/SuluArticleBundle/issues).
 
-        # Prototype
-        name:
-            translation_key:      ~
-
-    # Display tab 'all' in list view
-    display_tab_all:      true
-```
-
-Configure the bundles:
-
-```yml
-sulu_route:
-    mappings:
-        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            generator: schema
-            options:
-                route_schema: /articles/{object.getTitle()}
-
-sulu_core:
-    content:
-        structure:
-            default_type:
-                article: "article_default"
-            paths:
-                article:
-                    path: "%kernel.root_dir%/Resources/templates/articles"
-                    type: "article"
-                    
-ongr_elasticsearch:
-    connections:
-        default:
-            index_name: su_articles
-        live:
-            index_name: su_articles_live
-    managers:
-        default:
-            connection: default
-            mappings:
-                - SuluArticleBundle
-        live:
-            connection: live
-            mappings:
-                - SuluArticleBundle
-```
-
-Add xml template for structure in configured folder:
-
-```
-%kernel.root_dir%/Resources/templates/articles/article_default.xml
-```
-
-Example is located in Bundle:
-
-```
-Resources/doc/article_default.xml
-```
-
-Add template for article type in configured folder:
-
-```
-%kernel.root_dir%/Resources/views/articles/article_default.html.twig
-```
-
-Example is located in Bundle:
-
-```
-Resources/doc/article_default.html.twig
-```
-
-Configure the routing
-
-```yml
-sulu_arictle_api:
-    resource: "@SuluArticleBundle/Resources/config/routing_api.xml"
-    type: rest
-    prefix: /admin/api
-
-sulu_article:
-    resource: "@SuluArticleBundle/Resources/config/routing.xml"
-    prefix: /admin/articles
-```
-
-Add bundle to AbstractKernel:
-
-```php
-new Sulu\Bundle\ArticleBundle\SuluArticleBundle(),
-new ONGR\ElasticsearchBundle\ONGRElasticsearchBundle(),
-```
-
-Create required phpcr nodes:
-
-```bash
-bin/console sulu:document:init
-```
-
-Create elasticsearch index:
-
-```bash
-bin/console ongr:es:index:create
-```
+When reporting a bug, it may be a good idea to reproduce it in a basic project built using the
+[Sulu Minimal Edition](https://github.com/sulu/sulu-minimal) to allow developers of the bundle to reproduce the issue
+by simply cloning it and following some steps.

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -1,0 +1,113 @@
+# Installation
+
+Install ElasticSearch
+
+Install bundle over composer:
+
+```bash
+composer require sulu/article-bundle
+```
+
+Possible bundle configurations:
+
+```yml
+sulu_article:
+    documents:
+        article:
+            view: Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument
+    types:
+
+        # Prototype
+        name:
+            translation_key:      ~
+
+    # Display tab 'all' in list view
+    display_tab_all:      true
+```
+
+Configure the bundles:
+
+```yml
+sulu_route:
+    mappings:
+        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
+            generator: schema
+            options:
+                route_schema: /articles/{object.getTitle()}
+
+sulu_core:
+    content:
+        structure:
+            default_type:
+                article: "article_default"
+            paths:
+                article:
+                    path: "%kernel.root_dir%/Resources/templates/articles"
+                    type: "article"
+
+ongr_elasticsearch:
+    connections:
+        default:
+            index_name: su_articles
+        live:
+            index_name: su_articles_live
+    managers:
+        default:
+            connection: default
+            mappings:
+                - SuluArticleBundle
+        live:
+            connection: live
+            mappings:
+                - SuluArticleBundle
+```
+
+Add xml template for structure in configured folder:
+
+```
+%kernel.root_dir%/Resources/templates/articles/article_default.xml
+```
+
+Example is located in Bundle
+[article_default.xml](https://github.com/sulu/SuluArticleBundle/blob/master/Resources/doc/article_default.xml).
+
+Add template for article type in configured folder: ``
+
+```
+%kernel.root_dir%/Resources/views/articles/article_default.html.twig
+```
+
+Example is located in Bundle
+[article_default.xml](https://github.com/sulu/SuluArticleBundle/blob/master/Resources/doc/article_default.html.twig).
+
+Configure the routing
+
+```yml
+sulu_arictle_api:
+    resource: "@SuluArticleBundle/Resources/config/routing_api.xml"
+    type: rest
+    prefix: /admin/api
+
+sulu_article:
+    resource: "@SuluArticleBundle/Resources/config/routing.xml"
+    prefix: /admin/articles
+```
+
+Add bundle to AbstractKernel:
+
+```php
+new Sulu\Bundle\ArticleBundle\SuluArticleBundle(),
+new ONGR\ElasticsearchBundle\ONGRElasticsearchBundle(),
+```
+
+Create required phpcr nodes:
+
+```bash
+bin/console sulu:document:init
+```
+
+Create elasticsearch index:
+
+```bash
+bin/console ongr:es:index:create
+```


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR moves the actual content to `Resources/doc/installation.md` and places general informations in the `README.md` file. This restructure allows us to extend the doc in the future without spaming in the `README.md`.