### PR TITLE
Extracted routable-behavior from article-subscriber

### DIFF
--- a/Document/ArticleDocument.php
+++ b/Document/ArticleDocument.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Document;
 
 use Sulu\Bundle\ArticleBundle\Document\Behavior\DateShardingBehavior;
-use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
+use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Document\Behavior\AuthorBehavior;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
@@ -44,7 +44,7 @@ class ArticleDocument implements
     LocalizedStructureBehavior,
     LocalizedAuditableBehavior,
     DateShardingBehavior,
-    RoutableInterface,
+    RoutableBehavior,
     ExtensionBehavior,
     WorkflowStageBehavior,
     VersionBehavior,
@@ -178,9 +178,7 @@ class ArticleDocument implements
     }
 
     /**
-     * Set uuid.
-     *
-     * @param string $uuid
+     * {@inheritdoc}
      */
     public function setUuid($uuid)
     {
@@ -257,9 +255,7 @@ class ArticleDocument implements
     }
 
     /**
-     * Returns route-path.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getRoutePath()
     {
@@ -267,9 +263,7 @@ class ArticleDocument implements
     }
 
     /**
-     * Set route-path.
-     *
-     * @param string $routePath
+     * {@inheritdoc}
      */
     public function setRoutePath($routePath)
     {

--- a/Document/Behavior/RoutableBehavior.php
+++ b/Document/Behavior/RoutableBehavior.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Behavior;
+
+use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+
+/**
+ * This behavior has to be attached to documents which should have a sulu-route.
+ */
+interface RoutableBehavior extends RoutableInterface, UuidBehavior, LocaleBehavior
+{
+    /**
+     * Returns route-path.
+     *
+     * @return string
+     */
+    public function getRoutePath();
+
+    /**
+     * Set route-path.
+     *
+     * @param string $routePath
+     */
+    public function setRoutePath($routePath);
+
+    /**
+     * Set uuid.
+     *
+     * @param string $uuid
+     */
+    public function setUuid($uuid);
+}

--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Subscriber;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
+use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
+use Sulu\Component\DocumentManager\Event\MetadataLoadEvent;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Handles document-manager events to create/update/remove routes.
+ */
+class RoutableSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var RouteManagerInterface
+     */
+    private $routeManager;
+
+    /**
+     * @var RouteRepositoryInterface
+     */
+    private $routeRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @param RouteManagerInterface $routeManager
+     * @param RouteRepositoryInterface $routeRepository
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(RouteManagerInterface $routeManager, RouteRepositoryInterface $routeRepository, EntityManagerInterface $entityManager)
+    {
+        $this->routeManager = $routeManager;
+        $this->routeRepository = $routeRepository;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => [['handleHydrate', -500]],
+            Events::PERSIST => [['handleRouteUpdate', 1], ['handleRoute', 0]],
+            Events::REMOVE => [['handleRemove', -500]],
+            Events::METADATA_LOAD => 'handleMetadataLoad',
+            Events::CONFIGURE_OPTIONS => 'configureOptions',
+        ];
+    }
+
+    /**
+     * Load route.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function handleHydrate(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof RoutableBehavior || null === $document->getRoutePath()) {
+            return;
+        }
+
+        $route = $this->routeRepository->findByPath($document->getRoutePath(), $document->getOriginalLocale());
+        if (!$route) {
+            return;
+        }
+
+        $document->setRoute($route);
+    }
+
+    /**
+     * Generate route.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function handleRoute(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof RoutableBehavior || null !== $document->getRoutePath()) {
+            return;
+        }
+
+        $document->setUuid($event->getNode()->getIdentifier());
+
+        $route = $this->routeManager->create($document, $event->getOption('route_path'));
+        $this->entityManager->persist($route);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Update route if route-path was changed.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function handleRouteUpdate(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof RoutableBehavior
+            || null === $document->getRoute()
+            || null === ($routePath = $event->getOption('route_path'))
+        ) {
+            return;
+        }
+
+        $route = $this->routeManager->update($document, $routePath);
+        $document->setRoutePath($route->getPath());
+        $this->entityManager->persist($route);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Removes route.
+     *
+     * @param RemoveEvent $event
+     */
+    public function handleRemove(RemoveEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof RoutableBehavior) {
+            return;
+        }
+
+        $route = $this->routeRepository->findByPath($document->getRoutePath(), $document->getOriginalLocale());
+        if (!$route) {
+            return;
+        }
+
+        $this->entityManager->remove($route);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Add route to metadata.
+     *
+     * @param MetadataLoadEvent $event
+     */
+    public function handleMetadataLoad(MetadataLoadEvent $event)
+    {
+        if (!$event->getMetadata()->getReflectionClass()->implementsInterface(RoutableBehavior::class)) {
+            return;
+        }
+
+        $metadata = $event->getMetadata();
+        $metadata->addFieldMapping(
+            'routePath',
+            [
+                'encoding' => 'system_localized',
+                'property' => 'routePath',
+            ]
+        );
+    }
+
+    /**
+     * Add route-path to options.
+     *
+     * @param ConfigureOptionsEvent $event
+     */
+    public function configureOptions(ConfigureOptionsEvent $event)
+    {
+        $options = $event->getOptions();
+        $options->setDefaults(['route_path' => null]);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -101,10 +101,15 @@
                  class="Sulu\Bundle\ArticleBundle\Document\Subscriber\ArticleSubscriber">
             <argument type="service" id="sulu_article.elastic_search.article_indexer"/>
             <argument type="service" id="sulu_article.elastic_search.article_live_indexer"/>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+        <service id="sulu_article.subscriber.routable"
+                 class="Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber">
             <argument type="service" id="sulu_route.manager.route_manager"/>
             <argument type="service" id="sulu.repository.route"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
-            <argument type="service" id="sulu_document_manager.document_manager"/>
 
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -60,7 +60,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($title, $response['title']);
         $this->assertEquals(self::$typeMap[$template], $response['articleType']);
         $this->assertEquals($template, $response['template']);
-        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
+        $this->assertEquals('2016-01-01', date('Y-m-d', strtotime($response['authored'])));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
 
         return $response;
@@ -86,7 +86,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($title, $response['title']);
         $this->assertEquals(self::$typeMap[$template], $response['articleType']);
         $this->assertEquals($template, $response['template']);
-        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
+        $this->assertEquals('2016-01-01', date('Y-m-d', strtotime($response['authored'])));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
 
         return $response;
@@ -130,7 +130,7 @@ class ArticleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertNotEquals($article['title'], $response['title']);
         $this->assertEquals($title, $response['title']);
-        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
+        $this->assertEquals('2016-01-01', date('Y-m-d', strtotime($response['authored'])));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
 
         return $article;
@@ -155,7 +155,7 @@ class ArticleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertNotEquals($article['title'], $response['title']);
         $this->assertEquals($title, $response['title']);
-        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
+        $this->assertEquals('2016-01-01', date('Y-m-d', strtotime($response['authored'])));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
         $this->assertEquals(['name' => 'ghost', 'value' => 'de'], $response['type']);
     }

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -60,7 +60,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($title, $response['title']);
         $this->assertEquals(self::$typeMap[$template], $response['articleType']);
         $this->assertEquals($template, $response['template']);
-        $this->assertEquals(new \DateTime('2016-01-01'), new \DateTime($response['authored']));
+        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
 
         return $response;
@@ -86,7 +86,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($title, $response['title']);
         $this->assertEquals(self::$typeMap[$template], $response['articleType']);
         $this->assertEquals($template, $response['template']);
-        $this->assertEquals(new \DateTime('2016-01-01'), new \DateTime($response['authored']));
+        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
 
         return $response;
@@ -130,7 +130,7 @@ class ArticleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertNotEquals($article['title'], $response['title']);
         $this->assertEquals($title, $response['title']);
-        $this->assertEquals(new \DateTime('2016-01-01'), new \DateTime($response['authored']));
+        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
 
         return $article;
@@ -155,7 +155,7 @@ class ArticleControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertNotEquals($article['title'], $response['title']);
         $this->assertEquals($title, $response['title']);
-        $this->assertEquals(new \DateTime('2016-01-01'), new \DateTime($response['authored']));
+        $this->assertEquals('2016-01-01', (new \DateTime($response['authored']))->format('Y-m-d'));
         $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
         $this->assertEquals(['name' => 'ghost', 'value' => 'de'], $response['type']);
     }

--- a/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Document\Subscriber;
+
+use Prophecy\Argument;
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
+use Sulu\Bundle\ArticleBundle\Document\Index\IndexerInterface;
+use Sulu\Bundle\ArticleBundle\Document\Subscriber\ArticleSubscriber;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Event\FlushEvent;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+
+class ArticleSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var IndexerInterface
+     */
+    private $indexer;
+
+    /**
+     * @var IndexerInterface
+     */
+    private $liveIndexer;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var ArticleSubscriber
+     */
+    private $articleSubscriber;
+
+    /**
+     * @var ArticleDocument
+     */
+    private $document;
+
+    /**
+     * @var string
+     */
+    private $uuid = '123-123-123';
+
+    /**
+     * @var string
+     */
+    private $locale = 'de';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->indexer = $this->prophesize(IndexerInterface::class);
+        $this->liveIndexer = $this->prophesize(IndexerInterface::class);
+        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+
+        $this->document = $this->prophesize(ArticleDocument::class);
+        $this->document->getUuid()->willReturn($this->uuid);
+        $this->document->getLocale()->willReturn($this->locale);
+        $this->documentManager->find($this->uuid, $this->locale)->willReturn($this->document->reveal());
+
+        $this->articleSubscriber = new ArticleSubscriber(
+            $this->indexer->reveal(),
+            $this->liveIndexer->reveal(),
+            $this->documentManager->reveal()
+        );
+    }
+
+    protected function prophesizeEvent($className)
+    {
+        $event = $this->prophesize($className);
+        $event->getDocument()->willReturn($this->document->reveal());
+
+        return $event->reveal();
+    }
+
+    public function testHandleScheduleIndex()
+    {
+        $event = $this->prophesizeEvent(AbstractMappingEvent::class);
+        $this->articleSubscriber->handleScheduleIndex($event);
+
+        $this->indexer->index(Argument::any())->shouldNotBeCalled();
+        $this->indexer->flush()->shouldNotBeCalled();
+        $this->liveIndexer->index(Argument::any())->shouldNotBeCalled();
+        $this->liveIndexer->flush()->shouldNotBeCalled();
+    }
+
+    public function testHandleScheduleIndexLive()
+    {
+        $event = $this->prophesizeEvent(AbstractMappingEvent::class);
+        $this->articleSubscriber->handleScheduleIndexLive($event);
+
+        $this->indexer->index(Argument::any())->shouldNotBeCalled();
+        $this->indexer->flush()->shouldNotBeCalled();
+        $this->liveIndexer->index(Argument::any())->shouldNotBeCalled();
+        $this->liveIndexer->flush()->shouldNotBeCalled();
+    }
+
+    public function testHandleFlush()
+    {
+        $event = $this->prophesizeEvent(AbstractMappingEvent::class);
+        $this->articleSubscriber->handleScheduleIndex($event);
+
+        $this->documentManager->find($this->uuid, $this->locale)->willReturn($this->document->reveal());
+
+        $this->articleSubscriber->handleFlush($this->prophesize(FlushEvent::class)->reveal());
+
+        $this->indexer->index($this->document->reveal())->shouldBeCalled();
+        $this->indexer->flush()->shouldBeCalled();
+        $this->liveIndexer->index(Argument::any())->shouldNotBeCalled();
+        $this->liveIndexer->flush()->shouldNotBeCalled();
+    }
+
+    public function testHandleFlushLive()
+    {
+        $event = $this->prophesizeEvent(AbstractMappingEvent::class);
+        $this->articleSubscriber->handleScheduleIndexLive($event);
+
+        $this->documentManager->find($this->uuid, $this->locale)->willReturn($this->document->reveal());
+
+        $this->articleSubscriber->handleFlushLive($this->prophesize(FlushEvent::class)->reveal());
+
+        $this->indexer->index(Argument::any())->shouldNotBeCalled();
+        $this->indexer->flush()->shouldNotBeCalled();
+        $this->liveIndexer->index($this->document->reveal())->shouldBeCalled();
+        $this->liveIndexer->flush()->shouldBeCalled();
+    }
+
+    public function testHandleRemove()
+    {
+        $this->articleSubscriber->handleRemove($this->prophesizeEvent(RemoveEvent::class));
+
+        $this->indexer->remove($this->document->reveal())->shouldBeCalled();
+        $this->indexer->flush()->shouldBeCalled();
+        $this->liveIndexer->index(Argument::any())->shouldNotBeCalled();
+        $this->liveIndexer->flush()->shouldNotBeCalled();
+    }
+
+    public function testHandleRemoveLive()
+    {
+        $this->articleSubscriber->handleRemoveLive($this->prophesizeEvent(RemoveEvent::class));
+
+        $this->indexer->remove(Argument::any())->shouldNotBeCalled();
+        $this->indexer->flush()->shouldNotBeCalled();
+        $this->liveIndexer->remove($this->document->reveal())->shouldBeCalled();
+        $this->liveIndexer->flush()->shouldBeCalled();
+    }
+}

--- a/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
@@ -13,28 +13,16 @@ namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Document\Subscriber;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PHPCR\NodeInterface;
-use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
-use Sulu\Bundle\ArticleBundle\Document\Index\ArticleIndexer;
-use Sulu\Bundle\ArticleBundle\Document\Subscriber\ArticleSubscriber;
+use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
+use Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
-use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 
-class ArticleSubscriberTest extends \PHPUnit_Framework_TestCase
+class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var ArticleIndexer
-     */
-    private $draftIndexer;
-
-    /**
-     * @var ArticleIndexer
-     */
-    private $liveIndexer;
-
     /**
      * @var RouteManagerInterface
      */
@@ -51,38 +39,27 @@ class ArticleSubscriberTest extends \PHPUnit_Framework_TestCase
     private $entityManager;
 
     /**
-     * @var DocumentManagerInterface
-     */
-    private $documentManager;
-
-    /**
-     * @var ArticleSubscriber
+     * @var RoutableSubscriber
      */
     private $articleSubscriber;
 
     /**
-     * @var ArticleDocument
+     * @var RoutableBehavior
      */
     private $document;
 
     protected function setUp()
     {
-        $this->draftIndexer = $this->prophesize(ArticleIndexer::class);
-        $this->liveIndexer = $this->prophesize(ArticleIndexer::class);
         $this->routeManager = $this->prophesize(RouteManagerInterface::class);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
-        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
 
-        $this->document = $this->prophesize(ArticleDocument::class);
+        $this->document = $this->prophesize(RoutableBehavior::class);
 
-        $this->articleSubscriber = new ArticleSubscriber(
-            $this->draftIndexer->reveal(),
-            $this->liveIndexer->reveal(),
+        $this->articleSubscriber = new RoutableSubscriber(
             $this->routeManager->reveal(),
             $this->routeRepository->reveal(),
-            $this->entityManager->reveal(),
-            $this->documentManager->reveal()
+            $this->entityManager->reveal()
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR improves the separation of concerns by extracting the route-stuff from the article subscriber.

#### Why?

This part will be used also for the pages afterwards in the multi-page feature.

#### To Do

- [x] Tests for `ArticleSubscriber`
