### PR TITLE
Implemented page document and API

### DIFF
--- a/Content/ArticleSelectionContentType.php
+++ b/Content/ArticleSelectionContentType.php
@@ -18,7 +18,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\SimpleContentType;
 
 /**
- * TODO add description here.
+ * Provides article_selection content-type.
  */
 class ArticleSelectionContentType extends SimpleContentType
 {

--- a/Controller/ArticlePageController.php
+++ b/Controller/ArticlePageController.php
@@ -1,0 +1,239 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Controller;
+
+use FOS\RestBundle\Routing\ClassResourceInterface;
+use JMS\Serializer\SerializationContext;
+use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
+use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
+use Sulu\Bundle\ArticleBundle\Document\Form\ArticlePageDocumentType;
+use Sulu\Bundle\ArticleBundle\Exception\ParameterNotAllowedException;
+use Sulu\Component\Content\Form\Exception\InvalidFormException;
+use Sulu\Component\Content\Mapper\ContentMapperInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\Rest\Exception\MissingParameterException;
+use Sulu\Component\Rest\RequestParametersTrait;
+use Sulu\Component\Rest\RestController;
+use Sulu\Component\Security\SecuredControllerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Provides API for article-pages.
+ */
+class ArticlePageController extends RestController implements ClassResourceInterface, SecuredControllerInterface
+{
+    const DOCUMENT_TYPE = 'article_page';
+
+    use RequestParametersTrait;
+
+    /**
+     * Returns single article-page.
+     *
+     * @param string $articleUuid
+     * @param string $uuid
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function getAction($articleUuid, $uuid, Request $request)
+    {
+        $locale = $this->getRequestParameter($request, 'locale', true);
+        $document = $this->getDocumentManager()->find(
+            $uuid,
+            $locale,
+            [
+                'load_ghost_content' => true,
+                'load_shadow_content' => false,
+            ]
+        );
+
+        return $this->handleView(
+            $this->view($document)->setSerializationContext(
+                SerializationContext::create()->setSerializeNull(true)->setGroups(['defaultPage'])
+            )
+        );
+    }
+
+    /**
+     * Create article-page.
+     *
+     * @param string $articleUuid
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function postAction($articleUuid, Request $request)
+    {
+        $action = $request->get('action');
+        $document = $this->getDocumentManager()->create(self::DOCUMENT_TYPE);
+        $locale = $this->getRequestParameter($request, 'locale', true);
+        $data = $request->request->all();
+
+        $this->persistDocument($data, $document, $locale, $articleUuid);
+        $this->handleActionParameter($action, $document, $locale);
+        $this->getDocumentManager()->flush();
+
+        return $this->handleView(
+            $this->view($document)->setSerializationContext(
+                SerializationContext::create()->setSerializeNull(true)->setGroups(['defaultPage'])
+            )
+        );
+    }
+
+    /**
+     * Update article-page.
+     *
+     * @param string $articleUuid
+     * @param string $uuid
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function putAction($articleUuid, $uuid, Request $request)
+    {
+        $locale = $this->getRequestParameter($request, 'locale', true);
+        $action = $request->get('action');
+        $data = $request->request->all();
+
+        $document = $this->getDocumentManager()->find(
+            $uuid,
+            $locale,
+            [
+                'load_ghost_content' => false,
+                'load_shadow_content' => false,
+            ]
+        );
+
+        $this->get('sulu_hash.request_hash_checker')->checkHash($request, $document, $document->getUuid());
+
+        $this->persistDocument($data, $document, $locale, $articleUuid);
+        $this->handleActionParameter($action, $document, $locale);
+        $this->getDocumentManager()->flush();
+
+        return $this->handleView(
+            $this->view($document)->setSerializationContext(
+                SerializationContext::create()->setSerializeNull(true)->setGroups(['defaultPage'])
+            )
+        );
+    }
+
+    /**
+     * Delete article-page.
+     *
+     * @param string $articleUuid
+     * @param string $uuid
+     *
+     * @return Response
+     */
+    public function deleteAction($articleUuid, $uuid)
+    {
+        $documentManager = $this->getDocumentManager();
+        $document = $documentManager->find($uuid);
+        $documentManager->remove($document);
+        $documentManager->flush();
+
+        return $this->handleView($this->view(null));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSecurityContext()
+    {
+        return ArticleAdmin::SECURITY_CONTEXT;
+    }
+
+    /**
+     * Persists the document using the given information.
+     *
+     * @param array $data
+     * @param object $document
+     * @param string $locale
+     * @param string $articleUuid
+     *
+     * @throws InvalidFormException
+     * @throws MissingParameterException
+     * @throws ParameterNotAllowedException
+     */
+    private function persistDocument($data, $document, $locale, $articleUuid)
+    {
+        if (array_key_exists('title', $data)) {
+            throw new ParameterNotAllowedException('title', ArticlePageDocument::class);
+        }
+        if (array_key_exists('template', $data)) {
+            throw new ParameterNotAllowedException('template', ArticlePageDocument::class);
+        }
+
+        $article = $this->getDocumentManager()->find($articleUuid, $locale);
+        $data['template'] = $article->getStructureType();
+
+        $form = $this->createForm(
+            ArticlePageDocumentType::class,
+            $document,
+            [
+                // disable csrf protection, since we can't produce a token, because the form is cached on the client
+                'csrf_protection' => false,
+            ]
+        );
+        $form->submit($data, false);
+
+        $document->setParent($article);
+
+        if (!$form->isValid()) {
+            throw new InvalidFormException($form);
+        }
+
+        $this->getDocumentManager()->persist(
+            $document,
+            $locale,
+            [
+                'user' => $this->getUser()->getId(),
+                'clear_missing_content' => false,
+            ]
+        );
+    }
+
+    /**
+     * Returns document-manager.
+     *
+     * @return DocumentManagerInterface
+     */
+    protected function getDocumentManager()
+    {
+        return $this->get('sulu_document_manager.document_manager');
+    }
+
+    /**
+     * @return ContentMapperInterface
+     */
+    protected function getMapper()
+    {
+        return $this->get('sulu.content.mapper');
+    }
+
+    /**
+     * Delegates actions by given actionParameter, which can be retrieved from the request.
+     *
+     * @param string $actionParameter
+     * @param object $document
+     * @param string $locale
+     */
+    private function handleActionParameter($actionParameter, $document, $locale)
+    {
+        switch ($actionParameter) {
+            case 'publish':
+                $this->getDocumentManager()->publish($document, $locale);
+                break;
+        }
+    }
+}

--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -12,7 +12,10 @@
 namespace Sulu\Bundle\ArticleBundle\DependencyInjection;
 
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
+use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
 use Sulu\Bundle\ArticleBundle\Document\Structure\ArticleBridge;
+use Sulu\Bundle\ArticleBundle\Document\Structure\ArticlePageBridge;
+use Sulu\Bundle\ArticleBundle\Exception\ParameterNotAllowedException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -37,6 +40,7 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
                         'structure' => [
                             'type_map' => [
                                 'article' => ArticleBridge::class,
+                                'article_page' => ArticlePageBridge::class,
                             ],
                         ],
                     ],
@@ -67,6 +71,7 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
                     'search' => [
                         'mapping' => [
                             ArticleDocument::class => ['index' => 'article'],
+                            ArticlePageDocument::class => ['index' => 'article_page'],
                         ],
                     ],
                 ]
@@ -79,9 +84,23 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
                 [
                     'mapping' => [
                         'article' => ['class' => ArticleDocument::class, 'phpcr_type' => 'sulu:article'],
+                        'article_page' => ['class' => ArticlePageDocument::class, 'phpcr_type' => 'sulu:articlepage'],
                     ],
                     'path_segments' => [
                         'articles' => 'articles',
+                    ],
+                ]
+            );
+        }
+
+        if ($container->hasExtension('fos_rest')) {
+            $container->prependExtensionConfig(
+                'fos_rest',
+                [
+                    'exception' => [
+                        'codes' => [
+                            ParameterNotAllowedException::class => 400,
+                        ],
                     ],
                 ]
             );

--- a/Document/ArticleDocument.php
+++ b/Document/ArticleDocument.php
@@ -23,12 +23,14 @@ use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\Extension\ExtensionContainer;
 use Sulu\Component\Content\Document\Structure\Structure;
 use Sulu\Component\Content\Document\Structure\StructureInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ChildrenBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocalizedTitleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
 use Sulu\Component\DocumentManager\Behavior\VersionBehavior;
+use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
 use Sulu\Component\DocumentManager\Version;
 
 /**
@@ -48,7 +50,8 @@ class ArticleDocument implements
     ExtensionBehavior,
     WorkflowStageBehavior,
     VersionBehavior,
-    AuthorBehavior
+    AuthorBehavior,
+    ChildrenBehavior
 {
     /**
      * @var string
@@ -163,10 +166,16 @@ class ArticleDocument implements
      */
     protected $versions = [];
 
+    /**
+     * @var ChildrenCollection
+     */
+    protected $children;
+
     public function __construct()
     {
         $this->structure = new Structure();
         $this->extensions = new ExtensionContainer();
+        $this->children = new \ArrayIterator();
     }
 
     /**
@@ -462,5 +471,13 @@ class ArticleDocument implements
     public function setVersions($versions)
     {
         $this->versions = $versions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChildren()
+    {
+        return $this->children;
     }
 }

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -1,0 +1,217 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document;
+
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
+use Sulu\Component\Content\Document\Structure\Structure;
+use Sulu\Component\Content\Document\Structure\StructureInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocalizedTitleBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
+
+/**
+ * Represents an article-page in phpcr.
+ */
+class ArticlePageDocument implements
+    UuidBehavior,
+    LocalizedTitleBehavior,
+    ParentBehavior,
+    AutoNameBehavior,
+    PathBehavior,
+    StructureBehavior
+{
+    /**
+     * @var string
+     */
+    private $uuid;
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var ArticleDocument
+     */
+    private $parent;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var string
+     */
+    private $originalLocale;
+
+    /**
+     * @var string
+     */
+    private $structureType;
+
+    /**
+     * @var StructureInterface
+     */
+    private $structure;
+
+    /**
+     * @var int
+     */
+    private $page;
+
+    public function __construct()
+    {
+        $this->structure = new Structure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUuid($uuid)
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOriginalLocale()
+    {
+        return $this->originalLocale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOriginalLocale($originalLocale)
+    {
+        $this->originalLocale = $originalLocale;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStructureType()
+    {
+        return $this->structureType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStructureType($structureType)
+    {
+        $this->structureType = $structureType;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStructure()
+    {
+        return $this->structure;
+    }
+
+    /**
+     * Returns page.
+     *
+     * @return int
+     */
+    public function getPage()
+    {
+        return $this->page;
+    }
+}

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -74,7 +74,7 @@ class ArticlePageDocument implements
     /**
      * @var int
      */
-    private $page;
+    private $pageNumber;
 
     public function __construct()
     {
@@ -210,8 +210,8 @@ class ArticlePageDocument implements
      *
      * @return int
      */
-    public function getPage()
+    public function getPageNumber()
     {
-        return $this->page;
+        return $this->pageNumber;
     }
 }

--- a/Document/ArticlePageViewObject.php
+++ b/Document/ArticlePageViewObject.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document;
+
+use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\Property;
+
+/**
+ * Contains page information.
+ *
+ * @Object
+ */
+class ArticlePageViewObject
+{
+    /**
+     * @var string
+     *
+     * @Property(type="string", options={"index"="not_analyzed"})
+     */
+    public $uuid;
+
+    /**
+     * @var string
+     *
+     * @Property(
+     *     type="string",
+     *     options={
+     *        "fields"={
+     *            "raw"={"type"="string", "index"="not_analyzed"},
+     *            "value"={"type"="string"}
+     *        }
+     *    }
+     * )
+     */
+    public $title;
+
+    /**
+     * @var int
+     *
+     * @Property(type="integer", options={"index"="not_analyzed"})
+     */
+    public $pageNumber;
+}

--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -15,6 +15,7 @@ use ONGR\ElasticsearchBundle\Annotation\Document;
 use ONGR\ElasticsearchBundle\Annotation\Embedded;
 use ONGR\ElasticsearchBundle\Annotation\Id;
 use ONGR\ElasticsearchBundle\Annotation\Property;
+use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Indexable document for articles.
@@ -247,11 +248,17 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     protected $changerContactId;
 
     /**
+     * @var ArticlePageViewObject[]
+     *
+     * @Embedded(class="SuluArticleBundle:ArticlePageViewObject", multiple=true)
+     */
+    protected $pages = [];
+
+    /**
      * @param string $uuid
      */
-    public function __construct(
-        $uuid = null
-    ) {
+    public function __construct($uuid = null)
+    {
         $this->uuid = $uuid;
     }
 
@@ -681,5 +688,23 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     public function getChangerContactId()
     {
         return $this->changerContactId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPages()
+    {
+        return $this->pages;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPages(Collection $pages)
+    {
+        $this->pages = $pages;
+
+        return $this;
     }
 }

--- a/Document/ArticleViewDocumentInterface.php
+++ b/Document/ArticleViewDocumentInterface.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
+use ONGR\ElasticsearchBundle\Collection\Collection;
+
 /**
  * Interface for indexable article-document.
  */
@@ -399,4 +401,20 @@ interface ArticleViewDocumentInterface
      * @return string
      */
     public function getChangerContactId();
+
+    /**
+     * Returns pages.
+     *
+     * @return ArticlePageViewObject[]
+     */
+    public function getPages();
+
+    /**
+     * Set pages.
+     *
+     * @param Collection $pages
+     *
+     * @return $this
+     */
+    public function setPages(Collection $pages);
 }

--- a/Document/Form/ArticleDocumentType.php
+++ b/Document/Form/ArticleDocumentType.php
@@ -32,17 +32,12 @@ class ArticleDocumentType extends AbstractStructureBehaviorType
         // extensions
         $builder->add('extensions', TextType::class, ['property_path' => 'extensionsData']);
 
-        // TODO: Fix the admin interface to not send this junk (not required for articles)
-        $builder->add('redirectType', TextType::class, ['mapped' => false]);
-        $builder->add('resourceSegment', TextType::class, ['mapped' => false]);
-        $builder->add('navigationContexts', TextType::class, ['mapped' => false]);
-        $builder->add('shadowLocaleEnabled', TextType::class, ['mapped' => false]);
+        $builder->add('author', TextType::class);
         $builder->add(
             'authored',
             DateType::class,
             ['widget' => 'single_text', 'model_timezone' => 'UTC', 'view_timezone' => 'UTC']
         );
-        $builder->add('author', TextType::class);
     }
 
     /**

--- a/Document/Form/ArticlePageDocumentType.php
+++ b/Document/Form/ArticlePageDocumentType.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\ArticleBundle\Document\Form;
 
 use Sulu\Bundle\ContentBundle\Form\Type\AbstractStructureBehaviorType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -20,14 +19,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ArticlePageDocumentType extends AbstractStructureBehaviorType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
-    {
-        parent::buildForm($builder, $options);
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/Document/Form/ArticlePageDocumentType.php
+++ b/Document/Form/ArticlePageDocumentType.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Form;
+
+use Sulu\Bundle\ContentBundle\Form\Type\AbstractStructureBehaviorType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Form-type for article-page mapping.
+ */
+class ArticlePageDocumentType extends AbstractStructureBehaviorType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        parent::buildForm($builder, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'allow_extra_fields' => true,
+            ]
+        );
+    }
+}

--- a/Document/Initializer/ArticleInitializer.php
+++ b/Document/Initializer/ArticleInitializer.php
@@ -54,6 +54,7 @@ class ArticleInitializer implements InitializerInterface
     {
         $nodeTypeManager = $this->sessionManager->getSession()->getWorkspace()->getNodeTypeManager();
         $nodeTypeManager->registerNodeType(new ArticleNodeType(), true);
+        $nodeTypeManager->registerNodeType(new ArticlePageNodeType(), true);
 
         $articlesPath = $this->pathBuilder->build(['%base%', '%articles%']);
         if (true === $this->nodeManager->has($articlesPath)) {

--- a/Document/Initializer/ArticlePageNodeType.php
+++ b/Document/Initializer/ArticlePageNodeType.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Initializer;
+
+use PHPCR\NodeType\NodeTypeDefinitionInterface;
+
+/**
+ * Node type for article-page phpcr-nodes.
+ */
+class ArticlePageNodeType implements NodeTypeDefinitionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sulu:articlepage';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeclaredSupertypeNames()
+    {
+        return [
+            'sulu:article',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAbstract()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMixin()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasOrderableChildNodes()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isQueryable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrimaryItemName()
+    {
+        return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeclaredPropertyDefinitions()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeclaredChildNodeDefinitions()
+    {
+        return [];
+    }
+}

--- a/Document/Serializer/ArticlePageSubscriber.php
+++ b/Document/Serializer/ArticlePageSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Serializer;
+
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\ObjectEvent;
+use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
+
+/**
+ * Extends serialization for article-pages.
+ */
+class ArticlePageSubscriber implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'addTitleOnPostSerialize',
+            ],
+        ];
+    }
+
+    /**
+     * Append title to result.
+     *
+     * @param ObjectEvent $event
+     */
+    public function addTitleOnPostSerialize(ObjectEvent $event)
+    {
+        $articlePage = $event->getObject();
+        $visitor = $event->getVisitor();
+        $context = $event->getContext();
+
+        if (!$articlePage instanceof ArticlePageDocument) {
+            return;
+        }
+
+        $visitor->addData('title', $context->accept($articlePage->getParent()->getTitle()));
+    }
+}

--- a/Document/Structure/ArticlePageBridge.php
+++ b/Document/Structure/ArticlePageBridge.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Structure;
+
+use Sulu\Component\Content\Compat\Structure\StructureBridge;
+
+/**
+ * Own structure bridge for articles.
+ */
+class ArticlePageBridge extends StructureBridge
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getWebspaceKey()
+    {
+        return;
+    }
+}

--- a/Document/Subscriber/ArticlePageSubscriber.php
+++ b/Document/Subscriber/ArticlePageSubscriber.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Subscriber;
+
+use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Indexes article and generate route on persist and removes it from index and routing on delete.
+ */
+class ArticlePageSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var StructureMetadataFactoryInterface
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * @param StructureMetadataFactoryInterface $structureMetadataFactory
+     */
+    public function __construct(StructureMetadataFactoryInterface $structureMetadataFactory)
+    {
+        $this->structureMetadataFactory = $structureMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => [['setTitleOnPersist', 2048], ['setPageOnPersist', 0]],
+            Events::HYDRATE => [['setPageOnHydrate', 0]],
+        ];
+    }
+
+    /**
+     * Set page-title from structure to document.
+     *
+     * @param PersistEvent $event
+     */
+    public function setTitleOnPersist(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof ArticlePageDocument) {
+            return;
+        }
+
+        $metadata = $this->structureMetadataFactory->getStructureMetadata(
+            'article_page',
+            $document->getStructureType()
+        );
+
+        $pageTitleProperty = $metadata->getPropertyByTagName('sulu_article.page_title');
+        if (!$pageTitleProperty) {
+            $pageTitleProperty = $metadata->getProperty('pageTitle');
+        }
+
+        $pageTitle = 'page-' . uniqid('page-1', true);
+        if ($pageTitleProperty) {
+            $pageTitle = $document->getStructure()->getStagedData()[$pageTitleProperty->getName()];
+        }
+
+        $document->setTitle($pageTitle);
+    }
+
+    public function setPageOnPersist(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof ArticlePageDocument) {
+            return;
+        }
+
+        $event->getAccessor()->set('page', $event->getNode()->getIndex() + 1);
+    }
+
+    public function setPageOnHydrate(HydrateEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof ArticlePageDocument) {
+            return;
+        }
+
+        $event->getAccessor()->set('page', $event->getNode()->getIndex() + 1);
+    }
+}

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Document\Subscriber;
 
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
+use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
 use Sulu\Bundle\ArticleBundle\Document\Index\IndexerInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
@@ -73,7 +74,12 @@ class ArticleSubscriber implements EventSubscriberInterface
     {
         return [
             Events::PERSIST => [['handleScheduleIndex', -500]],
-            Events::REMOVE => [['handleRemove', -500], ['handleRemoveLive', -500]],
+            Events::REMOVE => [
+                ['handleRemove', -500],
+                ['handleRemoveLive', -500],
+                ['handleRemovePage', -500],
+                ['handleRemovePageLive', -500],
+            ],
             Events::PUBLISH => [['handleScheduleIndexLive', 0], ['handleScheduleIndex', 0]],
             Events::UNPUBLISH => 'handleUnpublish',
             Events::REMOVE_DRAFT => ['handleScheduleIndex', -1024],
@@ -90,7 +96,11 @@ class ArticleSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
         if (!$document instanceof ArticleDocument) {
-            return;
+            if (!$document instanceof ArticlePageDocument) {
+                return;
+            }
+
+            $document = $document->getParent();
         }
 
         $this->documents[$document->getUuid()] = [
@@ -108,7 +118,11 @@ class ArticleSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
         if (!$document instanceof ArticleDocument) {
-            return;
+            if (!$document instanceof ArticlePageDocument) {
+                return;
+            }
+
+            $document = $document->getParent();
         }
 
         $this->liveDocuments[$document->getUuid()] = [
@@ -128,13 +142,11 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        foreach ($this->documents as $document) {
-            $this->indexer->index(
-                $this->documentManager->find(
-                    $document['uuid'],
-                    $document['locale']
-                )
-            );
+        foreach ($this->documents as $documentData) {
+            $document = $this->documentManager->find($documentData['uuid'], $documentData['locale']);
+            $this->documentManager->refresh($document, $documentData['locale']);
+
+            $this->indexer->index($document);
         }
         $this->indexer->flush();
         $this->documents = [];
@@ -151,32 +163,14 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        foreach ($this->liveDocuments as $document) {
-            $this->liveIndexer->index(
-                $this->documentManager->find(
-                    $document['uuid'],
-                    $document['locale']
-                )
-            );
+        foreach ($this->liveDocuments as $documentData) {
+            $document = $this->documentManager->find($documentData['uuid'], $documentData['locale']);
+            $this->documentManager->refresh($document, $documentData['locale']);
+
+            $this->liveIndexer->index($document);
         }
         $this->liveIndexer->flush();
         $this->liveDocuments = [];
-    }
-
-    /**
-     * Indexes for article-document in live index.
-     *
-     * @param AbstractMappingEvent $event
-     */
-    public function handleIndexLive(AbstractMappingEvent $event)
-    {
-        $document = $event->getDocument();
-        if (!$document instanceof ArticleDocument) {
-            return;
-        }
-
-        $this->liveIndexer->index($document);
-        $this->liveIndexer->flush();
     }
 
     /**
@@ -195,6 +189,44 @@ class ArticleSubscriber implements EventSubscriberInterface
         $this->liveIndexer->flush();
 
         $this->indexer->setUnpublished($document->getUuid());
+    }
+
+    /**
+     * Reindex article if a page was removed.
+     *
+     * @param RemoveEvent $event
+     */
+    public function handleRemovePage(RemoveEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof ArticlePageDocument) {
+            return;
+        }
+
+        $document = $document->getParent();
+        $this->documents[$document->getUuid()] = [
+            'uuid' => $document->getUuid(),
+            'locale' => $document->getLocale(),
+        ];
+    }
+
+    /**
+     * Reindex article live if a page was removed.
+     *
+     * @param RemoveEvent $event
+     */
+    public function handleRemovePageLive(RemoveEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof ArticlePageDocument) {
+            return;
+        }
+
+        $document = $document->getParent();
+        $this->liveDocuments[$document->getUuid()] = [
+            'uuid' => $document->getUuid(),
+            'locale' => $document->getLocale(),
+        ];
     }
 
     /**

--- a/Exception/ParameterNotAllowedException.php
+++ b/Exception/ParameterNotAllowedException.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Exception;
+
+/**
+ * Thrown when parameter is not allowed.
+ */
+class ParameterNotAllowedException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $property;
+
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @param string $property
+     * @param string $class
+     */
+    public function __construct($property, $class)
+    {
+        parent::__construct(sprintf('Parameter "%s" is not allowed for class "%s".', $property, $class));
+
+        $this->property = $property;
+        $this->class = $class;
+    }
+
+    /**
+     * Returns property.
+     *
+     * @return string
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    /**
+     * Returns class.
+     *
+     * @return string
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+}

--- a/Resources/config/routing_api.xml
+++ b/Resources/config/routing_api.xml
@@ -4,5 +4,6 @@
         xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
 
     <import id="sulu_article.article" type="rest" resource="@SuluArticleBundle/Controller/ArticleController.php"/>
+    <import id="sulu_article.article_page" type="rest" resource="@SuluArticleBundle/Controller/ArticlePageController.php"/>
     <import id="sulu_article.article.versioning" type="rest" parent="sulu_article.article" resource="@SuluArticleBundle/Controller/VersionController.php"/>
 </routes>

--- a/Resources/config/serializer/Document.ArticlePageDocument.xml
+++ b/Resources/config/serializer/Document.ArticlePageDocument.xml
@@ -19,8 +19,8 @@
         <property name="structure" type="Sulu\Component\Content\Document\Structure\Structure" groups="preview"/>
         <property name="structureType" type="string" groups="preview"/>
 
-        <property name="title" type="string" groups="preview"/>
-        <property name="page" type="integer" groups="website,defaultPage,preview"/>
+        <property name="title" serialized-name="articleTitle" type="string" groups="preview"/>
+        <property name="pageNumber" type="integer" groups="website,defaultPage,preview"/>
         <property name="creator" type="integer" groups="website,defaultPage,preview"/>
         <property name="changer" type="integer" groups="website,defaultPage,preview"/>
         <property name="created" type="DateTime" groups="website,defaultPage,preview"/>

--- a/Resources/config/serializer/Document.ArticlePageDocument.xml
+++ b/Resources/config/serializer/Document.ArticlePageDocument.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="Sulu\Bundle\ArticleBundle\Document\ArticleDocument" xmlns:h="https://github.com/willdurand/Hateoas" >
+    <class name="Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument" xmlns:h="https://github.com/willdurand/Hateoas" >
         <h:relation rel="self">
-            <h:href route="get_article">
+            <h:href route="get_article_page">
                 <h:parameter name="uuid" value="expr(object.getUuid())"/>
+                <h:parameter name="articleUuid" value="expr(object.getParent().getUuid())"/>
                 <h:parameter name="locale" value="expr(object.getLocale())"/>
             </h:href>
             <h:exclusion groups="defaultPage"/>
@@ -12,25 +13,19 @@
         <property name="uuid" serialized-name="id" type="string" groups="defaultPage,smallPage,preview"/>
         <property name="nodeName" type="string"/>
         <property name="path" type="string"/>
-        <property name="routePath" serialized-name="route" type="string" groups="website,defaultPage,smallPage,preview"/>
 
         <property name="locale" type="string" groups="preview"/>
         <property name="originalLocale" type="string" groups="preview"/>
         <property name="structure" type="Sulu\Component\Content\Document\Structure\Structure" groups="preview"/>
         <property name="structureType" type="string" groups="preview"/>
 
-        <property name="title" type="string" groups="defaultPage,smallPage,preview"/>
+        <property name="title" type="string" groups="preview"/>
+        <property name="page" type="integer" groups="website,defaultPage,preview"/>
         <property name="creator" type="integer" groups="website,defaultPage,preview"/>
         <property name="changer" type="integer" groups="website,defaultPage,preview"/>
         <property name="created" type="DateTime" groups="website,defaultPage,preview"/>
         <property name="changed" type="DateTime" groups="website,defaultPage,preview"/>
 
         <property name="published" type="DateTime" groups="website,defaultPage,smallPage,preview"/>
-        <property name="author" type="integer" groups="website,defaultPage,preview"/>
-        <property name="authored" type="DateTime" groups="website,defaultPage,smallPage,preview"/>
-        <property name="extensions" type="Sulu\Component\Content\Document\Extension\ExtensionContainer" serialized-name="ext" groups="defaultPage,preview"/>
-        <property name="children" serialized-name="pages" groups="defaultPage,preview">
-            <type><![CDATA[array<Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument>]]></type>
-        </property>
     </class>
 </serializer>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -113,6 +113,12 @@
 
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>
+        <service id="sulu_article.subscriber.article_page"
+                 class="Sulu\Bundle\ArticleBundle\Document\Subscriber\ArticlePageSubscriber">
+            <argument type="service" id="sulu_content.structure.factory"/>
+
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
         <service id="sulu_article.initializer"
                  class="Sulu\Bundle\ArticleBundle\Document\Initializer\ArticleInitializer">
             <argument type="service" id="sulu_document_manager.node_manager"/>
@@ -122,12 +128,16 @@
             <!-- This needs to happen after the content repository has been initialized !-->
             <tag name="sulu_document_manager.initializer" priority="-127"/>
         </service>
-        <service id="sulu_article.serializer.type"
+        <service id="sulu_article.serializer.article"
                  class="Sulu\Bundle\ArticleBundle\Document\Serializer\ArticleSubscriber">
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.content.type_manager"/>
             <argument type="service" id="sulu_article.content.data_provider.proxy_factory"/>
 
+            <tag name="jms_serializer.event_subscriber" />
+        </service>
+        <service id="sulu_article.serializer.article_page"
+                 class="Sulu\Bundle\ArticleBundle\Document\Serializer\ArticlePageSubscriber">
             <tag name="jms_serializer.event_subscriber" />
         </service>
         <service id="sulu_article.routing.default_provider"

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -36,10 +36,14 @@ sulu_core:
         structure:
             default_type:
                 article: "article_default"
+                article_page: "article_default"
             paths:
                 article:
                     path: "%kernel.root_dir%/Resources/templates/articles"
                     type: "article"
+                article_page:
+                    path: "%kernel.root_dir%/Resources/templates/articles"
+                    type: "article_page"
 
 ongr_elasticsearch:
     connections:

--- a/Tests/Functional/Controller/ArticlePageControllerTest.php
+++ b/Tests/Functional/Controller/ArticlePageControllerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Functional\Controller;
+
+use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadCollectionTypes;
+use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadMediaTypes;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class ArticlePageControllerTest extends SuluTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initPhpcr();
+
+        $collectionTypes = new LoadCollectionTypes();
+        $collectionTypes->load($this->getEntityManager());
+        $mediaTypes = new LoadMediaTypes();
+        $mediaTypes->load($this->getEntityManager());
+    }
+
+    private function createArticle($title = 'Test-Article', $template = 'default_pages')
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'POST',
+            '/api/articles?locale=de',
+            [
+                'title' => $title,
+                'pageTitle' => $title,
+                'template' => $template,
+                'authored' => '2016-01-01',
+                'author' => $this->getTestUser()->getContact()->getId(),
+            ]
+        );
+
+        return json_decode($client->getResponse()->getContent(), true);
+    }
+
+    private function getArticle($uuid)
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/articles/' . $uuid . '?locale=de');
+
+        return json_decode($client->getResponse()->getContent(), true);
+    }
+
+    private function post($article, $pageTitle = 'Test-Page')
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'POST',
+            '/api/articles/' . $article['id'] . '/pages?locale=de',
+            [
+                'pageTitle' => $pageTitle,
+                'author' => $this->getTestUser()->getContact()->getId(),
+            ]
+        );
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        return json_decode($client->getResponse()->getContent(), true);
+    }
+
+    public function testPost($title = 'Test-Article', $pageTitle = 'Test-Page', $template = 'default_pages')
+    {
+        $article = $this->createArticle($title, $template);
+        $response = $this->post($article, $pageTitle);
+
+        $this->assertEquals($title, $response['title']);
+        $this->assertEquals($pageTitle, $response['pageTitle']);
+        $this->assertEquals($template, $response['template']);
+        $this->assertEquals(2, $response['page']);
+
+        $article = $this->getArticle($article['id']);
+        $this->assertCount(1, $article['pages']);
+        $this->assertEquals($response['id'], reset($article['pages'])['id']);
+    }
+
+    public function testGet($title = 'Test-Article', $pageTitle = 'Test-Page', $template = 'default_pages')
+    {
+        $article = $this->createArticle($title, $template);
+        $page = $this->post($article, $pageTitle);
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/articles/' . $article['id'] . '/pages/' . $page['id'] . '?locale=de');
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertEquals($title, $response['title']);
+        $this->assertEquals($pageTitle, $response['pageTitle']);
+        $this->assertEquals($template, $response['template']);
+        $this->assertEquals(2, $response['page']);
+    }
+
+    public function testPut($title = 'Test-Article', $pageTitle = 'New-Page-Title', $template = 'default_pages')
+    {
+        $article = $this->createArticle($title, $template);
+        $page = $this->post($article);
+
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'PUT',
+            '/api/articles/' . $article['id'] . '/pages/' . $page['id'] . '?locale=de',
+            [
+                'pageTitle' => $pageTitle,
+                'article' => 'Sulu is awesome',
+                'author' => $this->getTestUser()->getContact()->getId(),
+            ]
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertEquals($title, $response['title']);
+        $this->assertEquals($pageTitle, $response['pageTitle']);
+        $this->assertEquals($template, $response['template']);
+        $this->assertEquals('Sulu is awesome', $response['article']);
+        $this->assertEquals(2, $response['page']);
+    }
+
+    public function testDelete()
+    {
+        $article = $this->createArticle();
+        $page = $this->post($article);
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('DELETE', '/api/articles/' . $article['id'] . '/pages/' . $page['id']);
+
+        $this->assertHttpStatusCode(204, $client->getResponse());
+
+        $article = $this->getArticle($article['id']);
+        $this->assertCount(0, $article['pages']);
+    }
+}

--- a/Tests/Unit/Document/Subscriber/ArticlePageSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/ArticlePageSubscriberTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Document\Subscriber;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
+use Sulu\Bundle\ArticleBundle\Document\Subscriber\ArticlePageSubscriber;
+use Sulu\Component\Content\Document\Structure\StructureInterface;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\Content\Metadata\PropertyMetadata;
+use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+
+class ArticlePageSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StructureMetadataFactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var ArticlePageSubscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var StructureMetadata
+     */
+    private $metadata;
+
+    /**
+     * @var ArticlePageDocument
+     */
+    private $document;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->factory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->metadata = $this->prophesize(StructureMetadata::class);
+        $this->document = $this->prophesize(ArticlePageDocument::class);
+
+        $this->document->getStructureType()->willReturn('default');
+        $this->factory->getStructureMetadata('article_page', 'default')->willReturn($this->metadata->reveal());
+
+        $this->subscriber = new ArticlePageSubscriber($this->factory->reveal());
+    }
+
+    private function createEvent($className, $node = null, $accessor = null)
+    {
+        $event = $this->prophesize($className);
+        $event->getDocument()->willReturn($this->document->reveal());
+
+        if ($node) {
+            $event->getNode()->willReturn($node);
+        }
+
+        if ($accessor) {
+            $event->getAccessor()->willReturn($accessor);
+        }
+
+        return $event->reveal();
+    }
+
+    public function testSetTitleOnPersist()
+    {
+        $event = $this->createEvent(PersistEvent::class);
+
+        $property = $this->prophesize(PropertyMetadata::class);
+        $property->getName()->willReturn('pageTitle');
+
+        $this->metadata->hasPropertyWithTagName(ArticlePageSubscriber::PAGE_TITLE_TAG_NAME)->willReturn(true);
+        $this->metadata->hasProperty(ArticlePageSubscriber::PAGE_TITLE_PROPERTY_NAME)->willReturn(false);
+        $this->metadata->getPropertyByTagName(ArticlePageSubscriber::PAGE_TITLE_TAG_NAME)->willReturn(
+            $property->reveal()
+        );
+
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->getStagedData()->willReturn(['pageTitle' => 'Test title']);
+        $this->document->getStructure()->willReturn($structure->reveal());
+
+        $this->document->setTitle('Test title')->shouldBeCalled();
+
+        $this->subscriber->setTitleOnPersist($event);
+    }
+
+    public function testSetTitleOnPersistWithoutTag()
+    {
+        $event = $this->createEvent(PersistEvent::class);
+
+        $property = $this->prophesize(PropertyMetadata::class);
+        $property->getName()->willReturn('pageTitle');
+
+        $this->metadata->hasPropertyWithTagName(ArticlePageSubscriber::PAGE_TITLE_TAG_NAME)->willReturn(false);
+        $this->metadata->hasProperty(ArticlePageSubscriber::PAGE_TITLE_PROPERTY_NAME)->willReturn(true);
+        $this->metadata->getProperty(ArticlePageSubscriber::PAGE_TITLE_PROPERTY_NAME)->willReturn(
+            $property->reveal()
+        );
+
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->getStagedData()->willReturn(['pageTitle' => 'Test title']);
+        $this->document->getStructure()->willReturn($structure->reveal());
+
+        $this->document->setTitle('Test title')->shouldBeCalled();
+
+        $this->subscriber->setTitleOnPersist($event);
+    }
+
+    public function testSetTitleOnPersistWithoutTagAndProperty()
+    {
+        $event = $this->createEvent(PersistEvent::class);
+
+        $property = $this->prophesize(PropertyMetadata::class);
+        $property->getName()->willReturn('pageTitle');
+
+        $this->metadata->hasPropertyWithTagName(ArticlePageSubscriber::PAGE_TITLE_TAG_NAME)->willReturn(false);
+        $this->metadata->hasProperty(ArticlePageSubscriber::PAGE_TITLE_PROPERTY_NAME)->willReturn(false);
+
+        $this->document->setTitle(Argument::type('string'))->shouldBeCalled();
+
+        $this->subscriber->setTitleOnPersist($event);
+    }
+
+    public function testSetPageNumberOnPersist()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getIndex()->willReturn(1);
+
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $accessor->set('pageNumber', 2)->shouldBeCalled();
+
+        $event = $this->createEvent(PersistEvent::class, $node->reveal(), $accessor->reveal());
+
+        $this->subscriber->setPageNumberOnPersist($event);
+    }
+
+    public function testSetPageNumberOnHydrate()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getIndex()->willReturn(1);
+
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $accessor->set('pageNumber', 2)->shouldBeCalled();
+
+        $event = $this->createEvent(HydrateEvent::class, $node->reveal(), $accessor->reveal());
+
+        $this->subscriber->setPageNumberOnHydrate($event);
+    }
+}

--- a/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
@@ -114,6 +114,7 @@ class ArticleSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->articleSubscriber->handleScheduleIndex($event);
 
         $this->documentManager->find($this->uuid, $this->locale)->willReturn($this->document->reveal());
+        $this->documentManager->refresh($this->document->reveal(), $this->locale)->willReturn($this->document->reveal());
 
         $this->articleSubscriber->handleFlush($this->prophesize(FlushEvent::class)->reveal());
 
@@ -129,6 +130,7 @@ class ArticleSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->articleSubscriber->handleScheduleIndexLive($event);
 
         $this->documentManager->find($this->uuid, $this->locale)->willReturn($this->document->reveal());
+        $this->documentManager->refresh($this->document->reveal(), $this->locale)->willReturn($this->document->reveal());
 
         $this->articleSubscriber->handleFlushLive($this->prophesize(FlushEvent::class)->reveal());
 

--- a/Tests/app/Resources/articles/default_pages.xml
+++ b/Tests/app/Resources/articles/default_pages.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>default_pages</key>
+
+    <view>::default</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <tag name="sulu_article.article_title"/>
+        </property>
+
+        <property name="routePath" type="route">
+            <tag name="sulu_article.article_route"/>
+        </property>
+
+        <property name="pageTitle" type="text_line" mandatory="true">
+            <tag name="sulu_article.page_title"/>
+        </property>
+
+        <property name="article" type="text_area"/>
+    </properties>
+</template>

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -1,17 +1,21 @@
 # Doctrine Configuration
 doctrine:
     dbal:
-        dbname:   "su_articles_test"
+        dbname: "su_articles_test"
 
 sulu_core:
     content:
         structure:
             default_type:
                 article: "default"
+                article_page: "default"
             paths:
                 article:
                     path: "%kernel.root_dir%/Resources/articles"
                     type: "article"
+                article_page:
+                    path: "%kernel.root_dir%/Resources/articles"
+                    type: "article_page"
 
 ongr_elasticsearch:
     connections:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces a `ArticlePageDocument`. This documents will be saved as childs of `ArticleDocuments`. 

#### Why?

This is the first part of the "Multi-Page" feature.

#### To Do

- [x] Unit-Tests
- [x] Indexing pages into article
