### PR TITLE
Fixed clear all article view documents

### DIFF
--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -293,16 +293,14 @@ class ArticleIndexer implements IndexerInterface
             ->addQuery(new MatchAllQuery())
             ->setSize($pageSize);
 
-        $count = $repository->count($repository->createSearch()->addQuery(new MatchAllQuery()));
-        $maxPage = ceil($count / $pageSize);
-        for ($page = 1; $page <= $maxPage; ++$page) {
-            $search->setFrom(($page - 1) * $pageSize);
-            foreach ($repository->execute($search) as $document) {
+        do {
+            $result = $repository->execute($search);
+            foreach ($result as $document) {
                 $this->manager->remove($document);
             }
 
             $this->manager->commit();
-        }
+        } while ($result->count() !== 0);
 
         $this->manager->clearCache();
         $this->manager->flush();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #108 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the clear of article index. it will execute search until no document will be returned. This ensures that all documents will be removed before reindexing.