### PR TITLE
Added high limit if no limit isset

### DIFF
--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -239,6 +239,9 @@ class ArticleDataProvider implements DataProviderInterface
             $this->addPagination($search, $pageSize, $page, $limit);
         } elseif (null !== $limit) {
             $search->setSize($limit);
+        } else {
+            // FIXME find better way to achieve this
+            $search->setSize(1000);
         }
 
         if (array_key_exists('sortBy', $filters) && is_array($filters['sortBy'])) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #115
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the issue that in the backend only 10 elements will be displayed if no limit isset. This is the default of elasticsearch.