### PR TITLE
Fixed call persist after article-listener

### DIFF
--- a/Document/Index/ArticleGhostIndexer.php
+++ b/Document/Index/ArticleGhostIndexer.php
@@ -33,12 +33,12 @@ class ArticleGhostIndexer extends ArticleIndexer
     /**
      * @var WebspaceManagerInterface
      */
-    private $webspaceManager;
+    protected $webspaceManager;
 
     /**
      * @var DocumentManagerInterface
      */
-    private $documentManager;
+    protected $documentManager;
 
     /**
      * @param StructureMetadataFactoryInterface $structureMetadataFactory
@@ -93,6 +93,7 @@ class ArticleGhostIndexer extends ArticleIndexer
         $article = $this->createOrUpdateArticle($document, $document->getLocale());
         $this->createOrUpdateGhosts($document);
         $this->dispatchIndexEvent($document, $article);
+        $this->manager->persist($article);
     }
 
     /**
@@ -115,19 +116,25 @@ class ArticleGhostIndexer extends ArticleIndexer
         /** @var Localization $localization */
         foreach ($this->webspaceManager->getAllLocalizations() as $localization) {
             $locale = $localization->getLocale();
-            if ($documentLocale !== $locale) {
-                // Try index the article ghosts.
-                $this->createOrUpdateArticle(
-                    $this->documentManager->find(
-                        $document->getUuid(),
-                        $locale,
-                        [
-                            'load_ghost_content' => true,
-                        ]
-                    ),
-                    $localization->getLocale(),
-                    LocalizationState::GHOST
-                );
+            if ($documentLocale === $locale) {
+                continue;
+            }
+
+            // Try index the article ghosts.
+            $article = $this->createOrUpdateArticle(
+                $this->documentManager->find(
+                    $document->getUuid(),
+                    $locale,
+                    [
+                        'load_ghost_content' => true,
+                    ]
+                ),
+                $localization->getLocale(),
+                LocalizationState::GHOST
+            );
+
+            if ($article) {
+                $this->manager->persist($article);
             }
         }
     }

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -42,56 +42,54 @@ class ArticleIndexer implements IndexerInterface
     /**
      * @var StructureMetadataFactoryInterface
      */
-    private $structureMetadataFactory;
+    protected $structureMetadataFactory;
 
     /**
      * @var UserManager
      */
-    private $userManager;
+    protected $userManager;
 
     /**
      * @var ContactRepository
      */
-    private $contactRepository;
+    protected $contactRepository;
 
     /**
      * @var DocumentFactoryInterface
      */
-    private $documentFactory;
+    protected $documentFactory;
 
     /**
      * @var Manager
      */
-    private $manager;
+    protected $manager;
 
     /**
      * @var ExcerptFactory
      */
-    private $excerptFactory;
+    protected $excerptFactory;
 
     /**
      * @var SeoFactory
      */
-    private $seoFactory;
+    protected $seoFactory;
 
     /**
      * @var EventDispatcherInterface
      */
-    private $eventDispatcher;
+    protected $eventDispatcher;
 
     /**
      * @var TranslatorInterface
      */
-    private $translator;
+    protected $translator;
 
     /**
      * @var array
      */
-    private $typeConfiguration;
+    protected $typeConfiguration;
 
     /**
-     * ArticleIndexer constructor.
-     *
      * @param StructureMetadataFactoryInterface $structureMetadataFactory
      * @param UserManager $userManager
      * @param ContactRepository $contactRepository
@@ -243,8 +241,6 @@ class ArticleIndexer implements IndexerInterface
             }
         }
 
-        $this->manager->persist($article);
-
         return $article;
     }
 
@@ -332,5 +328,6 @@ class ArticleIndexer implements IndexerInterface
     {
         $article = $this->createOrUpdateArticle($document, $document->getLocale());
         $this->dispatchIndexEvent($document, $article);
+        $this->manager->persist($article);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR moves the persist call after the index event to ensure persisting changes in the event.

#### Why?

Changes in the event were not persisted.

#### To Do

- [x] Tests
