### PR TITLE
Changed generating route only on publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,17 @@ matrix:
   include:
     - php: 5.5
       env:
-        - SULU_VERSION="~1.5.1"
+        # - SULU_VERSION="~1.6.0"
         - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
     - php: 7.0
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
-        - SULU_VERSION="dev-develop"
+        # - SULU_VERSION="dev-develop"
         - CODE_COVERAGE="--coverage-clover=coverage.clover"
     - php: 7.0
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
-        - SULU_VERSION="~1.5.1"
+        # - SULU_VERSION="~1.6.0"
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit
 
 before_install:
@@ -47,7 +47,8 @@ before_install:
   - composer self-update
 
 install:
-  - travis_retry composer require sulu/sulu:$SULU_VERSION $COMPOSER_FLAGS
+  # - travis_retry composer require sulu/sulu:$SULU_VERSION $COMPOSER_FLAGS
+  - travis_retry composer update $COMPOSER_FLAGS
   - composer info -i
   - ./Tests/app/console doctrine:database:create
   - ./Tests/app/console doctrine:schema:update --force

--- a/Controller/ArticlePageController.php
+++ b/Controller/ArticlePageController.php
@@ -195,14 +195,22 @@ class ArticlePageController extends RestController implements ClassResourceInter
      *
      * @param string $articleUuid
      * @param string $uuid
+     * @param Request $request
      *
      * @return Response
      */
-    public function deleteAction($articleUuid, $uuid)
+    public function deleteAction($articleUuid, $uuid, Request $request)
     {
+        $locale = $this->getRequestParameter($request, 'locale', true);
+
         $documentManager = $this->getDocumentManager();
-        $document = $documentManager->find($uuid);
+        $document = $documentManager->find($uuid, $locale);
         $documentManager->remove($document);
+        $documentManager->flush();
+
+        // FIXME this is a current hack which publishes article automatically when removing a single page
+        $document = $documentManager->find($articleUuid, $locale);
+        $documentManager->publish($document, $locale);
         $documentManager->flush();
 
         return $this->handleView($this->view(null));

--- a/Document/ArticleDocument.php
+++ b/Document/ArticleDocument.php
@@ -261,7 +261,6 @@ class ArticleDocument implements
     public function setRoute(RouteInterface $route)
     {
         $this->route = $route;
-        $this->routePath = $route->getPath();
     }
 
     /**
@@ -278,6 +277,14 @@ class ArticleDocument implements
     public function setRoutePath($routePath)
     {
         $this->routePath = $routePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass()
+    {
+        return self::class;
     }
 
     /**

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Document;
 
 use Sulu\Bundle\ArticleBundle\Document\Behavior\PageBehavior;
-use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
+use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutablePageBehavior;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Structure\Structure;
@@ -33,7 +33,7 @@ class ArticlePageDocument implements
     AutoNameBehavior,
     PathBehavior,
     StructureBehavior,
-    RoutableBehavior,
+    RoutablePageBehavior,
     PageBehavior,
     ArticleInterface
 {
@@ -243,7 +243,6 @@ class ArticlePageDocument implements
     public function setRoute(RouteInterface $route)
     {
         $this->route = $route;
-        $this->routePath = $route->getPath();
 
         return $this;
     }
@@ -262,6 +261,14 @@ class ArticlePageDocument implements
     public function setRoutePath($routePath)
     {
         $this->routePath = $routePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass()
+    {
+        return self::class;
     }
 
     /**

--- a/Document/Behavior/RoutableBehavior.php
+++ b/Document/Behavior/RoutableBehavior.php
@@ -11,34 +11,9 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document\Behavior;
 
-use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
-use Sulu\Component\Content\Document\Behavior\StructureBehavior;
-use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
-use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
-
 /**
- * This behavior has to be attached to documents which should have a sulu-route.
+ * This behavior has to be attached to documents which should have a sulu-route and handle their pages.
  */
-interface RoutableBehavior extends RoutableInterface, UuidBehavior, LocaleBehavior, StructureBehavior
+interface RoutableBehavior extends RoutablePageBehavior
 {
-    /**
-     * Returns route-path.
-     *
-     * @return string
-     */
-    public function getRoutePath();
-
-    /**
-     * Set route-path.
-     *
-     * @param string $routePath
-     */
-    public function setRoutePath($routePath);
-
-    /**
-     * Set uuid.
-     *
-     * @param string $uuid
-     */
-    public function setUuid($uuid);
 }

--- a/Document/Behavior/RoutablePageBehavior.php
+++ b/Document/Behavior/RoutablePageBehavior.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Behavior;
+
+use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
+use Sulu\Component\Content\Document\Behavior\StructureBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+
+/**
+ * This behavior has to be attached to documents which should have a sulu-route but managed by their parent.
+ */
+interface RoutablePageBehavior extends RoutableInterface, UuidBehavior, LocaleBehavior, StructureBehavior
+{
+    /**
+     * Returns route-path.
+     *
+     * @return string
+     */
+    public function getRoutePath();
+
+    /**
+     * Set route-path.
+     *
+     * @param string $routePath
+     */
+    public function setRoutePath($routePath);
+
+    /**
+     * Set uuid.
+     *
+     * @param string $uuid
+     */
+    public function setUuid($uuid);
+
+    /**
+     * Returns class of document without proxies.
+     *
+     * @return string
+     */
+    public function getClass();
+}

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -143,11 +143,7 @@ class ArticleIndexer implements IndexerInterface
 
         $typeTranslationKey = $this->typeConfiguration[$type]['translation_key'];
 
-        return $this->translator->trans(
-            $typeTranslationKey,
-            [],
-            'backend'
-        );
+        return $this->translator->trans($typeTranslationKey, [], 'backend');
     }
 
     /**

--- a/Document/Subscriber/PageSubscriber.php
+++ b/Document/Subscriber/PageSubscriber.php
@@ -128,7 +128,7 @@ class PageSubscriber implements EventSubscriberInterface
             }
 
             $childNode = $this->documentInspector->getNode($child);
-            $childNode->setProperty($this->propertyEncoder->systemName(static::FIELD), $page++);
+            $childNode->setProperty($this->propertyEncoder->systemName(static::FIELD), ++$page);
         }
     }
 }

--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
 use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutablePageBehavior;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
-use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorPoolInterface;
+use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
@@ -37,11 +37,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class RoutableSubscriber implements EventSubscriberInterface
 {
     const ROUTE_FIELD = 'routePath';
+    const ROUTES_PROPERTY = 'suluRoutes';
     const TAG_NAME = 'sulu_article.article_route';
-    const ROUTES_FIELD = 'routes';
 
     /**
-     * @var RouteGeneratorPoolInterface
+     * @var ChainRouteGeneratorInterface
      */
     private $routeGeneratorPool;
 
@@ -76,7 +76,7 @@ class RoutableSubscriber implements EventSubscriberInterface
     private $documentInspector;
 
     /**
-     * @param RouteGeneratorPoolInterface $routeGeneratorPool
+     * @param ChainRouteGeneratorInterface $routeGeneratorPool
      * @param RouteManagerInterface $routeManager
      * @param RouteRepositoryInterface $routeRepository
      * @param EntityManagerInterface $entityManager
@@ -85,7 +85,7 @@ class RoutableSubscriber implements EventSubscriberInterface
      * @param DocumentInspector $documentInspector
      */
     public function __construct(
-        RouteGeneratorPoolInterface $routeGeneratorPool,
+        ChainRouteGeneratorInterface $routeGeneratorPool,
         RouteManagerInterface $routeManager,
         RouteRepositoryInterface $routeRepository,
         EntityManagerInterface $entityManager,
@@ -183,7 +183,7 @@ class RoutableSubscriber implements EventSubscriberInterface
 
         $this->entityManager->persist($this->createOrUpdateRoute($document, $event->getLocale()));
 
-        $propertyName = $this->getPropertyName($event->getLocale(), self::ROUTES_FIELD);
+        $propertyName = $this->getPropertyName($event->getLocale(), self::ROUTES_PROPERTY);
 
         // check if nodes previous generated routes exists and remove them if not
         $oldRoutes = $event->getNode()->getPropertyValueWithDefault($propertyName, []);
@@ -196,7 +196,7 @@ class RoutableSubscriber implements EventSubscriberInterface
         }
 
         // save the newly generated routes of children
-        $event->getNode()->setProperty($this->getPropertyName($event->getLocale(), self::ROUTES_FIELD), $routes);
+        $event->getNode()->setProperty($this->getPropertyName($event->getLocale(), self::ROUTES_PROPERTY), $routes);
         $this->entityManager->flush();
     }
 

--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -12,15 +12,20 @@
 namespace Sulu\Bundle\ArticleBundle\Document\Subscriber;
 
 use Doctrine\ORM\EntityManagerInterface;
+use PHPCR\ItemNotFoundException;
+use PHPCR\SessionInterface;
 use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
+use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutablePageBehavior;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorPoolInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ChildrenBehavior;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
-use Sulu\Component\DocumentManager\Event\MetadataLoadEvent;
-use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\PropertyEncoder;
@@ -31,8 +36,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class RoutableSubscriber implements EventSubscriberInterface
 {
-    const FIELD = 'routePath';
+    const ROUTE_FIELD = 'routePath';
     const TAG_NAME = 'sulu_article.article_route';
+    const ROUTES_FIELD = 'routes';
+
+    /**
+     * @var RouteGeneratorPoolInterface
+     */
+    private $routeGeneratorPool;
 
     /**
      * @var RouteManagerInterface
@@ -60,24 +71,35 @@ class RoutableSubscriber implements EventSubscriberInterface
     private $metadataFactory;
 
     /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
+    /**
+     * @param RouteGeneratorPoolInterface $routeGeneratorPool
      * @param RouteManagerInterface $routeManager
      * @param RouteRepositoryInterface $routeRepository
      * @param EntityManagerInterface $entityManager
      * @param PropertyEncoder $propertyEncoder
      * @param StructureMetadataFactoryInterface $metadataFactory
+     * @param DocumentInspector $documentInspector
      */
     public function __construct(
+        RouteGeneratorPoolInterface $routeGeneratorPool,
         RouteManagerInterface $routeManager,
         RouteRepositoryInterface $routeRepository,
         EntityManagerInterface $entityManager,
         PropertyEncoder $propertyEncoder,
-        StructureMetadataFactoryInterface $metadataFactory
+        StructureMetadataFactoryInterface $metadataFactory,
+        DocumentInspector $documentInspector
     ) {
+        $this->routeGeneratorPool = $routeGeneratorPool;
         $this->routeManager = $routeManager;
         $this->routeRepository = $routeRepository;
         $this->entityManager = $entityManager;
         $this->propertyEncoder = $propertyEncoder;
         $this->metadataFactory = $metadataFactory;
+        $this->documentInspector = $documentInspector;
     }
 
     /**
@@ -87,13 +109,15 @@ class RoutableSubscriber implements EventSubscriberInterface
     {
         return [
             Events::HYDRATE => ['handleHydrate'],
-            // low priority because all other subscriber should be finished
-            Events::PERSIST => [['handleRouteUpdate', -2000], ['handleRoute', -2010], ['persistRoute', -2020]],
+            Events::PERSIST => [
+                // low priority because all other subscriber should be finished
+                ['handlePersist', -2000],
+            ],
             Events::REMOVE => [
                 // high priority to ensure nodes are not deleted until we iterate over children
                 ['handleRemove', 1024],
             ],
-            Events::METADATA_LOAD => 'handleMetadataLoad',
+            Events::PUBLISH => ['handlePublish', -2000],
             Events::CONFIGURE_OPTIONS => 'configureOptions',
         ];
     }
@@ -106,80 +130,144 @@ class RoutableSubscriber implements EventSubscriberInterface
     public function handleHydrate(AbstractMappingEvent $event)
     {
         $document = $event->getDocument();
-        if (!$document instanceof RoutableBehavior) {
+        if (!$document instanceof RoutablePageBehavior) {
             return;
         }
 
         $propertyName = $this->getRoutePathPropertyName($document->getStructureType(), $event->getLocale());
         $routePath = $event->getNode()->getPropertyValueWithDefault($propertyName, null);
-        if (!$routePath) {
-            return;
-        }
-
-        $route = $this->routeRepository->findByPath($routePath, $event->getLocale());
-        if (!$route) {
-            return;
-        }
-
         $document->setRoutePath($routePath);
-        $document->setRoute($route);
+
+        $route = $this->routeRepository->findByEntity($document->getClass(), $document->getUuid(), $event->getLocale());
+        if ($route) {
+            $document->setRoute($route);
+        }
     }
 
     /**
-     * Generate route.
+     * Generate route and save route-path.
      *
      * @param AbstractMappingEvent $event
      */
-    public function handleRoute(AbstractMappingEvent $event)
+    public function handlePersist(AbstractMappingEvent $event)
     {
         $document = $event->getDocument();
-        if (!$document instanceof RoutableBehavior || null !== $document->getRoutePath()) {
+        if (!$document instanceof RoutablePageBehavior) {
             return;
         }
 
         $document->setUuid($event->getNode()->getIdentifier());
 
-        $route = $this->routeManager->create($document, $event->getOption('route_path'));
-        $this->entityManager->persist($route);
-        $this->entityManager->flush();
-    }
+        $generatedRoute = $this->routeGeneratorPool->generate(
+            $document,
+            $event->getOption('route_path') ?: $document->getRoutePath()
+        );
 
-    /**
-     * Update route if route-path was changed.
-     *
-     * @param AbstractMappingEvent $event
-     */
-    public function handleRouteUpdate(AbstractMappingEvent $event)
-    {
-        $document = $event->getDocument();
-        if (!$document instanceof RoutableBehavior
-            || null === $document->getRoute()
-            || null === ($routePath = $event->getOption('route_path'))
-        ) {
-            return;
-        }
+        $document->setRoutePath($generatedRoute->getPath());
 
-        $route = $this->routeManager->update($document, $routePath);
-        $document->setRoutePath($route->getPath());
-        $this->entityManager->persist($route);
-        $this->entityManager->flush();
-    }
-
-    /**
-     * Save route-path to node.
-     *
-     * @param PersistEvent $event
-     */
-    public function persistRoute(PersistEvent $event)
-    {
-        $document = $event->getDocument();
-        if (!$document instanceof RoutableBehavior || null === $document->getRoute()) {
-            return;
-        }
-
-        $node = $event->getNode();
         $propertyName = $this->getRoutePathPropertyName($document->getStructureType(), $event->getLocale());
-        $node->setProperty($propertyName, $document->getRoutePath());
+        $event->getNode()->setProperty($propertyName, $generatedRoute->getPath());
+    }
+
+    /**
+     * Handle publish event and generate route and the child-routes.
+     *
+     * @param PublishEvent $event
+     */
+    public function handlePublish(PublishEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof RoutableBehavior) {
+            return;
+        }
+
+        $this->entityManager->persist($this->createOrUpdateRoute($document, $event->getLocale()));
+
+        $propertyName = $this->getPropertyName($event->getLocale(), self::ROUTES_FIELD);
+
+        // check if nodes previous generated routes exists and remove them if not
+        $oldRoutes = $event->getNode()->getPropertyValueWithDefault($propertyName, []);
+        $this->removeOldChildRoutes($event->getNode()->getSession(), $oldRoutes, $event->getLocale());
+
+        $routes = [];
+        if ($document instanceof ChildrenBehavior) {
+            // generate new routes of children
+            $routes = $this->generateChildRoutes($document, $event->getLocale());
+        }
+
+        // save the newly generated routes of children
+        $event->getNode()->setProperty($this->getPropertyName($event->getLocale(), self::ROUTES_FIELD), $routes);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Create or update for given document.
+     *
+     * @param RoutablePageBehavior $document
+     * @param string $locale
+     *
+     * @return RouteInterface
+     */
+    private function createOrUpdateRoute(RoutablePageBehavior $document, $locale)
+    {
+        $route = $this->routeRepository->findByEntity($document->getClass(), $document->getUuid(), $locale);
+        if ($route) {
+            $document->setRoute($route);
+
+            return $this->routeManager->update($document, $document->getRoutePath());
+        }
+
+        return $this->routeManager->create($document, $document->getRoutePath());
+    }
+
+    /**
+     * Removes old-routes where the node does not exists anymore.
+     *
+     * @param SessionInterface $session
+     * @param array $oldRoutes
+     * @param string $locale
+     */
+    private function removeOldChildRoutes(SessionInterface $session, array $oldRoutes, $locale)
+    {
+        foreach ($oldRoutes as $oldRoute) {
+            $oldRouteEntity = $this->routeRepository->findByPath($oldRoute, $locale);
+            if (!$this->nodeExists($session, $oldRouteEntity->getEntityId())) {
+                $this->entityManager->remove($oldRouteEntity);
+            }
+        }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Generates child routes.
+     *
+     * @param ChildrenBehavior $document
+     * @param string $locale
+     *
+     * @return string[]
+     */
+    private function generateChildRoutes(ChildrenBehavior $document, $locale)
+    {
+        $routes = [];
+        foreach ($document->getChildren() as $child) {
+            if (!$child instanceof RoutablePageBehavior) {
+                continue;
+            }
+
+            $childRoute = $this->createOrUpdateRoute($child, $locale);
+            $this->entityManager->persist($childRoute);
+
+            $child->setRoutePath($childRoute->getPath());
+            $childNode = $this->documentInspector->getNode($child);
+
+            $propertyName = $this->getRoutePathPropertyName($child->getStructureType(), $locale);
+            $childNode->setProperty($propertyName, $childRoute->getPath());
+
+            $routes[] = $childRoute->getPath();
+        }
+
+        return $routes;
     }
 
     /**
@@ -216,7 +304,7 @@ class RoutableSubscriber implements EventSubscriberInterface
     private function removeChildRoutes(ChildrenBehavior $document)
     {
         foreach ($document->getChildren() as $child) {
-            if ($child instanceof RoutableBehavior) {
+            if ($child instanceof RoutablePageBehavior) {
                 $this->removeChildRoute($child);
             }
 
@@ -229,35 +317,14 @@ class RoutableSubscriber implements EventSubscriberInterface
     /**
      * Removes route if exists.
      *
-     * @param RoutableBehavior $document
+     * @param RoutablePageBehavior $document
      */
-    private function removeChildRoute(RoutableBehavior $document)
+    private function removeChildRoute(RoutablePageBehavior $document)
     {
         $route = $this->routeRepository->findByPath($document->getRoutePath(), $document->getOriginalLocale());
         if ($route) {
             $this->entityManager->remove($route);
         }
-    }
-
-    /**
-     * Add route to metadata.
-     *
-     * @param MetadataLoadEvent $event
-     */
-    public function handleMetadataLoad(MetadataLoadEvent $event)
-    {
-        if (!$event->getMetadata()->getReflectionClass()->implementsInterface(RoutableBehavior::class)) {
-            return;
-        }
-
-        $metadata = $event->getMetadata();
-        $metadata->addFieldMapping(
-            'routePath',
-            [
-                'encoding' => 'system_localized',
-                'property' => 'routePath',
-            ]
-        );
     }
 
     /**
@@ -287,19 +354,38 @@ class RoutableSubscriber implements EventSubscriberInterface
             return $this->getPropertyName($locale, $metadata->getPropertyByTagName(self::TAG_NAME)->getName());
         }
 
-        return $this->getPropertyName($locale, self::FIELD);
+        return $this->getPropertyName($locale, self::ROUTE_FIELD);
     }
 
     /**
      * Returns encoded property-name.
      *
      * @param string $locale
-     * @param string $name
+     * @param string $field
      *
      * @return string
      */
-    private function getPropertyName($locale, $name)
+    private function getPropertyName($locale, $field)
     {
-        return $this->propertyEncoder->localizedSystemName($name, $locale);
+        return $this->propertyEncoder->localizedSystemName($field, $locale);
+    }
+
+    /**
+     * Returns true if given uuid exists.
+     *
+     * @param SessionInterface $session
+     * @param string $uuid
+     *
+     * @return bool
+     */
+    private function nodeExists(SessionInterface $session, $uuid)
+    {
+        try {
+            $session->getNodeByIdentifier($uuid);
+
+            return true;
+        } catch (ItemNotFoundException $exception) {
+            return false;
+        }
     }
 }

--- a/Resources/config/serializer/Document.ArticleDocument.xml
+++ b/Resources/config/serializer/Document.ArticleDocument.xml
@@ -19,7 +19,7 @@
         <property name="uuid" serialized-name="id" type="string" groups="defaultArticle,smallArticle,preview"/>
         <property name="nodeName" type="string"/>
         <property name="path" type="string"/>
-        <property name="routePath" serialized-name="route" type="string" groups="website,defaultArticle,smallArticle,preview"/>
+        <property name="routePath" serialized-name="route" type="string" groups="defaultArticle,smallArticle,preview"/>
 
         <property name="locale" type="string" groups="preview"/>
         <property name="originalLocale" type="string" groups="preview"/>

--- a/Resources/config/serializer/Document.ArticlePageDocument.xml
+++ b/Resources/config/serializer/Document.ArticlePageDocument.xml
@@ -20,7 +20,7 @@
         <property name="uuid" serialized-name="id" type="string" groups="defaultArticlePage,smallArticlePage,preview"/>
         <property name="nodeName" type="string" groups="preview"/>
         <property name="path" type="string"/>
-        <property name="routePath" serialized-name="route" type="string" groups="website,defaultArticle,smallArticle,preview"/>
+        <property name="routePath" serialized-name="route" type="string" groups="defaultArticle,smallArticle,preview"/>
 
         <property name="locale" type="string" groups="preview"/>
         <property name="originalLocale" type="string" groups="preview"/>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -108,11 +108,13 @@
         </service>
         <service id="sulu_article.subscriber.routable"
                  class="Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber">
+            <argument type="service" id="sulu_route.generator_pool"/>
             <argument type="service" id="sulu_route.manager.route_manager"/>
             <argument type="service" id="sulu.repository.route"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="sulu_document_manager.property_encoder"/>
             <argument type="service" id="sulu_content.structure.factory"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
 
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -108,7 +108,7 @@
         </service>
         <service id="sulu_article.subscriber.routable"
                  class="Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber">
-            <argument type="service" id="sulu_route.generator_pool"/>
+            <argument type="service" id="sulu_route.chain_generator"/>
             <argument type="service" id="sulu_route.manager.route_manager"/>
             <argument type="service" id="sulu.repository.route"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>

--- a/Tests/Functional/Controller/ArticlePageControllerTest.php
+++ b/Tests/Functional/Controller/ArticlePageControllerTest.php
@@ -216,7 +216,7 @@ class ArticlePageControllerTest extends SuluTestCase
         $page = $this->post($article);
 
         $client = $this->createAuthenticatedClient();
-        $client->request('DELETE', '/api/articles/' . $article['id'] . '/pages/' . $page['id']);
+        $client->request('DELETE', '/api/articles/' . $article['id'] . '/pages/' . $page['id'] . '?locale=de');
 
         $this->assertHttpStatusCode(204, $client->getResponse());
 

--- a/Tests/Unit/Document/Subscriber/PageSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/PageSubscriberTest.php
@@ -146,8 +146,8 @@ class PageSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->propertyEncoder->systemName(PageSubscriber::FIELD)->willReturn('sulu:' . PageSubscriber::FIELD);
 
-        $childNode2->setProperty('sulu:' . PageSubscriber::FIELD, 1)->shouldBeCalled();
-        $childNode3->setProperty('sulu:' . PageSubscriber::FIELD, 2)->shouldBeCalled();
+        $childNode2->setProperty('sulu:' . PageSubscriber::FIELD, 2)->shouldBeCalled();
+        $childNode3->setProperty('sulu:' . PageSubscriber::FIELD, 3)->shouldBeCalled();
 
         $this->pageSubscriber->handleRemove($event->reveal());
     }

--- a/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
@@ -19,9 +19,9 @@ use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
 use Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Bundle\RouteBundle\Entity\Route;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
-use Sulu\Bundle\RouteBundle\Generator\GeneratedRoute;
-use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorPoolInterface;
+use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
@@ -35,7 +35,7 @@ use Sulu\Component\DocumentManager\Event\RemoveEvent;
 class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var RouteGeneratorPoolInterface
+     * @var ChainRouteGeneratorInterface
      */
     private $routeGeneratorPool;
 
@@ -86,7 +86,7 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->routeGeneratorPool = $this->prophesize(RouteGeneratorPoolInterface::class);
+        $this->routeGeneratorPool = $this->prophesize(ChainRouteGeneratorInterface::class);
         $this->routeManager = $this->prophesize(RouteManagerInterface::class);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
@@ -191,7 +191,7 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory->getStructureMetadata('article', 'default')->willReturn($metadata->reveal());
 
         $this->routeGeneratorPool->generate($this->document->reveal(), null)
-            ->willReturn(new GeneratedRoute($this->document->reveal(), '/test'));
+            ->willReturn(new Route('/test', null, get_class($this->document->reveal())));
 
         $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
             ->willReturn('i18n:de-routePath');
@@ -216,7 +216,7 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory->getStructureMetadata('article', 'default')->willReturn($metadata->reveal());
 
         $this->routeGeneratorPool->generate($this->document->reveal(), '/test-1')
-            ->willReturn(new GeneratedRoute($this->document->reveal(), '/test-1'));
+            ->willReturn(new Route('/test-1', null, get_class($this->document->reveal())));
 
         $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
             ->willReturn('i18n:de-routePath');
@@ -241,7 +241,7 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory->getStructureMetadata('article', 'default')->willReturn($metadata->reveal());
 
         $this->routeGeneratorPool->generate($this->document->reveal(), '/test-2')
-            ->willReturn(new GeneratedRoute($this->document->reveal(), '/test-2'));
+            ->willReturn(new Route('/test-2', null, get_class($this->document->reveal())));
 
         $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
             ->willReturn('i18n:de-routePath');

--- a/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/RoutableSubscriberTest.php
@@ -13,10 +13,15 @@ namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Document\Subscriber;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
 use Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Generator\GeneratedRoute;
+use Sulu\Bundle\RouteBundle\Generator\RouteGeneratorPoolInterface;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
@@ -29,6 +34,11 @@ use Sulu\Component\DocumentManager\Event\RemoveEvent;
 
 class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var RouteGeneratorPoolInterface
+     */
+    private $routeGeneratorPool;
+
     /**
      * @var RouteManagerInterface
      */
@@ -55,6 +65,11 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
     private $metadataFactory;
 
     /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
+    /**
      * @var RoutableSubscriber
      */
     private $routableSubscriber;
@@ -71,11 +86,13 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $this->routeGeneratorPool = $this->prophesize(RouteGeneratorPoolInterface::class);
         $this->routeManager = $this->prophesize(RouteManagerInterface::class);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
         $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
         $this->metadataFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->documentInspector = $this->prophesize(DocumentInspector::class);
 
         $this->document = $this->prophesize(RoutableBehavior::class);
 
@@ -83,11 +100,13 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->node->getIdentifier()->willReturn('123-123-123');
 
         $this->routableSubscriber = new RoutableSubscriber(
+            $this->routeGeneratorPool->reveal(),
             $this->routeManager->reveal(),
             $this->routeRepository->reveal(),
             $this->entityManager->reveal(),
             $this->propertyEncoder->reveal(),
-            $this->metadataFactory->reveal()
+            $this->metadataFactory->reveal(),
+            $this->documentInspector->reveal()
         );
     }
 
@@ -114,9 +133,19 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
         $metadata->hasTag(RoutableSubscriber::TAG_NAME)->willReturn(false);
         $this->metadataFactory->getStructureMetadata('article', 'default')->willReturn($metadata->reveal());
 
-        $this->propertyEncoder->localizedSystemName(RoutableSubscriber::FIELD, 'de')
-            ->willReturn('i18n:de-' . RoutableSubscriber::FIELD);
-        $this->node->getPropertyValueWithDefault('i18n:de-' . RoutableSubscriber::FIELD, null)->willReturn('/test');
+        $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
+            ->willReturn('i18n:de-' . RoutableSubscriber::ROUTE_FIELD);
+        $this->node->getPropertyValueWithDefault('i18n:de-' . RoutableSubscriber::ROUTE_FIELD, null)
+            ->willReturn('/test');
+        $this->document->getClass()->willReturn(ArticleDocument::class);
+        $this->document->getUuid()->willReturn('123-123-123');
+
+        $this->routeRepository->findByEntity(ArticleDocument::class, '123-123-123', 'de')->willReturn($route->reveal());
+
+        $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
+            ->willReturn('i18n:de-' . RoutableSubscriber::ROUTE_FIELD);
+        $this->node->getPropertyValueWithDefault('i18n:de-' . RoutableSubscriber::ROUTE_FIELD, null)
+            ->willReturn('/test');
 
         $this->document->setRoutePath('/test')->shouldBeCalled();
 
@@ -127,9 +156,12 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $route = $this->prophesize(RouteInterface::class);
         $this->document->setRoute($route->reveal())->shouldBeCalled();
+        $this->document->getUuid()->willReturn('123-123-123');
         $this->document->getOriginalLocale()->willReturn('de');
         $this->document->getStructureType()->willReturn('default');
-        $this->routeRepository->findByPath('/test', 'de')->willReturn($route->reveal());
+        $this->document->getClass()->willReturn(ArticleDocument::class);
+
+        $this->routeRepository->findByEntity(ArticleDocument::class, '123-123-123', 'de')->willReturn($route->reveal());
 
         $propertyMetadata = $this->prophesize(PropertyMetadata::class);
         $propertyMetadata->getName()->willReturn('test');
@@ -147,48 +179,79 @@ class RoutableSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->routableSubscriber->handleHydrate($this->prophesizeEvent(HydrateEvent::class));
     }
 
-    public function testHandleRoute()
+    public function testHandlePersist()
     {
-        $route = $this->prophesize(RouteInterface::class);
         $this->document->getRoutePath()->willReturn(null);
+        $this->document->setRoutePath('/test')->shouldBeCalled();
         $this->document->setUuid('123-123-123')->shouldBeCalled();
-        $this->routeManager->create($this->document->reveal(), null)->shouldBeCalled()->willReturn($route->reveal());
 
-        $this->entityManager->persist($route->reveal())->shouldBeCalled();
-        $this->entityManager->flush()->shouldBeCalled();
+        $this->document->getStructureType()->willReturn('default');
+        $metadata = $this->prophesize(StructureMetadata::class);
+        $metadata->hasTag(RoutableSubscriber::TAG_NAME)->willReturn(false);
+        $this->metadataFactory->getStructureMetadata('article', 'default')->willReturn($metadata->reveal());
 
-        $this->routableSubscriber->handleRoute($this->prophesizeEvent(PersistEvent::class));
+        $this->routeGeneratorPool->generate($this->document->reveal(), null)
+            ->willReturn(new GeneratedRoute($this->document->reveal(), '/test'));
+
+        $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
+            ->willReturn('i18n:de-routePath');
+        $this->node->setProperty('i18n:de-routePath', '/test')->shouldBeCalled();
+
+        $this->routeManager->create(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->persist(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->flush()->shouldNotBeCalled();
+
+        $this->routableSubscriber->handlePersist($this->prophesizeEvent(PersistEvent::class));
     }
 
-    public function testHandleRouteWithRoute()
+    public function testHandlePersistWithRoute()
     {
-        $route = $this->prophesize(RouteInterface::class);
         $this->document->getRoutePath()->willReturn(null);
+        $this->document->setRoutePath('/test-1')->shouldBeCalled();
         $this->document->setUuid('123-123-123')->shouldBeCalled();
-        $this->routeManager->create($this->document->reveal(), '/test-1')
-            ->shouldBeCalled()
-            ->willReturn($route->reveal());
 
-        $this->entityManager->persist($route->reveal())->shouldBeCalled();
-        $this->entityManager->flush()->shouldBeCalled();
+        $this->document->getStructureType()->willReturn('default');
+        $metadata = $this->prophesize(StructureMetadata::class);
+        $metadata->hasTag(RoutableSubscriber::TAG_NAME)->willReturn(false);
+        $this->metadataFactory->getStructureMetadata('article', 'default')->willReturn($metadata->reveal());
 
-        $this->routableSubscriber->handleRoute($this->prophesizeEvent(PersistEvent::class, '/test-1'));
+        $this->routeGeneratorPool->generate($this->document->reveal(), '/test-1')
+            ->willReturn(new GeneratedRoute($this->document->reveal(), '/test-1'));
+
+        $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
+            ->willReturn('i18n:de-routePath');
+        $this->node->setProperty('i18n:de-routePath', '/test-1')->shouldBeCalled();
+
+        $this->routeManager->create(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->persist(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->flush()->shouldNotBeCalled();
+
+        $this->routableSubscriber->handlePersist($this->prophesizeEvent(PersistEvent::class, '/test-1'));
     }
 
-    public function testHandleRouteUpdate()
+    public function testHandlePersistUpdate()
     {
-        $route = $this->prophesize(RouteInterface::class);
-        $newRoute = $this->prophesize(RouteInterface::class);
-        $this->document->getRoute()->willReturn($route->reveal());
-
-        $newRoute->getPath()->willReturn('/test-2');
-
-        $this->routeManager->update($this->document->reveal(), '/test-2')->willReturn($newRoute->reveal());
+        $this->document->getRoutePath()->willReturn('/test-1');
+        $this->document->setUuid('123-123-123')->shouldBeCalled();
         $this->document->setRoutePath('/test-2')->shouldBeCalled();
-        $this->entityManager->persist($newRoute)->shouldBeCalled();
-        $this->entityManager->flush()->shouldBeCalled();
 
-        $this->routableSubscriber->handleRouteUpdate($this->prophesizeEvent(PersistEvent::class, '/test-2'));
+        $this->document->getStructureType()->willReturn('default');
+        $metadata = $this->prophesize(StructureMetadata::class);
+        $metadata->hasTag(RoutableSubscriber::TAG_NAME)->willReturn(false);
+        $this->metadataFactory->getStructureMetadata('article', 'default')->willReturn($metadata->reveal());
+
+        $this->routeGeneratorPool->generate($this->document->reveal(), '/test-2')
+            ->willReturn(new GeneratedRoute($this->document->reveal(), '/test-2'));
+
+        $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, 'de')
+            ->willReturn('i18n:de-routePath');
+        $this->node->setProperty('i18n:de-routePath', '/test-2')->shouldBeCalled();
+
+        $this->routeManager->create(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->persist(Argument::cetera())->shouldNotBeCalled();
+        $this->entityManager->flush()->shouldNotBeCalled();
+
+        $this->routableSubscriber->handlePersist($this->prophesizeEvent(PersistEvent::class, '/test-2'));
     }
 
     public function testHandleRemove()

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^5.5 || ^7.0",
-        "sulu/sulu": "dev-feature/route-generator-pool",
+        "sulu/sulu": "dev-develop",
         "ongr/elasticsearch-bundle": "~1.0"
     },
     "require-dev": {
@@ -23,12 +23,6 @@
         "php-task/task-bundle": "@dev",
         "php-task/php-task": "@dev"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/wachterjohannes/sulu"
-        }
-    ],
     "keywords": [
         "articles"
     ],

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^5.5 || ^7.0",
-        "sulu/sulu": "^1.5.2 || dev-develop",
+        "sulu/sulu": "dev-feature/route-generator-pool",
         "ongr/elasticsearch-bundle": "~1.0"
     },
     "require-dev": {
@@ -23,6 +23,12 @@
         "php-task/task-bundle": "@dev",
         "php-task/php-task": "@dev"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/wachterjohannes/sulu"
+        }
+    ],
     "keywords": [
         "articles"
     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | build ontop #122 https://github.com/sulu/sulu/pull/3299
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the time to generate the route to on-publish which allows us to detect deleted nodes and remove their routes.