### PR TITLE
Feature/elasticsearch 50

### DIFF
--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -13,9 +13,9 @@ namespace Sulu\Bundle\ArticleBundle\Content;
 
 use ONGR\ElasticsearchBundle\Result\DocumentIterator;
 use ONGR\ElasticsearchBundle\Service\Manager;
-use ONGR\ElasticsearchDSL\Query\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
-use ONGR\ElasticsearchDSL\Query\TermQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Search;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
@@ -249,7 +249,7 @@ class ArticleDataProvider implements DataProviderInterface
             $this->appendSortBy($filters['sortBy'], $sortMethod, $search);
         }
 
-        return $repository->execute($search);
+        return $repository->findDocuments($search);
     }
 
     /**

--- a/Content/ArticleSelectionContentType.php
+++ b/Content/ArticleSelectionContentType.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Content;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
-use ONGR\ElasticsearchDSL\Query\IdsQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
 use Sulu\Bundle\ArticleBundle\Metadata\ArticleViewDocumentIdTrait;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -72,7 +72,7 @@ class ArticleSelectionContentType extends SimpleContentType
 
         $result = [];
         /** @var ArticleViewDocumentInterface $articleDocument */
-        foreach ($repository->execute($search) as $articleDocument) {
+        foreach ($repository->findDocuments($search) as $articleDocument) {
             $result[array_search($articleDocument->getUuid(), $value, false)] = $articleDocument;
         }
 

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -16,10 +16,10 @@ use FOS\RestBundle\Routing\ClassResourceInterface;
 use JMS\Serializer\SerializationContext;
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
-use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
-use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\MatchQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\MultiMatchQuery;
+use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;
 use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
@@ -180,7 +180,7 @@ class ArticleController extends RestController implements ClassResourceInterface
     /**
      * Returns single article.
      *
-     * @param string $uuid
+     * @param string  $uuid
      * @param Request $request
      *
      * @return Response
@@ -233,7 +233,7 @@ class ArticleController extends RestController implements ClassResourceInterface
      * Update articles.
      *
      * @param Request $request
-     * @param string $uuid
+     * @param string  $uuid
      *
      * @return Response
      */
@@ -308,7 +308,7 @@ class ArticleController extends RestController implements ClassResourceInterface
      *
      * @Post("/articles/{uuid}")
      *
-     * @param string $uuid
+     * @param string  $uuid
      * @param Request $request
      *
      * @return Response
@@ -343,7 +343,7 @@ class ArticleController extends RestController implements ClassResourceInterface
                     $data = $this->getMapper()->copyLanguage($uuid, $userId, null, $locale, explode(',', $destLocales));
                     break;
                 default:
-                    throw new RestException('Unrecognized action: ' . $action);
+                    throw new RestException('Unrecognized action: '.$action);
             }
 
             // prepare view
@@ -367,7 +367,7 @@ class ArticleController extends RestController implements ClassResourceInterface
     /**
      * Persists the document using the given information.
      *
-     * @param array $data
+     * @param array  $data
      * @param object $document
      * @param string $locale
      *

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -15,12 +15,12 @@ use FOS\RestBundle\Controller\Annotations\Post;
 use FOS\RestBundle\Routing\ClassResourceInterface;
 use JMS\Serializer\SerializationContext;
 use ONGR\ElasticsearchBundle\Service\Manager;
-use ONGR\ElasticsearchDSL\Query\BoolQuery;
-use ONGR\ElasticsearchDSL\Query\IdsQuery;
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
-use ONGR\ElasticsearchDSL\Query\MatchQuery;
-use ONGR\ElasticsearchDSL\Query\MultiMatchQuery;
-use ONGR\ElasticsearchDSL\Query\TermQuery;
+use ONGR\ElasticsearchDSL\Query\FullText\MatchQuery;
+use ONGR\ElasticsearchDSL\Query\FullText\MultiMatchQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;
 use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
 use Sulu\Bundle\ArticleBundle\Document\Form\ArticleDocumentType;
@@ -149,7 +149,7 @@ class ArticleController extends RestController implements ClassResourceInterface
         $search->setFrom(($page - 1) * $limit);
 
         $result = [];
-        foreach ($repository->execute($search) as $document) {
+        foreach ($repository->findDocuments($search) as $document) {
             if (false !== ($index = array_search($document->getUuid(), $ids))) {
                 $result[$index] = $document;
             } else {

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\ArticleBundle\Document\Index;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
-use ONGR\ElasticsearchDSL\Query\TermQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
@@ -254,7 +254,7 @@ class ArticleIndexer implements IndexerInterface
         $search = $repository->createSearch()
             ->addQuery(new TermQuery('uuid', $document->getUuid()))
             ->setSize(1000);
-        foreach ($repository->execute($search) as $viewDocument) {
+        foreach ($repository->findDocuments($search) as $viewDocument) {
             $this->manager->remove($viewDocument);
         }
     }
@@ -279,7 +279,7 @@ class ArticleIndexer implements IndexerInterface
             ->setSize($pageSize);
 
         do {
-            $result = $repository->execute($search);
+            $result = $repository->findDocuments($search);
             foreach ($result as $document) {
                 $this->manager->remove($document);
             }

--- a/Markup/ArticleLinkProvider.php
+++ b/Markup/ArticleLinkProvider.php
@@ -12,8 +12,9 @@
 namespace Sulu\Bundle\ArticleBundle\Markup;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
-use ONGR\ElasticsearchDSL\Query\IdsQuery;
-use ONGR\ElasticsearchDSL\Query\RangeQuery;
+use ONGR\ElasticsearchBundle\Service\Repository;
+use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use ONGR\ElasticsearchDSL\Search;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
 use Sulu\Bundle\ArticleBundle\Document\Index\DocumentFactory;
@@ -27,7 +28,7 @@ use Sulu\Bundle\ContentBundle\Markup\Link\LinkProviderInterface;
 class ArticleLinkProvider implements LinkProviderInterface
 {
     /**
-     * @var Manager
+     * @var Repository
      */
     private $manager;
 
@@ -46,7 +47,7 @@ class ArticleLinkProvider implements LinkProviderInterface
      * @param DocumentFactory $documentFactory
      * @param array $types
      */
-    public function __construct(Manager $manager, DocumentFactory $documentFactory, array $types)
+    public function __construct(Repository $manager, DocumentFactory $documentFactory, array $types)
     {
         $this->manager = $manager;
         $this->documentFactory = $documentFactory;
@@ -87,7 +88,8 @@ class ArticleLinkProvider implements LinkProviderInterface
             $search->addQuery(new RangeQuery('authored', ['lte' => 'now']));
         }
 
-        $documents = $this->manager->execute([$this->documentFactory->getClass('article')], $search);
+        $repository = $this->manager->getRepository($this->documentFactory->getClass('article'));
+        $documents = $repository->findDocuments($search);
 
         $result = [];
         /** @var ArticleViewDocumentInterface $document */

--- a/Markup/ArticleLinkProvider.php
+++ b/Markup/ArticleLinkProvider.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\ArticleBundle\Markup;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
-use ONGR\ElasticsearchBundle\Service\Repository;
 use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use ONGR\ElasticsearchDSL\Search;
@@ -28,7 +27,7 @@ use Sulu\Bundle\ContentBundle\Markup\Link\LinkProviderInterface;
 class ArticleLinkProvider implements LinkProviderInterface
 {
     /**
-     * @var Repository
+     * @var Manager
      */
     private $manager;
 
@@ -43,11 +42,11 @@ class ArticleLinkProvider implements LinkProviderInterface
     private $types;
 
     /**
-     * @param Manager $manager
+     * @param Manager         $manager
      * @param DocumentFactory $documentFactory
-     * @param array $types
+     * @param array           $types
      */
-    public function __construct(Repository $manager, DocumentFactory $documentFactory, array $types)
+    public function __construct(Manager $manager, DocumentFactory $documentFactory, array $types)
     {
         $this->manager = $manager;
         $this->documentFactory = $documentFactory;

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -42,18 +42,15 @@ sulu_core:
                     type: "article"
 
 ongr_elasticsearch:
-    connections:
-        default:
-            index_name: su_articles
-        live:
-            index_name: su_articles_live
     managers:
         default:
-            connection: default
+            index: 
+                index_name: su_articles
             mappings:
                 - SuluArticleBundle
         live:
-            connection: live
+            index:
+                index_name: su_articles_live
             mappings:
                 - SuluArticleBundle
 ```

--- a/Sitemap/ArticleSitemapProvider.php
+++ b/Sitemap/ArticleSitemapProvider.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\ArticleBundle\Sitemap;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchBundle\Service\Repository;
-use ONGR\ElasticsearchDSL\Query\TermQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
 use Sulu\Bundle\ArticleBundle\Document\Index\DocumentFactoryInterface;
 use Sulu\Bundle\WebsiteBundle\Sitemap\Sitemap;
@@ -72,11 +72,11 @@ class ArticleSitemapProvider implements SitemapProviderInterface
     private function getBulk(Repository $repository, $from, $size)
     {
         $search = $repository->createSearch()
-            ->addQuery(new TermQuery('seo.hide_in_sitemap', false))
+            ->addQuery(new TermQuery('seo.hide_in_sitemap', 'false'))
             ->setFrom($from)
             ->setSize($size);
 
-        return $repository->execute($search);
+        return $repository->findDocuments($search);
     }
 
     /**
@@ -94,7 +94,7 @@ class ArticleSitemapProvider implements SitemapProviderInterface
     {
         $repository = $this->manager->getRepository($this->documentFactory->getClass('article'));
         $search = $repository->createSearch()
-            ->addQuery(new TermQuery('seo.hide_in_sitemap', false));
+            ->addQuery(new TermQuery('seo.hide_in_sitemap', 'false'));
 
         return ceil($repository->count($search) / self::PAGE_SIZE);
     }

--- a/Teaser/ArticleTeaserProvider.php
+++ b/Teaser/ArticleTeaserProvider.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Teaser;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
-use ONGR\ElasticsearchDSL\Query\IdsQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
 use Sulu\Bundle\ArticleBundle\Metadata\ArticleViewDocumentIdTrait;
 use Sulu\Bundle\ContentBundle\Teaser\Configuration\TeaserConfiguration;
 use Sulu\Bundle\ContentBundle\Teaser\Provider\TeaserProviderInterface;
@@ -88,7 +88,7 @@ class ArticleTeaserProvider implements TeaserProviderInterface
         $search->addQuery(new IdsQuery($articleIds));
 
         $result = [];
-        foreach ($repository->execute($search) as $item) {
+        foreach ($repository->findDocuments($search) as $item) {
             $excerpt = $item->getExcerpt();
             $result[] = new Teaser(
                 $item->getUuid(),

--- a/Tests/Unit/Content/ArticleSelectionContentTypeTest.php
+++ b/Tests/Unit/Content/ArticleSelectionContentTypeTest.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Content;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchBundle\Service\Repository;
-use ONGR\ElasticsearchDSL\Query\IdsQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
 use ONGR\ElasticsearchDSL\Search;
 use Prophecy\Argument;
 use Sulu\Bundle\ArticleBundle\Content\ArticleSelectionContentType;
@@ -64,7 +64,7 @@ class ArticleSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
                 }
             )
         )->shouldBeCalled();
-        $repository->execute($search->reveal())->willReturn($articles);
+        $repository->findDocuments($search->reveal())->willReturn($articles);
 
         $contentType = new ArticleSelectionContentType(
             $manager->reveal(),

--- a/Tests/app/AppKernel.php
+++ b/Tests/app/AppKernel.php
@@ -35,9 +35,14 @@ class AppKernel extends SuluTestKernel
         parent::registerContainerConfiguration($loader);
 
         if (getenv('SYMFONY__PHPCR__TRANSPORT') === 'jackrabbit') {
-            $loader->load(__DIR__ . '/config/versioning.yml');
+            $loader->load(__DIR__.'/config/versioning.yml');
         }
 
-        $loader->load(__DIR__ . '/config/config.yml');
+        // If version is lower then 5.6 it is an testcase for elasticsearch 2.*, so different ONGR config is needed
+        if (phpversion() < 5.6) {
+            $loader->load(__DIR__.'/config/config_es2.yml');
+        } else {
+            $loader->load(__DIR__.'/config/config.yml');
+        }
     }
 }

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -14,18 +14,15 @@ sulu_core:
                     type: "article"
 
 ongr_elasticsearch:
-    connections:
-        default:
-            index_name: su_articles_test
-        live:
-            index_name: su_articles_test_live
     managers:
         default:
-            connection: default
+            index:
+                index_name: su_articles_test
             mappings:
                 - SuluArticleBundle
         live:
-            connection: live
+            index:
+                index_name: su_articles_test_live
             mappings:
                 - SuluArticleBundle
 # Sulu Routing

--- a/Tests/app/config/config_es2.yml
+++ b/Tests/app/config/config_es2.yml
@@ -1,0 +1,37 @@
+# Doctrine Configuration
+doctrine:
+    dbal:
+        dbname:   "su_articles_test"
+
+sulu_core:
+    content:
+        structure:
+            default_type:
+                article: "default"
+            paths:
+                article:
+                    path: "%kernel.root_dir%/Resources/articles"
+                    type: "article"
+
+ongr_elasticsearch:
+    connections:
+        default:
+            index_name: su_articles_test
+        live:
+            index_name: su_articles_test_live
+    managers:
+        default:
+            connection: default
+            mappings:
+                - SuluArticleBundle
+        live:
+            connection: live
+            mappings:
+                - SuluArticleBundle
+# Sulu Routing
+sulu_route:
+    mappings:
+        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
+            generator: schema
+            options:
+                route_schema: /articles/{object.getTitle()}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "sulu/sulu": "^1.5.3 || dev-develop",
-        "ongr/elasticsearch-bundle": "~1.0"
+        "ongr/elasticsearch-bundle": "~1.0 || ~5.0"
     },
     "require-dev": {
         "zendframework/zend-stdlib": "2.3.1 as 2.0.0rc5",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #149 
| License | MIT

#### What's in this PR?

ArticleBundle now also ElasticSearch 5.0 compatible


#### BC Breaks

- Not compatible with PHP 5.5 anymore if you make use of 5.0 bundle

#### To Do

-  Documentation for ONGR/ElasticsearchBundle is different now. Config has changed. I only changed it to the new configuration. Don't if you can see this as Break.
