### PR TITLE
Fixed saving of articles without intl extension

### DIFF
--- a/Resources/config/serializer/Document.ArticleDocument.xml
+++ b/Resources/config/serializer/Document.ArticleDocument.xml
@@ -27,7 +27,9 @@
 
         <property name="published" type="DateTime" groups="website,defaultPage,smallPage,preview"/>
         <property name="author" type="integer" groups="website,defaultPage,preview"/>
-        <property name="authored" type="DateTime" groups="website,defaultPage,smallPage,preview"/>
+        <property name="authored" groups="website,defaultPage,smallPage,preview">
+            <type><![CDATA[DateTime<'Y-m-d'>]]></type>
+        </property>
         <property name="extensions" type="Sulu\Component\Content\Document\Extension\ExtensionContainer" serialized-name="ext" groups="defaultPage,preview"/>
     </class>
 </serializer>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Set the article authored format to `Y-m-d`.

#### Why?

Else it dont work without the intl extension.

