### PR TITLE
Use exist route object for route generation

### DIFF
--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -235,7 +235,12 @@ class RoutableSubscriber implements EventSubscriberInterface
      */
     private function createOrUpdatePageRoute(RoutablePageBehavior $document, $locale)
     {
-        $route = $this->routeRepository->findByEntity($document->getClass(), $document->getUuid(), $locale);
+        $route = $document->getRoute();
+
+        if (!$route) {
+            $route = $this->routeRepository->findByEntity($document->getClass(), $document->getUuid(), $locale);
+        }
+
         if ($route) {
             $document->setRoute($route);
 
@@ -255,7 +260,12 @@ class RoutableSubscriber implements EventSubscriberInterface
      */
     private function createOrUpdateRoute(RoutableBehavior $document, $locale)
     {
-        $route = $this->routeRepository->findByEntity($document->getClass(), $document->getUuid(), $locale);
+        $route = $document->getRoute();
+
+        if (!$route) {
+            $route = $this->routeRepository->findByEntity($document->getClass(), $document->getUuid(), $locale);
+        }
+
         if ($route) {
             $document->setRoute($route);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Use exist route object when document has one.

#### Why?

Avoid errors in imports when document is persisted multiple times.
