### PR TITLE
Fixed find linked articles query when multiple templates exists

### DIFF
--- a/Document/Subscriber/PageTreeRouteSubscriber.php
+++ b/Document/Subscriber/PageTreeRouteSubscriber.php
@@ -165,8 +165,8 @@ class PageTreeRouteSubscriber implements EventSubscriberInterface
 
         $query = $this->documentManager->createQuery(
             sprintf(
-                'SELECT * FROM [nt:unstructured] WHERE [jcr:mixinTypes] = "sulu:article" AND %s',
-                implode(' AND ', $where)
+                'SELECT * FROM [nt:unstructured] WHERE [jcr:mixinTypes] = "sulu:article" AND (%s)',
+                implode(' OR ', $where)
             ),
             $locale
         );

--- a/Tests/app/Resources/articles/page_tree_route_second.xml
+++ b/Tests/app/Resources/articles/page_tree_route_second.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>page_tree_route_second</key>
+
+    <view>::default</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true"/>
+        <property name="routePath" type="page_tree_route"/>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Fixes the query to find articles when a page was published (or moved) when multiple templates uses the `page-tree-route` content-type.