### PR TITLE
Fix caching for website articles

### DIFF
--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -123,6 +123,8 @@ class WebsiteArticleController extends Controller
                 HttpCache::HEADER_REVERSE_PROXY_TTL,
                 $cacheLifetime
             );
+            $response->setMaxAge($this->getParameter('sulu_http_cache.handler.public.max_age'));
+            $response->setSharedMaxAge($this->getParameter('sulu_http_cache.handler.public.shared_max_age'));
         }
 
         return $response;

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "zendframework/zend-stdlib": "2.3.1 as 2.0.0rc5",
         "zendframework/zendsearch": "2.*@dev",
         "symfony/monolog-bundle": "2.4.*",
-        "doctrine/doctrine-bundle": "1.4.*",
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
         "jackalope/jackalope-jackrabbit": "^1.2",
         "phpunit/phpunit": "^4.8 || ^5.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set maxAge and sharedMaxAge in the website article controller.

#### Why?

As it is require for the symfony cache to have a max and shared max age for caching.
