### PR TITLE
ArticleResourceItem: Use correct properties of ArticleViewDocument

### DIFF
--- a/Content/ArticleResourceItem.php
+++ b/Content/ArticleResourceItem.php
@@ -89,7 +89,7 @@ class ArticleResourceItem implements ResourceItemInterface
      */
     public function getChanger()
     {
-        return $this->article->getChanger();
+        return $this->article->getChangerFullName();
     }
 
     /**
@@ -99,7 +99,7 @@ class ArticleResourceItem implements ResourceItemInterface
      */
     public function getCreator()
     {
-        return $this->article->getCreator();
+        return $this->article->getCreatorFullName();
     }
 
     /**
@@ -120,6 +120,16 @@ class ArticleResourceItem implements ResourceItemInterface
     public function getCreated()
     {
         return $this->article->getCreated();
+    }
+
+    /**
+     * Returns published.
+     *
+     * @return \DateTime
+     */
+    public function getPublished()
+    {
+        return $this->article->getPublished();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT

#### What's in this PR?

ArticleResourceItem:
Corrected `getChanger` and `getCreator`.
Also added `getPublished`.

#### Why?

`getChanger` and `getCreator` were not working correctly.
