### PR TITLE
Fixed page-tree-updater if no template uses the page-tree

### DIFF
--- a/PageTree/PageTreeUpdater.php
+++ b/PageTree/PageTreeUpdater.php
@@ -106,6 +106,10 @@ class PageTreeUpdater implements PageTreeUpdaterInterface
             );
         }
 
+        if (0 === count($where)) {
+            return [];
+        }
+
         $query = $this->documentManager->createQuery(
             sprintf(
                 'SELECT * FROM [nt:unstructured] WHERE [jcr:mixinTypes] = "sulu:article" AND (%s)',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixes the `PageTreeUpdater` which throws an exception if no template uses this content-type.