### PR TITLE
Append config for article-page in article-extension

### DIFF
--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -168,6 +168,7 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
         }
 
         $this->appendDefaultAuthor($config, $container);
+        $this->appendArticlePageConfig($container);
     }
 
     /**
@@ -187,5 +188,39 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
 
         $container->setParameter('sulu_document_manager.mapping', $mapping);
         $container->setParameter('sulu_article.default_author', $config['default_author']);
+    }
+
+    /**
+     * Append configuration for article-page (cloned from article).
+     *
+     * @param ContainerBuilder $container
+     */
+    private function appendArticlePageConfig(ContainerBuilder $container)
+    {
+        $paths = $container->getParameter('sulu.content.structure.paths');
+        $paths['article_page'] = $this->cloneArticleConfig($paths['article'], 'article_page');
+        $container->setParameter('sulu.content.structure.paths', $paths);
+
+        $defaultTypes = $container->getParameter('sulu.content.structure.default_types');
+        $defaultTypes['article_page'] = $defaultTypes['article'];
+        $container->setParameter('sulu.content.structure.default_types', $defaultTypes);
+    }
+
+    /**
+     * Clone given path configuration and use given type.
+     *
+     * @param array $config
+     * @param string $type
+     *
+     * @return array
+     */
+    private function cloneArticleConfig(array $config, $type)
+    {
+        $result = [];
+        foreach ($config as $item) {
+            $result[] = ['path' => $item['path'], 'type' => $type];
+        }
+
+        return $result;
     }
 }

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -17,6 +17,8 @@ else read: [Installation for ElasticSearch 5.0](installation_es5.md)
 
 ### Add bundles to AbstractKernel
 
+The bundle should be registered after the `SuluCoreBundle`.
+
 ```php
 /* app/AbstractKernel.php */
 
@@ -41,14 +43,10 @@ sulu_core:
         structure:
             default_type:
                 article: "article_default"
-                article_page: "article_default"
             paths:
                 article:
                     path: "%kernel.root_dir%/Resources/templates/articles"
                     type: "article"
-                article_page:
-                    path: "%kernel.root_dir%/Resources/templates/articles"
-                    type: "article_page"
 ```
 
 ### Configure the routing


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR enhances the configuration at installation time. It makes the config for article_page obsolete and prepended (or better appended) by the article-extension.
