### PR TITLE
Reset route target when no history url

### DIFF
--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -312,6 +312,7 @@ class RoutableSubscriber implements EventSubscriberInterface
 
         $route->setEntityClass(get_class($document));
         $route->setEntityId($document->getId());
+        $route->setTarget(null);
         $route->setHistory(false);
 
         return $route;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/3411
| License | MIT

#### What's in this PR?

Reset the target when not an history url.

#### Why?

Else it still have a target but is no history.

#### Example Usage

~~~php
$route->setHistory(false);
$route->setTarget(null);
~~~

