### PR TITLE
Implemented page-mover command

### DIFF
--- a/Command/MovePageTreeCommand.php
+++ b/Command/MovePageTreeCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Move articles from given parent-page to another.
+ */
+class MovePageTreeCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('sulu:article:page-tree:move')
+            ->addArgument('source-segment', InputArgument::REQUIRED)
+            ->addArgument('destination-segment', InputArgument::REQUIRED)
+            ->addArgument('webspace-key', InputArgument::REQUIRED)
+            ->addArgument('locale', InputArgument::REQUIRED);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $source = $input->getArgument('source-segment');
+        $destination = $input->getArgument('destination-segment');
+        $webspaceKey = $input->getArgument('webspace-key');
+        $locale = $input->getArgument('locale');
+
+        $mover = $this->getContainer()->get('sulu_article.page_tree_route.mover');
+        $strategyPool = $this->getContainer()->get('sulu.content.resource_locator.strategy_pool');
+        $documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $strategy = $strategyPool->getStrategyByWebspaceKey($webspaceKey);
+
+        $destinationUuid = $strategy->loadByResourceLocator($destination, $webspaceKey, $locale);
+        $document = $documentManager->find($destinationUuid, $locale);
+
+        $mover->move($source, $document);
+
+        $documentManager->flush();
+    }
+}

--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -163,6 +163,7 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
             'sulu_article.page_tree_route.updater.' . $config['content_types']['page_tree_route']['page_route_cascade']
         );
 
+        $loader->load('page_tree_move.xml');
         if ($config['content_types']['page_tree_route']['page_route_cascade'] !== 'off') {
             $loader->load('page_tree_update.xml');
         }

--- a/PageTree/PageTreeMoverInterface.php
+++ b/PageTree/PageTreeMoverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\PageTree;
+
+use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
+
+/**
+ * Interface for page-tree-mover.
+ */
+interface PageTreeMoverInterface
+{
+    /**
+     * @param string $source
+     * @param BasePageDocument $destination
+     */
+    public function move($source, BasePageDocument $destination);
+}

--- a/Resources/config/page_tree_move.xml
+++ b/Resources/config/page_tree_move.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_article.page_tree_route.mover"
+                 class="Sulu\Bundle\ArticleBundle\PageTree\PageTreeRepository">
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_content.structure.factory"/>
+            <argument type="service" id="sulu_document_manager.property_encoder"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
+        </service>
+    </services>
+</container>

--- a/Resources/config/page_tree_update.xml
+++ b/Resources/config/page_tree_update.xml
@@ -16,7 +16,7 @@
         </service>
 
         <service id="sulu_article.page_tree_route.updater.request"
-                 class="Sulu\Bundle\ArticleBundle\PageTree\PageTreeUpdater">
+                 class="Sulu\Bundle\ArticleBundle\PageTree\PageTreeRepository">
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu_content.structure.factory"/>
             <argument type="service" id="sulu_document_manager.property_encoder"/>

--- a/Resources/doc/routing.md
+++ b/Resources/doc/routing.md
@@ -61,3 +61,12 @@ sulu_article:
         page_tree_route:
             update: task # "request" or "off" 
 ```
+
+**Route move**
+
+When the parent-page of multiple articles should be changed (e.g. the page was removed) you can use following command to
+update the parent-page of all articles which are related to the given page-url.
+
+```bash
+bin/console sulu:article:page-tree:move /page-1 /page-2 sulu_io de
+```

--- a/Tests/Functional/PageTree/PageTreeRepositoryTest.php
+++ b/Tests/Functional/PageTree/PageTreeRepositoryTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Functional\PageTree;
+
+use Ramsey\Uuid\Uuid;
+use Sulu\Bundle\ArticleBundle\PageTree\PageTreeRepository;
+use Sulu\Bundle\ContentBundle\Document\PageDocument;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+
+class PageTreeRepositoryTest extends SuluTestCase
+{
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var PageTreeRepository
+     */
+    private $pageTreeRepository;
+
+    /**
+     * @var string
+     */
+    private $locale = 'en';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initPhpcr();
+        $this->purgeDatabase();
+
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $this->pageTreeRepository = new PageTreeRepository(
+            $this->documentManager,
+            $this->getContainer()->get('sulu_content.structure.factory'),
+            $this->getContainer()->get('sulu_document_manager.property_encoder'),
+            $this->getContainer()->get('sulu_document_manager.document_inspector')
+        );
+    }
+
+    public function testUpdate()
+    {
+        $pages = [
+            $this->createPage('Test 1', '/test-1'),
+            $this->createPage('Test 2', '/test-2'),
+        ];
+
+        $articles = [
+            $this->createArticle($this->getPathData($pages[0], 'article-1')),
+            $this->createArticle($this->getPathData($pages[0], 'article-2')),
+            $this->createArticle($this->getPathData($pages[1], 'article-3')),
+        ];
+        $this->documentManager->flush();
+
+        $pages[0]->setResourceSegment('/test-3');
+        $this->documentManager->persist($pages[0], $this->locale);
+        $this->documentManager->publish($pages[0], $this->locale);
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+
+        $this->pageTreeRepository->update($pages[0]);
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+
+        $result = [
+            $this->documentManager->find($articles[0]['id'], $this->locale),
+            $this->documentManager->find($articles[1]['id'], $this->locale),
+            $this->documentManager->find($articles[2]['id'], $this->locale),
+        ];
+
+        $this->assertEquals('/test-3/article-1', $result[0]->getRoutePath());
+        $this->assertEquals('/test-3/article-2', $result[1]->getRoutePath());
+        $this->assertEquals('/test-2/article-3', $result[2]->getRoutePath());
+    }
+
+    public function testMove()
+    {
+        $pages = [
+            $this->createPage('Test 1', '/test-1'),
+            $this->createPage('Test 2', '/test-2'),
+            $this->createPage('Test 3', '/test-3'),
+        ];
+
+        $articles = [
+            $this->createArticle($this->getPathData($pages[0], 'article-1')),
+            $this->createArticle($this->getPathData($pages[0], 'article-2')),
+            $this->createArticle($this->getPathData($pages[1], 'article-3')),
+        ];
+
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+
+        $this->pageTreeRepository->move('/test-1', $pages[2]);
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+
+        $result = [
+            $this->documentManager->find($articles[0]['id'], $this->locale),
+            $this->documentManager->find($articles[1]['id'], $this->locale),
+            $this->documentManager->find($articles[2]['id'], $this->locale),
+        ];
+
+        $this->assertEquals('/test-3/article-1', $result[0]->getRoutePath());
+        $this->assertEquals('/test-3/article-2', $result[1]->getRoutePath());
+        $this->assertEquals('/test-2/article-3', $result[2]->getRoutePath());
+    }
+
+    /**
+     * Returns property value for given page.
+     *
+     * @param PageDocument $page
+     * @param string $suffix
+     *
+     * @return array
+     */
+    private function getPathData(PageDocument $page, $suffix)
+    {
+        return [
+            'page' => [
+                'uuid' => $page->getUuid(),
+                'path' => $page->getResourceSegment(),
+            ],
+            'suffix' => $suffix,
+            'path' => $page->getResourceSegment() . '/' . $suffix,
+        ];
+    }
+
+    /**
+     * Create a new article.
+     *
+     * @param array $routePathData
+     * @param string $title
+     *
+     * @return array
+     */
+    private function createArticle(array $routePathData, $title = 'Test Article')
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'POST',
+            '/api/articles?locale=' . $this->locale . '&action=publish',
+            [
+                'title' => $title,
+                'template' => 'page_tree_route',
+                'routePath' => $routePathData,
+                'authored' => '2016-01-01',
+            ]
+        );
+
+        return json_decode($client->getResponse()->getContent(), true);
+    }
+
+    /**
+     * Create a new page.
+     *
+     * @param string $title
+     * @param string $resourceSegment
+     *
+     * @return PageDocument
+     */
+    private function createPage($title = 'Test Page', $resourceSegment = '/test-page')
+    {
+        $sessionManager = $this->getContainer()->get('sulu.phpcr.session');
+        $page = $this->documentManager->create('page');
+
+        $uuidReflection = new \ReflectionProperty(PageDocument::class, 'uuid');
+        $uuidReflection->setAccessible(true);
+        $uuidReflection->setValue($page, Uuid::uuid4()->toString());
+
+        $page->setTitle($title);
+        $page->setStructureType('default');
+        $page->setParent($this->documentManager->find($sessionManager->getContentPath('sulu_io')));
+        $page->setResourceSegment($resourceSegment);
+
+        $this->documentManager->persist($page, $this->locale);
+        $this->documentManager->publish($page, $this->locale);
+        $this->documentManager->flush();
+
+        return $page;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | built ontop of https://github.com/sulu/SuluArticleBundle/pull/208
| License | MIT

#### What's in this PR?

This PR adds a command to move articles from one parent-page to another one.

#### Why?

If you remove a page in the page tree. The articles will be detached from the page (URL stays the same) and you can choose a new page when you edit the Article. But if you want to do this for all the affected Articles there is no way to do it in a single step.

This PR adds the command and the functionality todo that. Later this functionality can be triggered by the content-manager from the UI (additional later PR when needed).

#### Example Usage

~~~bash
bin/console sulu:article:page-tree:move /page-1 /page-2 sulu_io de
~~~

#### To Do

- [x] Finish prototype
- [x] Tests
- [x] Add documentation page
