### PR TITLE
Added webspace to node when saving page-tree content-type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: true
-
 language: php
 
 env:
@@ -33,14 +31,16 @@ matrix:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
         # - SULU_VERSION="~1.6.0"
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit
+
 addons:
   apt:
     packages:
       - oracle-java8-installer
 
 before_install:
-  # Container based PHP image ues PHP 5.6.5, once it will be upgraded sudo will be not necessary
-  - sudo apt-get install -y oracle-java8-set-default
+  - sudo update-java-alternatives -s java-8-oracle
+  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle/jre
+  - java -version
   - |
     if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then
         if [ ! -f downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar ]; then

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -292,6 +292,8 @@
         <service id="sulu_article.content_types.page_tree_route"
                  class="Sulu\Bundle\ArticleBundle\Content\PageTreeRouteContentType">
             <argument>%sulu_article.content-type.page_tree_route.template%</argument>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
             <argument type="service" id="sulu_document_manager.document_registry"/>
             <argument type="service" id="sulu_route.chain_generator"/>
             <argument type="service" id="sulu_route.manager.conflict_resolver.auto_increment"/>

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -911,6 +911,7 @@ class ArticleControllerTest extends SuluTestCase
             'page' => [
                 'uuid' => $page->getUuid(),
                 'path' => $page->getResourceSegment(),
+                'webspace' => 'sulu_io',
             ],
             'suffix' => 'test-article',
             'path' => '/test-page/test-article',
@@ -931,6 +932,7 @@ class ArticleControllerTest extends SuluTestCase
             'page' => [
                 'uuid' => $page->getUuid(),
                 'path' => $page->getResourceSegment(),
+                'webspace' => 'sulu_io',
             ],
             'suffix' => 'articles/test-article',
             'path' => '/test-page/articles/test-article',
@@ -978,6 +980,7 @@ class ArticleControllerTest extends SuluTestCase
                 'page' => [
                     'uuid' => $page->getUuid(),
                     'path' => $page->getResourceSegment(),
+                    'webspace' => 'sulu_io',
                 ],
                 'suffix' => 'articles/test-article',
                 'path' => '/test-page-2/articles/test-article',
@@ -1021,6 +1024,7 @@ class ArticleControllerTest extends SuluTestCase
                 'page' => [
                     'uuid' => $page1->getUuid(),
                     'path' => $page1->getResourceSegment(),
+                    'webspace' => 'sulu_io',
                 ],
                 'suffix' => 'articles/test-article',
                 'path' => '/page-2/page-1/articles/test-article',
@@ -1037,6 +1041,7 @@ class ArticleControllerTest extends SuluTestCase
             'page' => [
                 'uuid' => $page->getUuid(),
                 'path' => $page->getResourceSegment(),
+                'webspace' => 'sulu_io',
             ],
             'suffix' => 'articles/test-article',
             'path' => '/test-page/articles/test-article',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR saves the webspace on the article when saving the `PageTreeContentType`.
