### PR TITLE
Added index-builder

### DIFF
--- a/Builder/ArticleIndexBuilder.php
+++ b/Builder/ArticleIndexBuilder.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Builder;
+
+use ONGR\ElasticsearchBundle\Service\Manager;
+use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
+
+/**
+ * Builder for article-index.
+ */
+class ArticleIndexBuilder extends SuluBuilder
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'article_index';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies()
+    {
+        return ['cache'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        $this->buildForManager($this->container->get('es.manager.live'), $this->input->getOption('destroy'));
+        $this->buildForManager($this->container->get('es.manager.default'), $this->input->getOption('destroy'));
+    }
+
+    /**
+     * Build index for given manager.
+     *
+     * If index not exists - it will be created.
+     * If index exists and destroy flag is true - drop and create index.
+     * Else do nothing.
+     *
+     * @param Manager $manager
+     * @param bool $destroy
+     */
+    private function buildForManager(Manager $manager, $destroy)
+    {
+        if (!$manager->indexExists()) {
+            $manager->createIndex();
+
+            return;
+        }
+
+        if (!$destroy) {
+            return;
+        }
+
+        $manager->dropAndCreateIndex();
+    }
+}

--- a/Builder/ArticleIndexBuilder.php
+++ b/Builder/ArticleIndexBuilder.php
@@ -56,7 +56,9 @@ class ArticleIndexBuilder extends SuluBuilder
      */
     private function buildForManager(Manager $manager, $destroy)
     {
+        $name = $manager->getName();
         if (!$manager->indexExists()) {
+            $this->output->writeln(sprintf('Create index for "<comment>%s</comment>" manager.', $name));
             $manager->createIndex();
 
             return;
@@ -66,6 +68,7 @@ class ArticleIndexBuilder extends SuluBuilder
             return;
         }
 
+        $this->output->writeln(sprintf('Drop and create index for "<comment>%s</comment>" manager.', $name));
         $manager->dropAndCreateIndex();
     }
 }

--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -124,6 +124,31 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
                 ]
             );
         }
+
+        if ($container->hasExtension('massive_build')) {
+            $container->prependExtensionConfig(
+                'massive_build',
+                [
+                    'targets' => [
+                        'prod' => [
+                            'dependencies' => [
+                                'article_index' => [],
+                            ],
+                        ],
+                        'dev' => [
+                            'dependencies' => [
+                                'article_index' => [],
+                            ],
+                        ],
+                        'maintain' => [
+                            'dependencies' => [
+                                'article_index' => [],
+                            ],
+                        ],
+                    ],
+                ]
+            );
+        }
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -327,5 +327,9 @@
 
             <tag name="twig.extension"/>
         </service>
+
+        <service id="sulu_article.builder.index" class="Sulu\Bundle\ArticleBundle\Builder\ArticleIndexBuilder">
+            <tag name="massive_build.builder" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #198
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR adds an `article_index` builder. create index on build time when `--destroy` flag isset a created index will also be dropped.