### PR TITLE
Fixed reorder route generation

### DIFF
--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -302,6 +302,14 @@ class RoutableSubscriber implements EventSubscriberInterface
             $route = $this->routeRepository->findByEntity($document->getClass(), $document->getUuid(), $locale);
         }
 
+        if ($route && $route->getEntityId() !== $document->getId()) {
+            // Mismatch of entity-id's happens because doctrine don't check entities which has been changed in the
+            // current session.
+
+            $document->removeRoute();
+            $route = null;
+        }
+
         if ($route) {
             $document->setRoute($route);
 

--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -328,8 +328,14 @@ class RoutableSubscriber implements EventSubscriberInterface
 
         $oldRoute = $this->routeRepository->findByEntity(get_class($document), $document->getUuid(), $locale);
         $history = $this->routeRepository->findHistoryByEntity(get_class($document), $document->getUuid(), $locale);
+
+        /** @var RouteInterface $historyRoute */
         foreach (array_filter(array_merge($history, [$oldRoute])) as $historyRoute) {
-            if ($historyRoute->getId() === $newRoute->getId()) {
+            if ($historyRoute->getId() === $newRoute->getId() || $document->getId() !== $historyRoute->getEntityId()) {
+                // Mismatch of entity-id's happens because doctrine don't check entities which has been changed in the
+                // current session. If the old-route was already reused by a page before it will be returned in the
+                // query of line 329.
+
                 continue;
             }
 

--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -198,7 +198,7 @@ class RoutableSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            $route = $this->conflictResolver->resolve($this->chainRouteGenerator->generate($child));
+            $route = $this->chainRouteGenerator->generate($child);
             $child->setRoutePath($route->getPath());
 
             $node = $this->documentInspector->getNode($child);
@@ -328,7 +328,7 @@ class RoutableSubscriber implements EventSubscriberInterface
 
         $oldRoute = $this->routeRepository->findByEntity(get_class($document), $document->getUuid(), $locale);
         $history = $this->routeRepository->findHistoryByEntity(get_class($document), $document->getUuid(), $locale);
-        foreach (array_merge($history, [$oldRoute]) as $historyRoute) {
+        foreach (array_filter(array_merge($history, [$oldRoute])) as $historyRoute) {
             if ($historyRoute->getId() === $newRoute->getId()) {
                 continue;
             }

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -1096,9 +1096,11 @@ class ArticleControllerTest extends SuluTestCase
             $this->postPage($article, 'Page 3'),
             $this->postPage($article, 'Page 4'),
         ];
-        $expectedPages = [$pages[3]['id'], $pages[2]['id'], $pages[1]['id'], $pages[0]['id']];
-
         $this->publish($article['id']);
+
+        $pages[] = $this->postPage($article, 'Page 5');
+
+        $expectedPages = [$pages[4]['id'], $pages[3]['id'], $pages[2]['id'], $pages[1]['id'], $pages[0]['id']];
 
         $client = $this->createAuthenticatedClient();
         $client->request(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixes a problem when reordering pages of an article. The resulting URLs looks like `/test-article/page-2-1`

#### Why?

The conflicts were resolved when on reorder.