### PR TITLE
Added transaction handling for route-update

### DIFF
--- a/PageTree/PageTreeRouteUpdateHandler.php
+++ b/PageTree/PageTreeRouteUpdateHandler.php
@@ -17,12 +17,13 @@ use Sulu\Bundle\AutomationBundle\TaskHandler\TaskHandlerConfiguration;
 use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Task\Executor\RetryTaskHandlerInterface;
 use Task\Lock\LockingTaskHandlerInterface;
 
 /**
  * Task-Handler to update page-tree-routes.
  */
-class PageTreeRouteUpdateHandler implements AutomationTaskHandlerInterface, LockingTaskHandlerInterface
+class PageTreeRouteUpdateHandler implements AutomationTaskHandlerInterface, LockingTaskHandlerInterface, RetryTaskHandlerInterface
 {
     /**
      * @var PageTreeUpdaterInterface
@@ -105,5 +106,13 @@ class PageTreeRouteUpdateHandler implements AutomationTaskHandlerInterface, Lock
     public function getLockKey($workload)
     {
         return self::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMaximumAttempts()
+    {
+        return 3;
     }
 }

--- a/PageTree/PageTreeRouteUpdateHandler.php
+++ b/PageTree/PageTreeRouteUpdateHandler.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Task\Lock\LockingTaskHandlerInterface;
-use Task\Runner\RetryException;
 
 /**
  * Task-Handler to update page-tree-routes.
@@ -96,7 +95,7 @@ class PageTreeRouteUpdateHandler implements AutomationTaskHandlerInterface, Lock
         } catch (\Exception $exception) {
             $this->entityManager->rollback();
 
-            throw new RetryException($exception);
+            throw $exception;
         }
     }
 

--- a/PageTree/PageTreeRouteUpdateHandler.php
+++ b/PageTree/PageTreeRouteUpdateHandler.php
@@ -11,12 +11,14 @@
 
 namespace Sulu\Bundle\ArticleBundle\PageTree;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\AutomationBundle\TaskHandler\AutomationTaskHandlerInterface;
 use Sulu\Bundle\AutomationBundle\TaskHandler\TaskHandlerConfiguration;
 use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Task\Lock\LockingTaskHandlerInterface;
+use Task\Runner\RetryException;
 
 /**
  * Task-Handler to update page-tree-routes.
@@ -34,15 +36,23 @@ class PageTreeRouteUpdateHandler implements AutomationTaskHandlerInterface, Lock
     private $documentManager;
 
     /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
      * @param PageTreeUpdaterInterface $routeUpdater
      * @param DocumentManagerInterface $documentManager
+     * @param EntityManagerInterface $entityManager
      */
     public function __construct(
         PageTreeUpdaterInterface $routeUpdater,
-        DocumentManagerInterface $documentManager
+        DocumentManagerInterface $documentManager,
+        EntityManagerInterface $entityManager
     ) {
         $this->routeUpdater = $routeUpdater;
         $this->documentManager = $documentManager;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -76,9 +86,18 @@ class PageTreeRouteUpdateHandler implements AutomationTaskHandlerInterface, Lock
      */
     public function handle($workload)
     {
-        $this->routeUpdater->update($this->documentManager->find($workload['id'], $workload['locale']));
+        $this->entityManager->beginTransaction();
 
-        $this->documentManager->flush();
+        try {
+            $this->routeUpdater->update($this->documentManager->find($workload['id'], $workload['locale']));
+
+            $this->documentManager->flush();
+            $this->entityManager->commit();
+        } catch (\Exception $exception) {
+            $this->entityManager->rollback();
+
+            throw new RetryException($exception);
+        }
     }
 
     /**

--- a/Resources/config/automation.xml
+++ b/Resources/config/automation.xml
@@ -23,6 +23,7 @@
                  class="Sulu\Bundle\ArticleBundle\PageTree\PageTreeRouteUpdateHandler">
             <argument type="service" id="sulu_article.page_tree_route.updater.request"/>
             <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
 
             <tag name="task.handler"/>
         </service>

--- a/Tests/Unit/PageTree/PageTreeRouteUpdateHandlerTest.php
+++ b/Tests/Unit/PageTree/PageTreeRouteUpdateHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Tests\Unit\PageTree;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ArticleBundle\PageTree\PageTreeRouteUpdateHandler;
 use Sulu\Bundle\ArticleBundle\PageTree\PageTreeUpdaterInterface;
 use Sulu\Bundle\ContentBundle\Document\HomeDocument;
@@ -31,6 +32,11 @@ class PageTreeRouteUpdateHandlerTest extends \PHPUnit_Framework_TestCase
     private $documentManager;
 
     /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
      * @var PageTreeRouteUpdateHandler
      */
     private $handler;
@@ -39,10 +45,12 @@ class PageTreeRouteUpdateHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $this->routeUpdater = $this->prophesize(PageTreeUpdaterInterface::class);
         $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
 
         $this->handler = new PageTreeRouteUpdateHandler(
             $this->routeUpdater->reveal(),
-            $this->documentManager->reveal()
+            $this->documentManager->reveal(),
+            $this->entityManager->reveal()
         );
     }
 
@@ -74,6 +82,46 @@ class PageTreeRouteUpdateHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->documentManager->find('123-123-123', 'de')->willReturn($document->reveal());
         $this->documentManager->flush()->shouldBeCalled();
+
+        $this->entityManager->beginTransaction()->shouldBeCalled();
+        $this->entityManager->commit()->shouldBeCalled();
+        $this->entityManager->rollback()->shouldNotBeCalled();
+
+        $this->routeUpdater->update($document->reveal())->shouldBeCalled();
+
+        $this->handler->handle(['id' => '123-123-123', 'locale' => 'de']);
+    }
+
+    public function testHandleUpdateException()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $document = $this->prophesize(PageDocument::class);
+
+        $this->documentManager->find('123-123-123', 'de')->willReturn($document->reveal());
+        $this->documentManager->flush()->shouldNotBeCalled();
+
+        $this->entityManager->beginTransaction()->shouldBeCalled();
+        $this->entityManager->commit()->shouldNotBeCalled();
+        $this->entityManager->rollback()->shouldBeCalled();
+
+        $this->routeUpdater->update($document->reveal())->willThrow(new \InvalidArgumentException());
+
+        $this->handler->handle(['id' => '123-123-123', 'locale' => 'de']);
+    }
+
+    public function testHandleDocumentExceptionException()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $document = $this->prophesize(PageDocument::class);
+
+        $this->documentManager->find('123-123-123', 'de')->willReturn($document->reveal());
+        $this->documentManager->flush()->willThrow(new \InvalidArgumentException());
+
+        $this->entityManager->beginTransaction()->shouldBeCalled();
+        $this->entityManager->commit()->shouldNotBeCalled();
+        $this->entityManager->rollback()->shouldBeCalled();
 
         $this->routeUpdater->update($document->reveal())->shouldBeCalled();
 

--- a/Tests/Unit/PageTree/PageTreeRouteUpdateHandlerTest.php
+++ b/Tests/Unit/PageTree/PageTreeRouteUpdateHandlerTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\ContentBundle\Document\HomeDocument;
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Task\Executor\RetryTaskHandlerInterface;
 
 class PageTreeRouteUpdateHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -126,5 +127,11 @@ class PageTreeRouteUpdateHandlerTest extends \PHPUnit_Framework_TestCase
         $this->routeUpdater->update($document->reveal())->shouldBeCalled();
 
         $this->handler->handle(['id' => '123-123-123', 'locale' => 'de']);
+    }
+
+    public function testGetMaximumAttempts()
+    {
+        $this->assertInstanceOf(RetryTaskHandlerInterface::class, $this->handler);
+        $this->assertEquals(3, $this->handler->getMaximumAttempts());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "jackalope/jackalope-jackrabbit": "^1.2",
         "phpunit/phpunit": "^4.8 || ^5.0",
         "sulu/automation-bundle": "^1.0",
-        "php-task/task-bundle": "^1.1",
-        "php-task/php-task": "^1.1"
+        "php-task/task-bundle": "dev-master as 1.2.0",
+        "php-task/php-task": "dev-master as 1.2.0"
     },
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/php-task/php-task/pull/39 https://github.com/php-task/TaskBundle/pull/41
| License | MIT

#### What's in this PR?

This PR uses `RetryEcxeption` to restart the handler if an unexpected occurs

#### Why?

Long running processes seems to break of several reasons

#### To Do

- [x] PHP-Task
- [x] Tests
