### PR TITLE
Make it possible to override article and article page documents

### DIFF
--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -195,6 +195,22 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
 
         $this->appendDefaultAuthor($config, $container);
         $this->appendArticlePageConfig($container);
+
+        $articleDocument = ArticleDocument::class;
+        $articlePageDocument = ArticlePageDocument::class;
+
+        foreach ($container->getParameter('sulu_document_manager.mapping') as $mapping) {
+            if ($mapping['alias'] == 'article') {
+                $articleDocument = $mapping['class'];
+            }
+
+            if ($mapping['alias'] == 'article_page') {
+                $articlePageDocument = $mapping['class'];
+            }
+        }
+
+        $container->setParameter('sulu_article.article_document.class', $articleDocument);
+        $container->setParameter('sulu_article.article_page_document.class', $articlePageDocument);
     }
 
     /**

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -42,7 +42,7 @@ class ArticlePageDocument implements
     /**
      * @var string
      */
-    private $uuid;
+    protected $uuid;
 
     /**
      * @var string
@@ -62,7 +62,7 @@ class ArticlePageDocument implements
     /**
      * @var string
      */
-    private $path;
+    protected $path;
 
     /**
      * @var string
@@ -82,7 +82,7 @@ class ArticlePageDocument implements
     /**
      * @var StructureInterface
      */
-    private $structure;
+    protected $structure;
 
     /**
      * @var RouteInterface

--- a/Resources/config/automation.xml
+++ b/Resources/config/automation.xml
@@ -2,10 +2,6 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sulu_article.article_document.class">Sulu\Bundle\ArticleBundle\Document\ArticleDocument</parameter>
-    </parameters>
-
     <services>
         <service id="sulu_article.automation.content_navigation_provider"
                  class="Sulu\Bundle\AutomationBundle\Admin\AutomationContentNavigationProvider">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -260,8 +260,8 @@
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="serializer"/>
 
-            <tag name="sulu_preview.object_provider" class="Sulu\Bundle\ArticleBundle\Document\ArticleDocument"/>
-            <tag name="sulu_preview.object_provider" class="Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument"/>
+            <tag name="sulu_preview.object_provider" class="%sulu_article.article_document.class%"/>
+            <tag name="sulu_preview.object_provider" class="%sulu_article.article_page_document.class%"/>
         </service>
 
         <!-- link -->

--- a/Routing/ArticleRouteDefaultProvider.php
+++ b/Routing/ArticleRouteDefaultProvider.php
@@ -117,7 +117,10 @@ class ArticleRouteDefaultProvider implements RouteDefaultsProviderInterface
      */
     public function supports($entityClass)
     {
-        return $entityClass === ArticleDocument::class || $entityClass === ArticlePageDocument::class;
+        return $entityClass === ArticleDocument::class
+            || $entityClass === ArticlePageDocument::class
+            || is_subclass_of($entityClass, ArticleDocument::class)
+            || is_subclass_of($entityClass, ArticlePageDocument::class);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Make it possible to override article and article page documents

#### Why?

Was currently not possible:

#### Example Usage

```xml
sulu_document_manager:
    mapping:
        article_page:
            class: AppBundle\Document\ArticlePageDocument
            phpcr_type: 'sulu:articlepage'
            mapping: {  }
```