### PR TITLE
Search by multiple categories

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -145,6 +145,14 @@ class ArticleController extends RestController implements ClassResourceInterface
             $search->addQuery(new TermQuery('excerpt.categories.id', $categoryId), BoolQuery::MUST);
         }
 
+        if (count($categoriesIds = array_filter(explode(',', $request->get('categoriesIds', ''))))) {
+            $boolQuery = new BoolQuery();
+            foreach ($categoriesIds as $categoryId) {
+                $boolQuery->add(new TermQuery('excerpt.categories.id', $categoryId), BoolQuery::SHOULD);
+            }
+            $search->addQuery($boolQuery);
+        }
+
         if ($tagId = $request->get('tagId')) {
             $search->addQuery(new TermQuery('excerpt.tags.id', $tagId), BoolQuery::MUST);
         }

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -389,11 +389,13 @@ class ArticleController extends RestController implements ClassResourceInterface
                     $this->getDocumentManager()->flush();
 
                     $data = $this->getDocumentManager()->find($uuid, $locale);
+
                     break;
                 case 'remove-draft':
                     $data = $this->getDocumentManager()->find($uuid, $locale);
                     $this->getDocumentManager()->removeDraft($data, $locale);
                     $this->getDocumentManager()->flush();
+
                     break;
                 case 'copy-locale':
                     $destLocales = $this->getRequestParameter($request, 'dest', true);
@@ -410,6 +412,7 @@ class ArticleController extends RestController implements ClassResourceInterface
                     $this->getMapper()->copyLanguage($uuid, $userId, null, $locale, $destLocales);
 
                     $data = $this->getDocumentManager()->find($uuid, $locale);
+
                     break;
                 case 'copy':
                     /** @var ArticleDocument $document */
@@ -418,6 +421,7 @@ class ArticleController extends RestController implements ClassResourceInterface
                     $this->getDocumentManager()->flush();
 
                     $data = $this->getDocumentManager()->find($copiedPath, $locale);
+
                     break;
                 case 'order':
                     $this->orderPages($this->getRequestParameter($request, 'pages', true), $locale);
@@ -425,6 +429,7 @@ class ArticleController extends RestController implements ClassResourceInterface
                     $this->getDocumentManager()->clear();
 
                     $data = $this->getDocumentManager()->find($uuid, $locale);
+
                     break;
                 default:
                     throw new RestException('Unrecognized action: ' . $action);
@@ -539,6 +544,7 @@ class ArticleController extends RestController implements ClassResourceInterface
         switch ($actionParameter) {
             case 'publish':
                 $this->getDocumentManager()->publish($document, $locale);
+
                 break;
         }
     }

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -983,6 +983,49 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($article1['id'], $result['_embedded']['articles'][0]['id']);
     }
 
+    public function testCgetFilterByCategories()
+    {
+        $title = 'Test-Article';
+        $template = 'default';
+        $category1 = $this->createCategory();
+        $category2 = $this->createCategory();
+
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'POST',
+            '/api/articles?locale=de',
+            [
+                'title' => $title,
+                'template' => $template,
+                'authored' => '2016-01-01',
+                'ext' => ['excerpt' => ['categories' => [$category1->getId()]]],
+            ]
+        );
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $article1 = json_decode($client->getResponse()->getContent(), true);
+
+        $client->request(
+            'POST',
+            '/api/articles?locale=de',
+            [
+                'title' => $title,
+                'template' => $template,
+                'authored' => '2016-01-02',
+                'ext' => ['excerpt' => ['categories' => [$category2->getId()]]],
+            ]
+        );
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $article2 = json_decode($client->getResponse()->getContent(), true);
+
+        $client->request('GET', '/api/articles?locale=de&categoriesIds=' . $category1->getId() . ','. $category2->getId());
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $result = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertCount(2, $result['_embedded']['articles']);
+        $this->assertEquals($article1['id'], $result['_embedded']['articles'][0]['id']);
+        $this->assertEquals($article2['id'], $result['_embedded']['articles'][1]['id']);
+    }
+
     public function testCgetFilterByTag()
     {
         $title = 'Test-Article';

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -1017,7 +1017,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
         $article2 = json_decode($client->getResponse()->getContent(), true);
 
-        $client->request('GET', '/api/articles?locale=de&categoriesIds=' . $category1->getId() . ','. $category2->getId());
+        $client->request('GET', '/api/articles?locale=de&categoriesIds=' . $category1->getId() . ',' . $category2->getId());
         $this->assertHttpStatusCode(200, $client->getResponse());
         $result = json_decode($client->getResponse()->getContent(), true);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT

#### What's in this PR?

Allows to search by multiple categories in the articles API.
The new parameter `categoriesIds` take a comma-separated string of the searched categories ids.

#### Why?

Today, the only available parameter is `categoryId`. This PR allows to search multiple categories at a time.

#### Example Usage

~~~http
GET /api/articles?locale=de&categoriesIds=1,2,3
~~~

#### To Do

- [x] Functional tests


By the way, is there any place where I can/should add a documentation, a changelog, ..?