### PR TITLE
Fixed unpublish article does not update admin-index

### DIFF
--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -404,10 +404,10 @@ class ArticleIndexer implements IndexerInterface
     /**
      * {@inheritdoc}
      */
-    public function setUnpublished($uuid)
+    public function setUnpublished($uuid, $locale)
     {
-        $article = $this->manager->find($this->documentFactory->getClass('article'), $uuid);
-
+        $articleId = $this->getViewDocumentId($uuid, $locale);
+        $article = $this->manager->find($this->documentFactory->getClass('article'), $articleId);
         if (!$article) {
             return;
         }
@@ -416,6 +416,8 @@ class ArticleIndexer implements IndexerInterface
         $article->setPublishedState(false);
 
         $this->manager->persist($article);
+
+        return $article;
     }
 
     /**

--- a/Document/Index/IndexerInterface.php
+++ b/Document/Index/IndexerInterface.php
@@ -28,10 +28,11 @@ interface IndexerInterface
      * Clear published and sets published state to false.
      *
      * @param string $uuid
+     * @param string $locale
      *
      * @return ArticleDocument $document
      */
-    public function setUnpublished($uuid);
+    public function setUnpublished($uuid, $locale);
 
     /**
      * Indexes given document.

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -423,7 +423,8 @@ class ArticleSubscriber implements EventSubscriberInterface
         $this->liveIndexer->remove($document);
         $this->liveIndexer->flush();
 
-        $this->indexer->setUnpublished($document->getUuid());
+        $this->indexer->setUnpublished($document->getUuid(), $event->getLocale());
+        $this->indexer->flush();
     }
 
     /**

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -71,13 +71,20 @@ class ArticleIndexerTest extends SuluTestCase
             'page_tree_route'
         );
 
-        $documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $document = $documentManager->find($article['id'], $this->locale);
+        $document = $this->documentManager->find($article['id'], $this->locale);
         $this->indexer->index($document);
 
-        $viewDocument = $this->manager->find(ArticleViewDocument::class, $article['id'] . '-' . $this->locale);
-
+        $viewDocument = $this->findViewDocument($article['id']);
         $this->assertEquals($page->getUuid(), $viewDocument->getParentPageUuid());
+    }
+
+    public function testSetUnpublished()
+    {
+        $article = $this->createArticle();
+
+        $viewDocument = $this->indexer->setUnpublished($article['id'], $this->locale);
+        $this->assertNull($viewDocument->getPublished());
+        $this->assertFalse($viewDocument->getPublishedState());
     }
 
     /**
@@ -89,7 +96,7 @@ class ArticleIndexerTest extends SuluTestCase
      *
      * @return mixed
      */
-    private function createArticle(array $data, $title = 'Test Article', $template = 'default')
+    private function createArticle(array $data = [], $title = 'Test Article', $template = 'default')
     {
         $client = $this->createAuthenticatedClient();
         $client->request(
@@ -129,5 +136,17 @@ class ArticleIndexerTest extends SuluTestCase
         $this->documentManager->flush();
 
         return $page;
+    }
+
+    /**
+     * Find view-document.
+     *
+     * @param string $uuid
+     *
+     * @return ArticleViewDocument
+     */
+    private function findViewDocument($uuid)
+    {
+        return $this->manager->find(ArticleViewDocument::class, $uuid . '-' . $this->locale);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixes the problem that the admin-index will not be updated when unpublishing articles. This will lead into a wrong state in the list.
