### PR TITLE
Refactored reindex command

### DIFF
--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -105,8 +105,9 @@ class ReindexCommand extends ContainerAwareCommand
             $output->writeln(
                 '<comment>ATTENTION</comment>: This operation drops and recreates the whole index and deletes the complete data.'
             );
+            $output->writeln('');
 
-            $question = new ConfirmationQuestion('           Are you sure you want to drop the index? ');
+            $question = new ConfirmationQuestion('Are you sure you want to drop the index? [Y/n] ');
 
             /** @var QuestionHelper $questionHelper */
             $questionHelper = $this->getHelper('question');

--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -98,7 +98,7 @@ class ReindexCommand extends ContainerAwareCommand
     protected function dropIndex(IndexerInterface $indexer, InputInterface $input, OutputInterface $output)
     {
         if (!$input->getOption('drop')) {
-            return;
+            return true;
         }
 
         if (!$input->getOption('no-interaction')) {

--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -11,13 +11,16 @@
 
 namespace Sulu\Bundle\ArticleBundle\Command;
 
-use Sulu\Component\Content\Document\WorkflowStage;
+use PHPCR\Query\QueryResultInterface;
+use Sulu\Bundle\ArticleBundle\Document\Index\IndexerInterface;
+use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Reindixes articles.
@@ -29,10 +32,11 @@ class ReindexCommand extends ContainerAwareCommand
      */
     public function configure()
     {
-        $this->setName('sulu:article:index-rebuild')
-            ->addArgument('locale', InputArgument::REQUIRED)
-            ->addOption('live', 'l', InputOption::VALUE_NONE)
-            ->addOption('clear', null, InputOption::VALUE_NONE);
+        $this->setName('sulu:article:reindex');
+        $this->setDescription('Rebuild elastic-search index for articles');
+        $this->setHelp('This command will load all articles and index them to elastic-search indexes.');
+        $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop and recreate index before reindex');
+        $this->addOption('clear', null, InputOption::VALUE_NONE, 'Clear content of index before reindex');
     }
 
     /**
@@ -40,39 +44,172 @@ class ReindexCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $sql2 = 'SELECT * FROM [nt:unstructured] AS a WHERE [jcr:mixinTypes] = "sulu:article"';
+        $context = $this->getContainer()->getParameter('sulu.context');
+        $startTime = microtime(true);
 
         $id = 'sulu_article.elastic_search.article_indexer';
-        if ($input->getOption('live')) {
+        if ($context === SuluKernel::CONTEXT_WEBSITE) {
             $id = 'sulu_article.elastic_search.article_live_indexer';
-            $sql2 = sprintf(
-                '%s AND [i18n:%s-state] = %s',
-                $sql2,
-                $input->getArgument('locale'),
-                WorkflowStage::PUBLISHED
-            );
         }
 
+        /** @var IndexerInterface $indexer */
         $indexer = $this->getContainer()->get($id);
-        $documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $query = $documentManager->createQuery($sql2, $input->getArgument('locale'));
 
-        if ($input->getOption('clear')) {
-            $indexer->clear();
+        $output->writeln(sprintf('Reindex articles for the <comment>`%s`</comment> context' . PHP_EOL, $context));
+
+        if (!$this->dropIndex($indexer, $input, $output)) {
+            // Drop was canceled by user.
+
+            return;
         }
 
-        $result = $query->execute();
+        $indexer->createIndex();
+        $this->clearIndex($indexer, $input, $output);
 
-        $progessBar = new ProgressBar($output, count($result));
-        $progessBar->setFormat('debug');
+        $webspaceManager = $this->getContainer()->get('sulu_core.webspace.webspace_manager');
+        $locales = $webspaceManager->getAllLocalizations();
+
+        foreach ($locales as $locale) {
+            $output->writeln(sprintf('<info>Locale "</info>%s<info>"</info>' . PHP_EOL, $locale->getLocale()));
+
+            $this->indexDocuments($locale->getLocale(), $indexer, $output);
+
+            $output->writeln(PHP_EOL);
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Index rebuild completed (</info>%ss %s</info><info>)</info>',
+                number_format(microtime(true) - $startTime, 2),
+                $this->humanBytes(memory_get_peak_usage())
+            )
+        );
+    }
+
+    /**
+     * Drop index if requested.
+     *
+     * @param IndexerInterface $indexer
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return bool
+     */
+    protected function dropIndex(IndexerInterface $indexer, InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getOption('drop')) {
+            return;
+        }
+
+        if (!$input->getOption('no-interaction')) {
+            $output->writeln(
+                '<comment>ATTENTION</comment>: This operation drops and recreates the whole index and deletes the complete data.'
+            );
+
+            $question = new ConfirmationQuestion('           Are you sure you want to drop the index? ');
+
+            /** @var QuestionHelper $questionHelper */
+            $questionHelper = $this->getHelper('question');
+            if (!$questionHelper->ask($input, $output, $question)) {
+                return false;
+            }
+
+            $output->writeln('');
+        }
+
+        $indexer->dropIndex();
+
+        $context = $this->getContainer()->getParameter('sulu.context');
+        $output->writeln(
+            sprintf('Dropped and recreated index for the <comment>`%s`</comment> context' . PHP_EOL, $context)
+        );
+
+        return true;
+    }
+
+    /**
+     * Clear article-content of index.
+     *
+     * @param IndexerInterface $indexer
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function clearIndex(IndexerInterface $indexer, InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getOption('clear')) {
+            return;
+        }
+
+        $context = $this->getContainer()->getParameter('sulu.context');
+        $output->writeln(sprintf('Cleared index for the <comment>`%s`</comment> context', $context));
+        $indexer->clear();
+    }
+
+    /**
+     * Index documents for given locale.
+     *
+     * @param string $locale
+     * @param IndexerInterface $indexer
+     * @param OutputInterface $output
+     */
+    protected function indexDocuments($locale, IndexerInterface $indexer, OutputInterface $output)
+    {
+        $documents = $this->getDocuments($locale);
+        $count = count($documents);
+        if (0 === $count) {
+            $output->writeln('  No documents found');
+
+            return;
+        }
+
+        $progessBar = new ProgressBar($output, $count);
+        $progessBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%');
         $progessBar->start();
 
-        foreach ($result as $document) {
+        foreach ($documents as $document) {
             $indexer->index($document);
             $progessBar->advance();
         }
 
         $indexer->flush();
         $progessBar->finish();
+    }
+
+    /**
+     * Query for documents with given locale.
+     *
+     * @param string $locale
+     *
+     * @return QueryResultInterface
+     */
+    protected function getDocuments($locale)
+    {
+        $propertyEncoder = $this->getContainer()->get('sulu_document_manager.property_encoder');
+        $documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+
+        $sql2 = sprintf(
+            'SELECT * FROM [nt:unstructured] AS a WHERE [jcr:mixinTypes] = "sulu:article" AND [%s] IS NOT NULL',
+            $propertyEncoder->localizedSystemName('template', $locale)
+        );
+
+        return $documentManager->createQuery($sql2, $locale, ['load_ghost_content' => false])->execute();
+    }
+
+    /**
+     * Converts bytes into human readable.
+     *
+     * Inspired by http://jeffreysambells.com/2012/10/25/human-readable-filesize-php
+     *
+     * @param int $bytes
+     * @param int $dec
+     *
+     * @return string
+     */
+    protected function humanBytes($bytes, $dec = 2)
+    {
+        $size = ['b', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        $factor = (int) floor((strlen($bytes) - 1) / 3);
+
+        return sprintf("%.{$dec}f", $bytes / pow(1024, $factor)) . $size[$factor];
     }
 }

--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -36,7 +36,7 @@ class ReindexCommand extends ContainerAwareCommand
         $this->setDescription('Rebuild elastic-search index for articles');
         $this->setHelp('This command will load all articles and index them to elastic-search indexes.');
         $this->addOption('drop', null, InputOption::VALUE_NONE, 'Drop and recreate index before reindex');
-        $this->addOption('clear', null, InputOption::VALUE_NONE, 'Clear content of index before reindex');
+        $this->addOption('clear', null, InputOption::VALUE_NONE, 'Clear all articles of index before reindex');
     }
 
     /**

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -436,4 +436,24 @@ class ArticleIndexer implements IndexerInterface
         $this->dispatchIndexEvent($document, $article);
         $this->manager->persist($article);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropIndex()
+    {
+        $this->manager->dropIndex();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createIndex()
+    {
+        if ($this->manager->indexExists()) {
+            return;
+        }
+
+        $this->manager->createIndex();
+    }
 }

--- a/Document/Index/IndexerInterface.php
+++ b/Document/Index/IndexerInterface.php
@@ -52,4 +52,14 @@ interface IndexerInterface
      * Flushes index.
      */
     public function flush();
+
+    /**
+     * Drop and recreate elastic-search index.
+     */
+    public function dropIndex();
+
+    /**
+     * Drop and create elastic-search index.
+     */
+    public function createIndex();
 }

--- a/Resources/doc/README.md
+++ b/Resources/doc/README.md
@@ -9,5 +9,6 @@ This documentation covers basic-topics to install and use this bundle.
 * [Content-Types](content-types.md)
 * [ArticleViewDocument](article-view-document.md)
 * [Twig-Extensions](twig-extensions.md)
+* [Commands](commands.md)
 * [Author](author.md)
 * [Multi-Page](multi-page.md)

--- a/Resources/doc/commands.md
+++ b/Resources/doc/commands.md
@@ -1,0 +1,37 @@
+# Commands
+
+## Reindex command
+
+The reindex command can be used to rebuild the elastic-search index of the articles.
+
+```bash
+bin/adminconsole sulu:article:reindex
+bin/websiteconsole sulu:article:reindex
+```
+
+The default behaviour of the command is to load all the articles and update the content of them. This includes that
+deleted articles (which was not removed correctly from index) will stay inside the index.
+
+To avoid this behaviour you can use the `--clear` option to remove all the articles from the index before reindex the
+existing ones.
+
+```bash
+bin/adminconsole sulu:article:reindex --clear
+bin/websiteconsole sulu:article:reindex --clear
+```
+
+Sometimes you want to update also the mapping of the index. To achieve this you can use the `--drop` option. This will
+drop and recreate the index with the current mapping.
+
+```bash
+bin/adminconsole sulu:article:reindex --drop
+bin/websiteconsole sulu:article:reindex --drop
+```
+
+This options will answer you the confirm this operation. To avoid this interaction you can use the `--no-interaction` 
+option.
+
+```bash
+bin/adminconsole sulu:article:reindex --drop --no-interaction
+bin/websiteconsole sulu:article:reindex --drop --no-interaction
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,7 +5,7 @@
 ### Reindex command
 
 The `sulu:article:index-rebuild` command was refactored and renamed to `sulu:article:reindex`. 
-See [Commands in documentation](https://github.com/sulu/SuluArticleBundle/blob/master/Resources/doc/commands.md).
+See [Commands in documentation](Resources/doc/commands.md).
 
 ### NewIndex mapping has changed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,19 +2,18 @@
 
 ## 0.8.0 (unreleased)
 
+### Reindex command
+
+The `sulu:article:index-rebuild` command was refactored and renamed to `sulu:article:reindex`. 
+See [Commands in documentation](https://github.com/sulu/SuluArticleBundle/blob/master/Resources/doc/commands.md).
+
 ### NewIndex mapping has changed
 
 Recreate the index to update mapping (new `content_data` field) and reindex your articles:
 
 ```bash
-bin/adminconsole ongr:es:index:drop -m default --force
-bin/websiteconsole ongr:es:index:drop -m live --force
-
-bin/adminconsole ongr:es:index:create -m default
-bin/websiteconsole ongr:es:index:create -m live
-
-bin/adminconsole sulu:article:index-rebuild ###LOCALE###
-bin/websiteconsole sulu:article:index-rebuild ###LOCALE### --live
+bin/adminconsole sulu:article:reindex --drop --no-interactive
+bin/websiteconsole sulu:article:reindex --drop --no-interactive
 ```
 
 ## 0.7.0


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #135
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR refactored the reindex command to index all locales at once. Additionally, the option `drop` was introduced to drop and recreate the whole index.

#### Why?

This will increase the developer experience with reindexing the articles.

#### Example Usage

```bash
bin/adminconsole sulu:article:reindex --drop
bin/websiteconsole sulu:article:reindex --drop
```

Output:

```bash
$ bin/websiteconsole sulu:article:reindex --drop
Reindex articles for the `website` context

ATTENTION: This operation drops and recreates the whole index and deletes the complete data.
           Are you sure you want to drop the index? y

Dropped and recreated index for the `website` context

Locale "en"

 1/1 [============================] 100% < 1 sec/< 1 sec 40.0 MiB

Locale "de"

 1/1 [============================] 100% < 1 sec/< 1 sec 40.0 MiB

Index rebuild completed (1.53s 39.23MB)
$ bin/adminconsole sulu:article:reindex --drop
Reindex articles for the `admin` context

ATTENTION: This operation drops and recreates the whole index and deletes the complete data.
           Are you sure you want to drop the index? y

Dropped and recreated index for the `admin` context

Locale "en"

 1/1 [============================] 100% < 1 sec/< 1 sec 40.0 MiB

Locale "de"

 1/1 [============================] 100% < 1 sec/< 1 sec 40.0 MiB

Index rebuild completed (1.89s 38.94MB)
```

#### BC Breaks/Deprecations

The command `sulu:article:index-rebuild` will be replaced with `sulu:article:reindex`.

#### To Do

- [x] Add documentation page
