### PR TITLE
Added exception handling when no elastic-search node is alive

### DIFF
--- a/Document/Repository/ArticleViewDocumentRepository.php
+++ b/Document/Repository/ArticleViewDocumentRepository.php
@@ -20,16 +20,19 @@ use ONGR\ElasticsearchDSL\Query\Specialized\MoreLikeThisQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Search;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 use Sulu\Bundle\ArticleBundle\Metadata\ArticleViewDocumentIdTrait;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
 /**
  * Find article view documents in elasticsearch index.
  */
-class ArticleViewDocumentRepository
+class ArticleViewDocumentRepository implements LoggerAwareInterface
 {
     use ArticleViewDocumentIdTrait;
+    use LoggerAwareTrait;
 
     const DEFAULT_LIMIT = 5;
 
@@ -59,26 +62,16 @@ class ArticleViewDocumentRepository
     protected $searchFields;
 
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param Manager $searchManager
      * @param string $articleDocumentClass
      * @param array $searchFields
-     * @param LoggerInterface|null $logger
      */
-    public function __construct(
-        Manager $searchManager,
-        $articleDocumentClass,
-        array $searchFields,
-        LoggerInterface $logger = null
-    ) {
+    public function __construct(Manager $searchManager, $articleDocumentClass, array $searchFields)
+    {
         $this->searchManager = $searchManager;
         $this->articleDocumentClass = $articleDocumentClass;
         $this->searchFields = $searchFields;
-        $this->logger = $logger;
+        $this->logger = $logger = new NullLogger();
 
         $this->repository = $this->searchManager->getRepository($this->articleDocumentClass);
     }
@@ -106,9 +99,7 @@ class ArticleViewDocumentRepository
         try {
             return $this->repository->findDocuments($search);
         } catch (NoNodesAvailableException $exception) {
-            if ($this->logger) {
-                $this->logger->error($exception->getMessage());
-            }
+            $this->logger->error($exception->getMessage());
 
             return new DocumentIterator([], $this->searchManager);
         }
@@ -143,9 +134,7 @@ class ArticleViewDocumentRepository
         try {
             return $this->repository->findDocuments($search);
         } catch (NoNodesAvailableException $exception) {
-            if ($this->logger) {
-                $this->logger->error($exception->getMessage());
-            }
+            $this->logger->error($exception->getMessage());
 
             return new DocumentIterator([], $this->searchManager);
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -243,6 +243,7 @@
             <argument type="service" id="sulu_article.factory.resource_item"/>
             <argument type="string">%sulu_article.view_document.article.class%</argument>
             <argument type="string">%sulu_article.smart_content.default_limit%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
 
             <tag name="sulu.smart_content.data_provider" alias="articles"/>
         </service>
@@ -262,6 +263,7 @@
             <argument type="service" id="es.manager.live"/>
             <argument type="service" id="translator"/>
             <argument type="string">%sulu_article.view_document.article.class%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
 
             <tag name="sulu.teaser.provider" alias="article"/>
         </service>
@@ -270,6 +272,7 @@
         <service id="sulu_article.sitemap.articles" class="Sulu\Bundle\ArticleBundle\Sitemap\ArticleSitemapProvider">
             <argument type="service" id="es.manager.live"/>
             <argument type="service" id="sulu_article.view_document.factory"/>
+            <argument type="service" id="logger" on-invalid="null" />
 
             <tag name="sulu.sitemap.provider" alias="articles"/>
         </service>
@@ -291,6 +294,7 @@
             <argument type="service" id="es.manager.default"/>
             <argument>%sulu_article.types%</argument>
             <argument>%sulu_article.view_document.article.class%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
 
             <tag name="sulu.link.provider" alias="article"/>
         </service>
@@ -308,6 +312,7 @@
             <argument type="service" id="sulu_article.reference_store.article"/>
             <argument>%sulu_article.view_document.article.class%</argument>
             <argument>%sulu_article.content-type.article.template%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
 
             <tag name="sulu.content.type" alias="article_selection"/>
         </service>
@@ -337,6 +342,7 @@
             <argument type="service" id="es.manager.live"/>
             <argument type="string">%sulu_article.view_document.article.class%</argument>
             <argument>%sulu_article.search_fields%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
         </service>
 
         <!-- twig extension -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -243,7 +243,10 @@
             <argument type="service" id="sulu_article.factory.resource_item"/>
             <argument type="string">%sulu_article.view_document.article.class%</argument>
             <argument type="string">%sulu_article.smart_content.default_limit%</argument>
-            <argument type="service" id="logger" on-invalid="null" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
 
             <tag name="sulu.smart_content.data_provider" alias="articles"/>
         </service>
@@ -263,7 +266,10 @@
             <argument type="service" id="es.manager.live"/>
             <argument type="service" id="translator"/>
             <argument type="string">%sulu_article.view_document.article.class%</argument>
-            <argument type="service" id="logger" on-invalid="null" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
 
             <tag name="sulu.teaser.provider" alias="article"/>
         </service>
@@ -272,7 +278,10 @@
         <service id="sulu_article.sitemap.articles" class="Sulu\Bundle\ArticleBundle\Sitemap\ArticleSitemapProvider">
             <argument type="service" id="es.manager.live"/>
             <argument type="service" id="sulu_article.view_document.factory"/>
-            <argument type="service" id="logger" on-invalid="null" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
 
             <tag name="sulu.sitemap.provider" alias="articles"/>
         </service>
@@ -294,7 +303,10 @@
             <argument type="service" id="es.manager.default"/>
             <argument>%sulu_article.types%</argument>
             <argument>%sulu_article.view_document.article.class%</argument>
-            <argument type="service" id="logger" on-invalid="null" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
 
             <tag name="sulu.link.provider" alias="article"/>
         </service>
@@ -312,7 +324,10 @@
             <argument type="service" id="sulu_article.reference_store.article"/>
             <argument>%sulu_article.view_document.article.class%</argument>
             <argument>%sulu_article.content-type.article.template%</argument>
-            <argument type="service" id="logger" on-invalid="null" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
 
             <tag name="sulu.content.type" alias="article_selection"/>
         </service>
@@ -342,7 +357,10 @@
             <argument type="service" id="es.manager.live"/>
             <argument type="string">%sulu_article.view_document.article.class%</argument>
             <argument>%sulu_article.search_fields%</argument>
-            <argument type="service" id="logger" on-invalid="null" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
         </service>
 
         <!-- twig extension -->

--- a/Resources/doc/README.md
+++ b/Resources/doc/README.md
@@ -11,3 +11,4 @@ This documentation covers basic-topics to install and use this bundle.
 * [Twig-Extensions](twig-extensions.md)
 * [Author](author.md)
 * [Multi-Page](multi-page.md)
+* [Exception-Handling](exception-handling.md)

--- a/Resources/doc/exception-handling.md
+++ b/Resources/doc/exception-handling.md
@@ -1,0 +1,6 @@
+# Exception Handling
+
+## Elastic-Search
+
+To avoid 500 Errors on the website the system suppresses exceptions which will be raised when the elastic-search cluster
+is not available. When this happens the error message will be logged.

--- a/Tests/Unit/Repository/ArticleViewDocumentRepositoryTest.php
+++ b/Tests/Unit/Repository/ArticleViewDocumentRepositoryTest.php
@@ -74,9 +74,10 @@ class ArticleViewDocumentRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->articleViewDocumentRepository = new ArticleViewDocumentRepository(
             $this->searchManager->reveal(),
             ArticleViewDocument::class,
-            ['title', 'teaser_description'],
-            $this->logger->reveal()
+            ['title', 'teaser_description']
         );
+
+        $this->articleViewDocumentRepository->setLogger($this->logger->reveal());
     }
 
     public function dataProvider()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #252 
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR introduces exception handling if elastic-search is not available.

#### Why?

The whole website crashes when no elastic-search is alive.

#### To Do

- [x] Add log-entry for missing elastic-search (warning)
- [x] Add documentation page
