### PR TITLE
Bugfix/content data indexing max length

### DIFF
--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -265,7 +265,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     /**
      * @var string
      *
-     * @Property(type="binary", options={"index":false})
+     * @Property(type="binary")
      */
     protected $contentData;
 

--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -265,7 +265,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     /**
      * @var string
      *
-     * @Property(type="string", options={"index":"not_analyzed"})
+     * @Property(type="binary")
      */
     protected $contentData;
 

--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -265,7 +265,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     /**
      * @var string
      *
-     * @Property(type="binary")
+     * @Property(type="binary", options={"index":false})
      */
     protected $contentData;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

ElasticSearch indexing type has been changed to binary for ArticleViewDocument::contentData.
{"index":"not_analyzed"} is not available for binary types since ElasticSearch v5 so that has been changed to {"index":false} too.

#### Why?

Previously it's type has been string. ElasticSearch is based on Lucene which in turn has a max length for string types (32766) so when trying to index long articles it was throwing the following error:
```
Document contains at least one immense term in field=\"content_data\" (whose UTF8 encoding is longer than the max length 32766), all of which were skipped.  Please correct the analyzer to not produce such terms.
```