### PR TITLE
Fixed article link provider for more than ten links

### DIFF
--- a/Markup/ArticleLinkProvider.php
+++ b/Markup/ArticleLinkProvider.php
@@ -95,6 +95,7 @@ class ArticleLinkProvider implements LinkProviderInterface
     {
         $search = new Search();
         $search->addQuery(new IdsQuery($this->getViewDocumentIds($hrefs, $locale)));
+        $search->setSize(count($hrefs));
 
         $repository = $this->liveManager->getRepository($this->articleViewClass);
         if (!$published) {

--- a/Tests/Functional/Markup/ArticleLinkProviderTest.php
+++ b/Tests/Functional/Markup/ArticleLinkProviderTest.php
@@ -83,6 +83,34 @@ class ArticleLinkProviderTest extends SuluTestCase
         $this->assertEquals($articles[1]['id'], $result[0]->getId());
     }
 
+    public function testPreloadMoreThan10()
+    {
+        $articles = [
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+        ];
+
+        $uuids = array_map(
+            function (array $data) {
+                return $data['id'];
+            },
+            $articles
+        );
+
+        $result = $this->articleLinkProvider->preload($uuids, 'de', false);
+
+        $this->assertCount(11, $result);
+    }
+
     private function createArticle($title = 'Test-Article', $template = 'default', $data = [])
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixes the search-query size for article-links count more than 10 (auto size of 10 in elasticsearch)