### PR TITLE
Added check for existence when dropping the index

### DIFF
--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -442,6 +442,10 @@ class ArticleIndexer implements IndexerInterface
      */
     public function dropIndex()
     {
+        if (!$this->manager->indexExists()) {
+            return;
+        }
+
         $this->manager->dropIndex();
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR adds a check foe existence of index (before dropping it) to avoid crash of reindex command.