### PR TITLE
Fix drop index on none exist and remove ArticleIndexBuilder dependency on cache builder

### DIFF
--- a/Builder/ArticleIndexBuilder.php
+++ b/Builder/ArticleIndexBuilder.php
@@ -32,7 +32,7 @@ class ArticleIndexBuilder extends SuluBuilder
      */
     public function getDependencies()
     {
-        return ['cache'];
+        return [];
     }
 
     /**

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -442,6 +442,10 @@ class ArticleIndexer implements IndexerInterface
      */
     public function dropIndex()
     {
+        if (!$this->manager->indexExists()) {
+            return;
+        }
+
         $this->manager->dropIndex();
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

The cache clear need to be removed for 1.6.9

#### Why?

This was removed for symfony 3.4 in sulu/sulu.
