### PR TITLE
Update documentation where article bundle should be registered

### DIFF
--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -17,7 +17,7 @@ composer require sulu/article-bundle
 
 ### Add bundles to AbstractKernel
 
-The bundle should be registered after the `SuluCoreBundle`.
+The bundle need to be registered after the `SuluCoreBundle` and `SuluDocumentManagerBundle`.
 
 ```php
 /* app/AbstractKernel.php */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add text that it need to be registered after the SuluDocumentManager Bundle

#### Why?

Error when registered before the SuluDocumentManager.

#### To Do

- [x] Add documentation page
