### PR TITLE
Added webspace-key to article- and article-page-bridge

### DIFF
--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -19,6 +19,11 @@ use Sulu\Component\Content\Compat\Structure\StructureBridge;
 class ArticleBridge extends StructureBridge
 {
     /**
+     * @var string
+     */
+    private $webspaceKey = null;
+
+    /**
      * {@inheritdoc}
      */
     public function getView()
@@ -71,6 +76,14 @@ class ArticleBridge extends StructureBridge
      */
     public function getWebspaceKey()
     {
-        return;
+        return $this->webspaceKey;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setWebspaceKey($webspace)
+    {
+        $this->webspaceKey = $webspace;
     }
 }

--- a/Document/Structure/ArticlePageBridge.php
+++ b/Document/Structure/ArticlePageBridge.php
@@ -11,18 +11,9 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document\Structure;
 
-use Sulu\Component\Content\Compat\Structure\StructureBridge;
-
 /**
  * Own structure bridge for articles.
  */
-class ArticlePageBridge extends StructureBridge
+class ArticlePageBridge extends ArticleBridge
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getWebspaceKey()
-    {
-        return;
-    }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -170,6 +170,7 @@
                  class="Sulu\Bundle\ArticleBundle\Document\Structure\ContentProxyFactory">
             <argument type="service" id="sulu.content.type_manager"/>
             <argument type="service" id="sulu_article.content.data_provider.proxy_factory"/>
+            <argument type="service" id="request_stack"/>
         </service>
 
         <service id="sulu_article.content_proxy_listener"

--- a/Tests/Unit/Document/Subscriber/ArticleWebsiteSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/ArticleWebsiteSubscriberTest.php
@@ -27,6 +27,10 @@ use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Structure\Structure;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\DocumentManager\Document\UnknownDocument;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class ArticleWebsiteSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -67,12 +71,22 @@ class ArticleWebsiteSubscriberTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $requestAttributes = $this->prophesize(RequestAttributes::class);
+        $requestAttributes->getAttribute('webspaceKey')->willReturn('sulu_io');
+
+        $request = $this->prophesize(Request::class);
+        $request->reveal()->attributes = new ParameterBag(['_sulu' => $requestAttributes->reveal()]);
+
+        $requestStack = $this->prophesize(RequestStack::class);
+        $requestStack->getCurrentRequest()->willReturn($request->reveal());
+
         $this->structureManager = $this->prophesize(StructureManagerInterface::class);
         $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
         $this->proxyFactory = new LazyLoadingValueHolderFactory();
         $this->contentProxyFactory = new ContentProxyFactory(
             $this->contentTypeManager->reveal(),
-            $this->proxyFactory
+            $this->proxyFactory,
+            $requestStack->reveal()
         );
         $this->extensionManager = $this->prophesize(ExtensionManagerInterface::class);
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "jackalope/jackalope-jackrabbit": "^1.2",
         "phpunit/phpunit": "^4.8 || ^5.0",
         "sulu/automation-bundle": "^1.2",
-        "php-task/task-bundle": "^1.2"
+        "php-task/task-bundle": "^1.2",
+        "php-task/php-task": "^1.2"
     },
     "conflict": {
         "php": "^7.2"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #307 
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This pull-request add the webspace-key to article-structure.

#### Why?

This is necessary because some content-types (snippet for example) uses it.