### PR TITLE
Added check for automation-bundle before task is available

### DIFF
--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\ArticleBundle\Document\Structure\ArticleBridge;
 use Sulu\Bundle\ArticleBundle\Document\Structure\ArticlePageBridge;
 use Sulu\Bundle\ArticleBundle\Exception\ArticlePageNotFoundException;
 use Sulu\Bundle\ArticleBundle\Exception\ParameterNotAllowedException;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -191,6 +192,10 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
         $bundles = $container->getParameter('kernel.bundles');
         if (array_key_exists('SuluAutomationBundle', $bundles)) {
             $loader->load('automation.xml');
+        } elseif ('task' === $config['content_types']['page_tree_route']['page_route_cascade']) {
+            throw new InvalidConfigurationException(
+                'You need to install the SuluAutomationBundle to use task cascading!'
+            );
         }
 
         $container->setAlias(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR adds a check for `SuluAutomationBundle` to enable task cascade.