### PR TITLE
Fix route generation in correct class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,14 @@ jobs:
       - run: sudo composer self-update
       - restore_cache:
           keys:
-            - composer-v1-{{ checksum "composer.json" }}
-            - composer-v1-
+            - composer-v2-{{ checksum "composer.json" }}
+            - composer-v2-
       - run: composer install -n --prefer-dist
       - save_cache:
-          key: composer-v1-{{ checksum "composer.json" }}
+          key: composer-v2-{{ checksum "composer.json" }}
           paths:
             - vendor
+            - ~/.composer/cache
       - run:
           name: Run Elasticsearch
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/php:7.1-node-browsers
         environment:
           - ES_VERSION=5.6.8
+          - ARTICLE_TEST_CASE=extend
       - image: circleci/mysql:5.7
         environment:
           - MYSQL_USER=root
@@ -54,4 +55,8 @@ jobs:
             ./Tests/app/console sulu:document:initialize
             ./Tests/app/console ongr:es:index:create -m default
             ./Tests/app/console ongr:es:index:create -m live
+      - run:
+          name: List Bundles
+          command:
+            ./Tests/app/console debug:config
       - run: php -d memory_limit=2G ./vendor/bin/phpunit

--- a/Controller/ArticlePageController.php
+++ b/Controller/ArticlePageController.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\ArticleBundle\Controller;
 use FOS\RestBundle\Routing\ClassResourceInterface;
 use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
-use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
 use Sulu\Bundle\ArticleBundle\Exception\ArticlePageNotFoundException;
 use Sulu\Bundle\ArticleBundle\Exception\ParameterNotAllowedException;
 use Sulu\Component\Content\Form\Exception\InvalidFormException;
@@ -187,7 +186,7 @@ class ArticlePageController extends RestController implements ClassResourceInter
     private function persistDocument($data, $document, $locale, $articleUuid)
     {
         if (array_key_exists('title', $data)) {
-            throw new ParameterNotAllowedException('title', ArticlePageDocument::class);
+            throw new ParameterNotAllowedException('title', get_class($document));
         }
 
         $article = $this->getDocumentManager()->find($articleUuid, $locale);

--- a/Controller/ArticlePageController.php
+++ b/Controller/ArticlePageController.php
@@ -87,6 +87,7 @@ class ArticlePageController extends RestController implements ClassResourceInter
     {
         $action = $request->get('action');
         $document = $this->getDocumentManager()->create(self::DOCUMENT_TYPE);
+
         $locale = $this->getRequestParameter($request, 'locale', true);
         $data = $request->request->all();
 
@@ -190,6 +191,7 @@ class ArticlePageController extends RestController implements ClassResourceInter
         }
 
         $article = $this->getDocumentManager()->find($articleUuid, $locale);
+
         if (!array_key_exists('template', $data)) {
             $data['template'] = $article->getStructureType();
         }

--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -105,23 +105,6 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
             );
         }
 
-        if ($container->hasExtension('sulu_route')) {
-            $container->prependExtensionConfig(
-                'sulu_route',
-                [
-                    'mappings' => [
-                        ArticlePageDocument::class => [
-                            'generator' => 'article_page',
-                            'options' => [
-                                'route_schema' => '/{translator.trans("page")}-{object.getPageNumber()}',
-                                'parent' => '{object.getParent().getRoutePath()}',
-                            ],
-                        ],
-                    ],
-                ]
-            );
-        }
-
         if ($container->hasExtension('fos_rest')) {
             $container->prependExtensionConfig(
                 'fos_rest',

--- a/Document/ArticleDocument.php
+++ b/Document/ArticleDocument.php
@@ -72,47 +72,47 @@ class ArticleDocument implements
     /**
      * @var object
      */
-    private $parent;
+    protected $parent;
 
     /**
      * @var string
      */
-    private $title;
+    protected $title;
 
     /**
      * @var string
      */
-    private $pageTitle;
+    protected $pageTitle;
 
     /**
      * @var array
      */
-    private $pages;
+    protected $pages;
 
     /**
      * @var RouteInterface
      */
-    private $route;
+    protected $route;
 
     /**
      * @var string
      */
-    private $routePath;
+    protected $routePath;
 
     /**
      * @var string
      */
-    private $locale;
+    protected $locale;
 
     /**
      * @var string
      */
-    private $originalLocale;
+    protected $originalLocale;
 
     /**
      * @var string
      */
-    private $structureType;
+    protected $structureType;
 
     /**
      * @var StructureInterface
@@ -142,12 +142,12 @@ class ArticleDocument implements
     /**
      * @var int
      */
-    private $author;
+    protected $author;
 
     /**
      * @var \DateTime
      */
-    private $authored;
+    protected $authored;
 
     /**
      * Document's extensions ie seo, ...

--- a/Document/ArticleDocument.php
+++ b/Document/ArticleDocument.php
@@ -301,7 +301,7 @@ class ArticleDocument implements
      */
     public function getClass()
     {
-        return self::class;
+        return get_class($this);
     }
 
     /**

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -47,17 +47,17 @@ class ArticlePageDocument implements
     /**
      * @var string
      */
-    private $title;
+    protected $title;
 
     /**
      * @var string
      */
-    private $pageTitle;
+    protected $pageTitle;
 
     /**
      * @var ArticleDocument
      */
-    private $parent;
+    protected $parent;
 
     /**
      * @var string
@@ -67,17 +67,17 @@ class ArticlePageDocument implements
     /**
      * @var string
      */
-    private $locale;
+    protected $locale;
 
     /**
      * @var string
      */
-    private $originalLocale;
+    protected $originalLocale;
 
     /**
      * @var string
      */
-    private $structureType;
+    protected $structureType;
 
     /**
      * @var StructureInterface
@@ -87,17 +87,17 @@ class ArticlePageDocument implements
     /**
      * @var RouteInterface
      */
-    private $route;
+    protected $route;
 
     /**
      * @var string
      */
-    private $routePath;
+    protected $routePath;
 
     /**
      * @var int
      */
-    private $pageNumber;
+    protected $pageNumber;
 
     public function __construct()
     {

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -308,7 +308,7 @@ class ArticlePageDocument implements
      */
     public function getClass()
     {
-        return self::class;
+        return get_class($this);
     }
 
     /**

--- a/Document/Subscriber/ArticlePageSubscriber.php
+++ b/Document/Subscriber/ArticlePageSubscriber.php
@@ -251,7 +251,9 @@ class ArticlePageSubscriber implements EventSubscriberInterface
      */
     public function handleMetadataLoad(MetadataLoadEvent $event)
     {
-        if (ArticlePageDocument::class !== $event->getMetadata()->getClass()) {
+        if (ArticlePageDocument::class !== $event->getMetadata()->getClass()
+            && !is_subclass_of($event->getMetadata()->getClass(), ArticlePageDocument::class)
+        ) {
             return;
         }
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -34,9 +34,14 @@ new ONGR\ElasticsearchBundle\ONGRElasticsearchBundle(),
 sulu_route:
     mappings:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            generator: schema
+            generator: "schema"
             options:
-                route_schema: /articles/{object.getTitle()}
+                route_schema: "/articles/{object.getTitle()}"
+        Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
+            generator: "article_page"
+            options:
+                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
+                parent: "{object.getParent().getRoutePath()}"
 
 sulu_core:
     content:

--- a/Resources/doc/multi-page.md
+++ b/Resources/doc/multi-page.md
@@ -38,10 +38,10 @@ To change the default postfix use following configuration in your `app/config/co
 sulu_route:
     mappings:
         Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
-            generator: article_page
+            generator: "article_page"
             options:
-                route_schema: '/{translator.trans("page")}-{object.getPageNumber()}'
-                parent: '{object.getParent().getRoutePath()}'
+                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
+                parent: "{object.getParent().getRoutePath()}"
 ```
 
 ## Pagination

--- a/Resources/doc/routing.md
+++ b/Resources/doc/routing.md
@@ -31,6 +31,11 @@ sulu_route:
             generator: schema
             options:
                 route_schema: /articles/{object.getTitle()}
+        Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
+            generator: "article_page"
+            options:
+                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
+                parent: "{object.getParent().getRoutePath()}"
 ```
 
 This schema will be used for all articles which will be created in the future. Older articles

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -1262,7 +1262,7 @@ class ArticleControllerTest extends SuluTestCase
             );
 
             $route = $this->findRoute($responsePages[$i]['route'], 'de');
-            $this->assertEquals(ArticlePageDocument::class, $route->getEntityClass());
+            $this->assertTrue(is_subclass_of($route->getEntityClass(), ArticlePageDocument::class) || ArticlePageDocument::class === $route->getEntityClass());
             $this->assertEquals($responsePages[$i]['id'], $route->getEntityId());
             $this->assertEquals('de', $route->getLocale());
             $this->assertFalse($route->isHistory());

--- a/Tests/Functional/PageTree/PageTreeRepositoryTest.php
+++ b/Tests/Functional/PageTree/PageTreeRepositoryTest.php
@@ -128,6 +128,7 @@ class PageTreeRepositoryTest extends SuluTestCase
         ];
 
         $article = $this->createArticle($this->getPathData($pages[0], 'article-1'));
+
         $articlePages = [
             $this->createArticlePage($article, 'Test page 1'),
             $this->createArticlePage($article, 'Test page 2'),

--- a/Tests/TestExtendBundle/Document/ArticleDocument.php
+++ b/Tests/TestExtendBundle/Document/ArticleDocument.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document;
+
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument as SuluArticleDocument;
+
+class ArticleDocument extends SuluArticleDocument
+{
+}

--- a/Tests/TestExtendBundle/Document/ArticlePageDocument.php
+++ b/Tests/TestExtendBundle/Document/ArticlePageDocument.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document;
 
-use Sulu\Bundle\ArticleBundle\Document\ArticleDocument as SuluArticlePageDocument;
+use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument as SuluArticlePageDocument;
 
 class ArticlePageDocument extends SuluArticlePageDocument
 {

--- a/Tests/TestExtendBundle/Document/ArticlePageDocument.php
+++ b/Tests/TestExtendBundle/Document/ArticlePageDocument.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document;
+
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument as SuluArticlePageDocument;
+
+class ArticlePageDocument extends SuluArticlePageDocument
+{
+}

--- a/Tests/TestExtendBundle/TestExtendBundle.php
+++ b/Tests/TestExtendBundle/TestExtendBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class TestExtendBundle extends Bundle
+{
+}

--- a/Tests/app/AppKernel.php
+++ b/Tests/app/AppKernel.php
@@ -11,6 +11,7 @@
 
 use ONGR\ElasticsearchBundle\ONGRElasticsearchBundle;
 use Sulu\Bundle\ArticleBundle\SuluArticleBundle;
+use Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\TestExtendBundle;
 use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
@@ -24,7 +25,15 @@ class AppKernel extends SuluTestKernel
      */
     public function registerBundles()
     {
-        return array_merge(parent::registerBundles(), [new SuluArticleBundle(), new ONGRElasticsearchBundle()]);
+        $bundles = parent::registerBundles();
+        $bundles[] = new SuluArticleBundle();
+        $bundles[] = new ONGRElasticsearchBundle();
+
+        if ('extend' === getenv('ARTICLE_TEST_CASE')) {
+            $bundles[] = new TestExtendBundle();
+        }
+
+        return $bundles;
     }
 
     /**
@@ -37,7 +46,14 @@ class AppKernel extends SuluTestKernel
         if ('jackrabbit' === getenv('SYMFONY__PHPCR__TRANSPORT')) {
             $loader->load(__DIR__ . '/config/versioning.yml');
         }
+
         $loader->load(__DIR__ . '/config/config.yml');
+        $type = 'default';
+        if (getenv('ARTICLE_TEST_CASE')) {
+            $type = getenv('ARTICLE_TEST_CASE');
+        }
+
+        $loader->load(__DIR__ . '/config/config_' . $type . '.yml');
 
         $esVersion = getenv('ES_VERSION');
         if (version_compare($esVersion, '2.2', '>=') && version_compare($esVersion, '5.0', '<')) {

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -22,6 +22,11 @@ sulu_core:
 sulu_route:
     mappings:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            generator: schema
+            generator: "schema"
             options:
-                route_schema: /articles/{object.getTitle()}
+                route_schema: "/articles/{object.getTitle()}"
+        Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
+            generator: "article_page"
+            options:
+                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
+                parent: "{object.getParent().getRoutePath()}"

--- a/Tests/app/config/config_default.yml
+++ b/Tests/app/config/config_default.yml
@@ -1,11 +1,11 @@
 # This file will not be included when run under extend
 sulu_route:
     mappings:
-        Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument:
+        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
             generator: "schema"
             options:
                 route_schema: "/articles/{object.getTitle()}"
-        Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticlePageDocument:
+        Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
             generator: "article_page"
             options:
                 route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"

--- a/Tests/app/config/config_default.yml
+++ b/Tests/app/config/config_default.yml
@@ -1,0 +1,12 @@
+# This file will not be included when run under extend
+sulu_route:
+    mappings:
+        Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument:
+            generator: "schema"
+            options:
+                route_schema: "/articles/{object.getTitle()}"
+        Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticlePageDocument:
+            generator: "article_page"
+            options:
+                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
+                parent: "{object.getParent().getRoutePath()}"

--- a/Tests/app/config/config_extend.yml
+++ b/Tests/app/config/config_extend.yml
@@ -1,0 +1,21 @@
+# This file will configure using the TestExtendBundle documents
+sulu_document_manager:
+    mapping:
+        article:
+            class: Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument
+            phpcr_type: 'sulu:article'
+        article_page:
+            class: Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticlePageDocument
+            phpcr_type: 'sulu:articlepage'
+
+sulu_route:
+    mappings:
+        Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument:
+            generator: "schema"
+            options:
+                route_schema: "/articles/{object.getTitle()}"
+        Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticlePageDocument:
+            generator: "article_page"
+            options:
+                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
+                parent: "{object.getParent().getRoutePath()}"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,23 @@
 # Upgrade
 
+## dev-master
+
+### ArticlePageDocument route definition need to be defined
+
+The ArticleBundle will not longer prepend the configuration for the article page routes
+for this you need to define them in your configuration (app/config/config.yml):
+
+```yml
+sulu_route:
+    mappings:
+        # ...
+        Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
+            generator: "article_page"
+            options:
+                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
+                parent: "{object.getParent().getRoutePath()}"
+```
+
 ## 1.0.0-RC5
 
 ### Author and Authored


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use correct class for generating routes.

#### Why?

Currently there is a mix between classes when you extend the ArticleDocument and ArticlePageDocument.
