### PR TITLE
Fixed limit for article selection content type

### DIFF
--- a/Content/ArticleSelectionContentType.php
+++ b/Content/ArticleSelectionContentType.php
@@ -82,6 +82,7 @@ class ArticleSelectionContentType extends SimpleContentType implements PreResolv
         $repository = $this->searchManager->getRepository($this->articleDocumentClass);
         $search = $repository->createSearch();
         $search->addQuery(new IdsQuery($this->getViewDocumentIds($value, $locale)));
+        $search->setSize(count($value));
 
         $result = [];
         /** @var ArticleViewDocumentInterface $articleDocument */

--- a/Tests/Unit/Content/ArticleSelectionContentTypeTest.php
+++ b/Tests/Unit/Content/ArticleSelectionContentTypeTest.php
@@ -66,6 +66,8 @@ class ArticleSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
                 }
             )
         )->shouldBeCalled();
+        $search->setSize(2)->shouldBeCalled();
+
         $repository->findDocuments($search->reveal())->willReturn($articles);
 
         $contentType = new ArticleSelectionContentType(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

Fixes the limit of the article selection content type as the default value was 10.
