### PR TITLE
Added smart content filter by structure type (article.xml -> key attribute)

### DIFF
--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -150,6 +150,7 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
         $pageSize = null
     ) {
         $filters['types'] = $this->getTypesProperty($propertyParameter);
+        $filters['structureTypes'] = $this->getStructureTypesProperty($propertyParameter);
         $filters['excluded'] = $this->getExcludedFilter($filters, $propertyParameter);
 
         $queryResult = $this->getSearchResult($filters, $limit, $page, $pageSize, $options['locale']);
@@ -175,6 +176,7 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
         $pageSize = null
     ) {
         $filters['types'] = $this->getTypesProperty($propertyParameter);
+        $filters['structureTypes'] = $this->getStructureTypesProperty($propertyParameter);
         $filters['excluded'] = $this->getExcludedFilter($filters, $propertyParameter);
 
         $queryResult = $this->getSearchResult($filters, $limit, $page, $pageSize, $options['locale']);
@@ -289,6 +291,14 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
             $search->addQuery($typesQuery);
         }
 
+        if (array_key_exists('structureTypes', $filters) && $filters['structureTypes']) {
+            $strTypesQuery = new BoolQuery();
+            foreach ($filters['structureTypes'] as $filter) {
+                $strTypesQuery->add(new TermQuery('structure_type', $filter), BoolQuery::SHOULD);
+            }
+            $search->addQuery($strTypesQuery);
+        }
+
         if (0 === $queriesCount) {
             $search->addQuery(new MatchAllQuery(), BoolQuery::MUST);
         } else {
@@ -318,6 +328,28 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
         }
 
         return $filterTypes;
+    }
+
+    /**
+     * Returns array with all structure types (template keys) defined in property parameter.
+     *
+     * @param array $propertyParameter
+     *
+     * @return array
+     */
+    private function getStructureTypesProperty($propertyParameter)
+    {
+        $filterStrTypes = [];
+
+        if (array_key_exists('structureTypes', $propertyParameter)
+            && null !== ($types = explode(',', $propertyParameter['structureTypes']->getValue()))
+        ) {
+            foreach ($types as $type) {
+                $filterStrTypes[] = $type;
+            }
+        }
+
+        return $filterStrTypes;
     }
 
     /**

--- a/Tests/Functional/Content/ArticleDataProviderTest.php
+++ b/Tests/Functional/Content/ArticleDataProviderTest.php
@@ -114,6 +114,72 @@ class ArticleDataProviderTest extends SuluTestCase
         $this->assertCount(0, $result->getItems());
     }
 
+    public function testResolveDataItemsStructureTypeParam()
+    {
+        $item1 = $this->createArticle();
+        $item2 = $this->createArticle('Test', 'simple');
+
+        /** @var DataProviderInterface $dataProvider */
+        $dataProvider = $this->getContainer()->get('sulu_article.content.data_provider');
+
+        // get all articles with structureType simple
+        $result = $dataProvider->resolveDataItems(
+            [],
+            ['structureTypes' => new PropertyParameter('structureTypes', 'simple')],
+            ['locale' => 'de']
+        );
+
+        $this->assertInstanceOf(DataProviderResult::class, $result);
+        $this->assertCount(1, $result->getItems());
+        $this->assertEquals($item2['id'], $result->getItems()[0]->getId());
+    }
+
+    public function testResolveDataItemsStructureTypeParamMultiple()
+    {
+        $item1 = $this->createArticle('Test #1', 'default');
+        $item2 = $this->createArticle('Test #2', 'simple');
+        $item3 = $this->createArticle('Test no match', 'default_fallback');
+
+        /** @var DataProviderInterface $dataProvider */
+        $dataProvider = $this->getContainer()->get('sulu_article.content.data_provider');
+
+        // get all articles with structureType default or simple
+        $result = $dataProvider->resolveDataItems(
+            [],
+            ['structureTypes' => new PropertyParameter('structureTypes', 'default,simple')],
+            ['locale' => 'de']
+        );
+
+        $this->assertInstanceOf(DataProviderResult::class, $result);
+        $this->assertCount(2, $result->getItems());
+        $this->assertContains(
+            $item1['id'],
+            [$result->getItems()[0]->getId(), $result->getItems()[1]->getId()]
+        );
+        $this->assertContains(
+            $item2['id'],
+            [$result->getItems()[0]->getId(), $result->getItems()[1]->getId()]
+        );
+    }
+
+    public function testResolveDataItemsStructureTypeParamWrong()
+    {
+        $item1 = $this->createArticle();
+        $item2 = $this->createArticle('Test', 'simple');
+
+        /** @var DataProviderInterface $dataProvider */
+        $dataProvider = $this->getContainer()->get('sulu_article.content.data_provider');
+
+        // get all articles with structureType default_fallback
+        $result = $dataProvider->resolveDataItems(
+            [],
+            ['structureTypes' => new PropertyParameter('structureTypes', 'default_fallback')],
+            ['locale' => 'de']
+        );
+        $this->assertInstanceOf(DataProviderResult::class, $result);
+        $this->assertCount(0, $result->getItems());
+    }
+
     public function testResolveDataItemsPagination()
     {
         $items = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Added structureType filtering ability for articles smart-content provider.
It allows to filter articles not only by type, but also by article template `key` tag value.

`
<?xml version="1.0" ?>
<template xmlns="http://schemas.sulu.io/template/template"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns:xi="http://www.w3.org/2001/XInclude"
          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">

    <key>special_company_blog_article</key>
    ...
`

#### Why?

It is very convenient if we want to display list of same article types on different webspaces.

#### Example Usage

Simple use `structureTypes` param to filter articles by it:

`
                <properties>
                    <property name="articles" type="smart_content" mandatory="true">
                        <meta>
                            <title lang="en">Articles</title>
                            <title lang="uk">Статті</title>
                        </meta>

                        <params>
                            <param name="provider" value="articles"/>
                            <param name="types" value="blog"/>
                            <param name="structureTypes" value="special_company_blog_article"/>
                            <param name="max_per_page" value="3"/>
                        </params>
                    </property>
                </properties>
`
#### To Do

- [ ] Add documentation page
