### PR TITLE
Changed getFieldDescriptors from private to protected

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -59,7 +59,7 @@ class ArticleController extends RestController implements ClassResourceInterface
      *
      * @return ElasticSearchFieldDescriptor[]
      */
-    private function getFieldDescriptors()
+    protected function getFieldDescriptors()
     {
         return [
             'uuid' => ElasticSearchFieldDescriptor::create('id', 'public.id')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Change the `getFieldDescriptors` method in the ArticleController Class from private to protected

#### Why?

If you want to build your own article overview list.

#### Example Usage

Overwrite the ArticleController in the routing and set own fields in `getFieldDescriptors`
