### PR TITLE
Set branch alias for 2.0 require correct sulu version and specific symfony packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ before_install:
   - ./elasticsearch-*/bin/elasticsearch -d
 
 install:
-  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan $COMPOSER_FLAGS ; else travis_retry composer update $COMPOSER_FLAGS ; fi
+  - if [[ $ES_VERSION == '2.'* ]]; then travis_retry composer require ongr/elasticsearch-bundle:^1.2.9 --no-update $COMPOSER_FLAGS ; fi
+  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan --no-update $COMPOSER_FLAGS ; fi
+  - travis_retry composer update $COMPOSER_FLAGS
   - composer info -i
   - ./Tests/app/console doctrine:database:create
   - ./Tests/app/console doctrine:schema:update --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   include:
     - php: 7.1
       env:
-        - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
+        - COMPOSER_FLAGS="--prefer-lowest --prefer-stable --prefer-dist --no-interaction"
         - ES_VERSION="2.4.4"
         - ES_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.zip"
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,11 @@
     "require": {
         "php": "^7.1",
         "sulu/sulu": "^2.0",
-        "symfony/symfony": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "symfony/force-lowest": "^3.4",
+        "symfony/http-foundation": "^3.4",
+        "symfony/http-kernel": "^3.4",
         "symfony-cmf/slugifier-api": "^1.0 || ^2.0",
         "ongr/elasticsearch-bundle": "^1.2.9 || ~5.0",
         "ongr/elasticsearch-dsl": "^2.2.2 || ~5.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "sulu/sulu": "dev-develop as 1.6.16",
+        "sulu/sulu": "^2.0",
         "ongr/elasticsearch-bundle": "^1.2.9 || ~5.0",
         "ongr/elasticsearch-dsl": "^2.2.2 || ~5.0",
         "jackalope/jackalope": "^1.2.8 || >=1.3.3",
@@ -21,7 +21,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
         "jackalope/jackalope-jackrabbit": "^1.2",
         "phpunit/phpunit": "^4.8 || ^5.0",
-        "sulu/automation-bundle": "dev-develop",
+        "sulu/automation-bundle": "^2.0",
         "php-task/task-bundle": "^1.2",
         "php-task/php-task": "^1.2"
     },
@@ -45,6 +45,12 @@
     "autoload": {
         "psr-4": {
             "Sulu\\Bundle\\ArticleBundle\\": ""
+        }
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-sulu-2.0": "2.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,12 @@
     "require": {
         "php": "^7.1",
         "sulu/sulu": "^2.0",
+        "symfony/config": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "symfony/http-foundation": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/force-lowest": "^3.4",
+        "symfony-cmf/slugifier-api": "^1.0 || ^2.0",
         "ongr/elasticsearch-bundle": "^1.2.9 || ~5.0",
         "ongr/elasticsearch-dsl": "^2.2.2 || ~5.0",
         "jackalope/jackalope": "^1.2.8 || >=1.3.3",

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,7 @@
     "require": {
         "php": "^7.1",
         "sulu/sulu": "^2.0",
-        "symfony/config": "^3.4",
-        "symfony/dependency-injection": "^3.4",
-        "symfony/http-foundation": "^3.4",
-        "symfony/http-kernel": "^3.4",
-        "symfony/force-lowest": "^3.4",
+        "symfony/symfony": "^3.4",
         "symfony-cmf/slugifier-api": "^1.0 || ^2.0",
         "ongr/elasticsearch-bundle": "^1.2.9 || ~5.0",
         "ongr/elasticsearch-dsl": "^2.2.2 || ~5.0",
@@ -27,9 +23,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
         "jackalope/jackalope-jackrabbit": "^1.2",
         "phpunit/phpunit": "^4.8 || ^5.0",
-        "sulu/automation-bundle": "^2.0",
-        "php-task/task-bundle": "^1.2",
-        "php-task/php-task": "^1.2"
+        "sulu/automation-bundle": "^2.0"
     },
     "conflict": {
         "php": "^7.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related PRs | ~https://github.com/sulu/SuluAutomationBundle/pull/19~
| License | MIT

#### What's in this PR?

Set correct symfony requirements and branch alias for 2.0.

#### Why?

Allow to install article bundle as ^2.0@dev
