### PR TITLE
Fix contact repository deprecations and fielddescriptor searchability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           keys:
             - composer-v2-{{ checksum "composer.json" }}
             - composer-v2-
-      - run: composer install -n --prefer-dist
+      - run: php -d memory_limit=2G /usr/local/bin/composer install -n --prefer-dist
       - save_cache:
           key: composer-v2-{{ checksum "composer.json" }}
           paths:

--- a/ListBuilder/ElasticSearchFieldDescriptor.php
+++ b/ListBuilder/ElasticSearchFieldDescriptor.php
@@ -20,7 +20,7 @@ use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
  */
 class ElasticSearchFieldDescriptor extends FieldDescriptor
 {
-    public static function create($name, $translation = null)
+    public static function create(string $name, string $translation = null)
     {
         return new ElasticSearchFieldDescriptorBuilder($name, $translation);
     }
@@ -31,16 +31,17 @@ class ElasticSearchFieldDescriptor extends FieldDescriptor
     private $sortField;
 
     public function __construct(
-        $name,
-        $sortField = null,
-        $translation = null,
-        $visibility = FieldDescriptorInterface::VISIBILITY_NO,
-        $type = '',
-        $width = '',
-        $minWidth = '',
-        $sortable = true,
-        $editable = false,
-        $cssClass = ''
+        string $name,
+        string $sortField = null,
+        string $translation = null,
+        string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
+        string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
+        string $type = '',
+        string $width = '',
+        string $minWidth = '',
+        bool $sortable = true,
+        bool $editable = false,
+        string $cssClass = ''
     ) {
         $this->sortField = $sortField ? $sortField : $name;
 
@@ -48,6 +49,7 @@ class ElasticSearchFieldDescriptor extends FieldDescriptor
             $name,
             $translation,
             $visibility,
+            $searchability,
             $type,
             $width,
             $minWidth,

--- a/ListBuilder/ElasticSearchFieldDescriptorBuilder.php
+++ b/ListBuilder/ElasticSearchFieldDescriptorBuilder.php
@@ -33,7 +33,12 @@ final class ElasticSearchFieldDescriptorBuilder
     /**
      * @var string
      */
-    private $visibility = FieldDescriptorInterface::VISIBILITY_NEVER;
+    private $visibility = FieldDescriptorInterface::VISIBILITY_YES;
+
+    /**
+     * @var string
+     */
+    private $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER;
 
     /**
      * @var string
@@ -45,13 +50,13 @@ final class ElasticSearchFieldDescriptorBuilder
      */
     private $sortable = false;
 
-    public function __construct($name, $translation)
+    public function __construct(string $name, string $translation = null)
     {
         $this->name = $name;
         $this->translation = $translation;
     }
 
-    public function setSortField($sortField)
+    public function setSortField(string $sortField)
     {
         $this->sortField = $sortField;
         $this->sortable = true;
@@ -59,14 +64,21 @@ final class ElasticSearchFieldDescriptorBuilder
         return $this;
     }
 
-    public function setVisibility($visibility)
+    public function setVisibility(string $visibility)
     {
         $this->visibility = $visibility;
 
         return $this;
     }
 
-    public function setType($type)
+    public function setSearchability(string $searchability)
+    {
+        $this->searchability = $searchability;
+
+        return $this;
+    }
+
+    public function setType(string $type)
     {
         $this->type = $type;
 
@@ -80,6 +92,7 @@ final class ElasticSearchFieldDescriptorBuilder
             $this->sortField,
             $this->translation,
             $this->visibility,
+            $this->searchability,
             $this->type,
             '',
             '',

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,7 +42,7 @@
                  class="Sulu\Bundle\ArticleBundle\Document\Index\ArticleGhostIndexer">
             <argument type="service" id="sulu_content.structure.factory"/>
             <argument type="service" id="sulu_security.user_manager"/>
-            <argument type="service" id="sulu_contact.contact_repository"/>
+            <argument type="service" id="sulu.repository.contact"/>
             <argument type="service" id="sulu_article.view_document.factory"/>
             <argument type="service" id="es.manager.default"/>
             <argument type="service" id="sulu_article.elastic_search.factory.excerpt"/>
@@ -57,7 +57,7 @@
                  class="Sulu\Bundle\ArticleBundle\Document\Index\ArticleIndexer">
             <argument type="service" id="sulu_content.structure.factory"/>
             <argument type="service" id="sulu_security.user_manager"/>
-            <argument type="service" id="sulu_contact.contact_repository"/>
+            <argument type="service" id="sulu.repository.contact"/>
             <argument type="service" id="sulu_article.view_document.factory"/>
             <argument type="service" id="es.manager.live"/>
             <argument type="service" id="sulu_article.elastic_search.factory.excerpt"/>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade
 
+## dev-develop
+
+### ElasticSearchFieldDescriptor constructor changed
+
+The ElasticSearchFieldDescriptor changed see FieldDescriptor update in the UPGRADE.md of sulu/sulu.
+
 ## dev-master
 
 ### ArticlePageDocument route definition need to be defined


### PR DESCRIPTION
| Q | A
| --- | ---
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix contact repository deprecations.

#### Why?

sulu_contact.contact_repository was removed and the fielddescriptor constructor changed.
