### PR TITLE
Fix: Use use ObjectIterator instead of Collection

### DIFF
--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -16,6 +16,7 @@ use ONGR\ElasticsearchBundle\Annotation\Embedded;
 use ONGR\ElasticsearchBundle\Annotation\Id;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 use ONGR\ElasticsearchBundle\Collection\Collection;
+use ONGR\ElasticsearchBundle\Result\ObjectIterator;
 
 /**
  * Indexable document for articles.
@@ -744,7 +745,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     /**
      * {@inheritdoc}
      */
-    public function setPages(Collection $pages)
+    public function setPages(ObjectIterator $pages)
     {
         $this->pages = $pages;
 

--- a/Document/ArticleViewDocumentInterface.php
+++ b/Document/ArticleViewDocumentInterface.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Document;
 
 use ONGR\ElasticsearchBundle\Collection\Collection;
+use ONGR\ElasticsearchBundle\Result\ObjectIterator;
 
 /**
  * Interface for indexable article-document.
@@ -428,11 +429,11 @@ interface ArticleViewDocumentInterface
     /**
      * Set pages.
      *
-     * @param Collection $pages
+     * @param ObjectIterator $pages
      *
      * @return $this
      */
-    public function setPages(Collection $pages);
+    public function setPages(ObjectIterator $pages);
 
     /**
      * Returns contentData.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | Yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Use `ONGR\ElasticsearchBundle\Result\ObjectIterator` instead of ` ONGR\ElasticsearchBundle\Collection\Collection ` in *ArticleViewDocument* and *ArticleViewDocumentInterface*

#### Why?

I am using those versions:
ES: 5.6.3
ElasticSearchBundle: v5.3.2
SuluArticleBundle: 0.7.1
Sulu: 1.6.21

``` Type error: Argument 1 passed to Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument::setPages() must be an instance of ONGR\ElasticsearchBundle\Collection\Collection, instance of ONGR\ElasticsearchBundle\Result\ObjectIterator given, called in /var/www/project/vendor/ongr/elasticsearch-bundle/Result/Converter.php on line 134 ```

#### BC Breaks/Deprecations

```ONGR\ElasticsearchBundle\Collection\Collection```

#### To Do

- [ ] Add documentation page
