### PR TITLE
Fixed incompatibility with ongr/elasticsearch 5.0.6

### DIFF
--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -15,7 +15,6 @@ use ONGR\ElasticsearchBundle\Annotation\Document;
 use ONGR\ElasticsearchBundle\Annotation\Embedded;
 use ONGR\ElasticsearchBundle\Annotation\Id;
 use ONGR\ElasticsearchBundle\Annotation\Property;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Indexable document for articles.
@@ -763,7 +762,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     /**
      * {@inheritdoc}
      */
-    public function setPages(Collection $pages)
+    public function setPages($pages)
     {
         $this->pages = $pages;
 

--- a/Document/ArticleViewDocumentInterface.php
+++ b/Document/ArticleViewDocumentInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
@@ -428,11 +429,11 @@ interface ArticleViewDocumentInterface
     /**
      * Set pages.
      *
-     * @param Collection $pages
+     * @param Collection|ArrayCollection $pages
      *
      * @return $this
      */
-    public function setPages(Collection $pages);
+    public function setPages($pages);
 
     /**
      * Returns contentData.

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -70,7 +70,7 @@ class ArticleControllerTest extends SuluTestCase
         $requestData = [
             'title' => $title,
             'template' => $template,
-            'authored' => $authored,
+            'authored' => date('c', strtotime($authored)),
             'action' => $action,
         ];
 
@@ -94,7 +94,7 @@ class ArticleControllerTest extends SuluTestCase
             [
                 'pageTitle' => $pageTitle,
                 'template' => $article['template'],
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
             ]
         );
 
@@ -129,7 +129,7 @@ class ArticleControllerTest extends SuluTestCase
             [
                 'title' => $title,
                 'template' => 'default',
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
                 'author' => $user->getId(),
             ]
         );
@@ -174,7 +174,7 @@ class ArticleControllerTest extends SuluTestCase
         $requestData = [
             'title' => $title,
             'template' => 'default',
-            'authored' => '2016-01-01',
+            'authored' => date('c', strtotime('2016-01-01')),
         ];
 
         if ($shadowLocale) {
@@ -225,7 +225,7 @@ class ArticleControllerTest extends SuluTestCase
             [
                 'title' => $title,
                 'template' => 'default',
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
                 'author' => $user->getId(),
             ]
         );
@@ -1254,7 +1254,7 @@ class ArticleControllerTest extends SuluTestCase
             [
                 'title' => $title,
                 'template' => $template,
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
                 'ext' => ['excerpt' => ['categories' => [$category->getId()]]],
             ]
         );
@@ -1286,7 +1286,7 @@ class ArticleControllerTest extends SuluTestCase
             [
                 'title' => $title,
                 'template' => $template,
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
                 'ext' => ['excerpt' => ['tags' => [$tag->getName()]]],
             ]
         );
@@ -1564,7 +1564,7 @@ class ArticleControllerTest extends SuluTestCase
                 'title' => $title,
                 'template' => 'page_tree_route',
                 'routePath' => $routePathData,
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
             ]
         );
 

--- a/Tests/Functional/Controller/ArticlePageControllerTest.php
+++ b/Tests/Functional/Controller/ArticlePageControllerTest.php
@@ -54,7 +54,7 @@ class ArticlePageControllerTest extends SuluTestCase
                 'title' => $title,
                 'pageTitle' => $title,
                 'template' => $template,
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
             ]
         );
 
@@ -73,7 +73,7 @@ class ArticlePageControllerTest extends SuluTestCase
                 'title' => $title,
                 'pageTitle' => $title,
                 'template' => $template,
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
             ]
         );
 

--- a/Tests/Functional/PageTree/PageTreeRepositoryTest.php
+++ b/Tests/Functional/PageTree/PageTreeRepositoryTest.php
@@ -190,7 +190,7 @@ class PageTreeRepositoryTest extends SuluTestCase
                 'title' => $title,
                 'template' => 'page_tree_route',
                 'routePath' => $routePathData,
-                'authored' => '2016-01-01',
+                'authored' => date('c', strtotime('2016-01-01')),
             ]
         );
 

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "php-task/php-task": "^1.2"
     },
     "conflict": {
-        "php": "^7.2",
-        "ongr/elasticsearch-bundle": "^5.2.0"
+        "php": "^7.2"
     },
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "conflict": {
         "php": "^7.2",
-        "ongr/elasticsearch-bundle": "^5.2.0" 
+        "ongr/elasticsearch-bundle": "^5.2.0"
     },
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "php-task/php-task": "^1.2"
     },
     "conflict": {
-        "php": "^7.2",
-        "ongr/elasticsearch-bundle": "^5.0.6"
+        "php": "^7.2"
     },
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php-task/php-task": "^1.2"
     },
     "conflict": {
-        "php": "^7.2"
+        "php": "^7.2",
+        "ongr/elasticsearch-bundle": "^5.2.0" 
     },
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added support ongr newest version after a bc break in ongr ( https://github.com/ongr-io/ElasticsearchBundle/pull/777 )

#### Why?

To support needed fixes of 5.0.6.
