### PR TITLE
Pluralize menu entry

### DIFF
--- a/Resources/translations/sulu/backend.de.xlf
+++ b/Resources/translations/sulu/backend.de.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1" resname="sulu_article.title">
                 <source>sulu_article.title</source>
-                <target>Artikels</target>
+                <target>Artikel</target>
             </trans-unit>
             <trans-unit id="2" resname="sulu_article.list.title">
                 <source>sulu_article.list.title</source>
-                <target>Artikels</target>
+                <target>Artikel</target>
             </trans-unit>
             <trans-unit id="3" resname="sulu_article.list.creator">
                 <source>sulu_article.list.creator</source>

--- a/Resources/translations/sulu/backend.de.xlf
+++ b/Resources/translations/sulu/backend.de.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1" resname="sulu_article.title">
                 <source>sulu_article.title</source>
-                <target>Artikel</target>
+                <target>Artikels</target>
             </trans-unit>
             <trans-unit id="2" resname="sulu_article.list.title">
                 <source>sulu_article.list.title</source>
-                <target>Artikel</target>
+                <target>Artikels</target>
             </trans-unit>
             <trans-unit id="3" resname="sulu_article.list.creator">
                 <source>sulu_article.list.creator</source>

--- a/Resources/translations/sulu/backend.en.xlf
+++ b/Resources/translations/sulu/backend.en.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1" resname="sulu_article.title">
                 <source>sulu_article.title</source>
-                <target>Article</target>
+                <target>Articles</target>
             </trans-unit>
             <trans-unit id="2" resname="sulu_article.list.title">
                 <source>sulu_article.list.title</source>
-                <target>Article</target>
+                <target>Articles</target>
             </trans-unit>
             <trans-unit id="3" resname="sulu_article.list.creator">
                 <source>sulu_article.list.creator</source>

--- a/Resources/translations/sulu/backend.fr.xlf
+++ b/Resources/translations/sulu/backend.fr.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1" resname="sulu_article.title">
                 <source>sulu_article.title</source>
-                <target>Article</target>
+                <target>Articles</target>
             </trans-unit>
             <trans-unit id="2" resname="sulu_article.list.title">
                 <source>sulu_article.list.title</source>
-                <target>Article</target>
+                <target>Articles</target>
             </trans-unit>
             <trans-unit id="3" resname="sulu_article.list.creator">
                 <source>sulu_article.list.creator</source>

--- a/Resources/translations/sulu/backend.nl.xlf
+++ b/Resources/translations/sulu/backend.nl.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1" resname="sulu_article.title">
                 <source>sulu_article.title</source>
-                <target>Artikel</target>
+                <target>Artikels</target>
             </trans-unit>
             <trans-unit id="2" resname="sulu_article.list.title">
                 <source>sulu_article.list.title</source>
-                <target>Artikel</target>
+                <target>Artikels</target>
             </trans-unit>
             <trans-unit id="3" resname="sulu_article.list.creator">
                 <source>sulu_article.list.creator</source>

--- a/Resources/translations/sulu/backend.nl.xlf
+++ b/Resources/translations/sulu/backend.nl.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1" resname="sulu_article.title">
                 <source>sulu_article.title</source>
-                <target>Artikels</target>
+                <target>Artikelen</target>
             </trans-unit>
             <trans-unit id="2" resname="sulu_article.list.title">
                 <source>sulu_article.list.title</source>
-                <target>Artikels</target>
+                <target>Artikelen</target>
             </trans-unit>
             <trans-unit id="3" resname="sulu_article.list.creator">
                 <source>sulu_article.list.creator</source>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR pluralize the menu entry for the articles, by replacing "Article" with "Articles".

#### Why?

Most entries are already pluralized: "Snippets", "Users", ... the goal of this PR is to use the same convention on this entry.


By the way I don't speak german or dutch, so I'm not 100% sure of the pluralization here.