### PR TITLE
Compatibility with PHP 7.2 by updating elasticsearch-bundle dependency

### DIFF
--- a/Document/ArticlePageViewObject.php
+++ b/Document/ArticlePageViewObject.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
-use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\ObjectType;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 
 /**
  * Contains page information.
  *
- * @Object
+ * @ObjectType
  */
 class ArticlePageViewObject
 {

--- a/Document/CategoryViewObject.php
+++ b/Document/CategoryViewObject.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
-use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\ObjectType;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 
 /**
  * Contains excerpt information for articles.
  *
- * @Object
+ * @ObjectType
  */
 class CategoryViewObject
 {

--- a/Document/ExcerptViewObject.php
+++ b/Document/ExcerptViewObject.php
@@ -12,14 +12,14 @@
 namespace Sulu\Bundle\ArticleBundle\Document;
 
 use ONGR\ElasticsearchBundle\Annotation\Embedded;
-use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\ObjectType;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Contains excerpt information for articles.
  *
- * @Object
+ * @ObjectType
  */
 class ExcerptViewObject
 {

--- a/Document/LocalizationStateViewObject.php
+++ b/Document/LocalizationStateViewObject.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
-use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\ObjectType;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 
 /**
  * Contains localization state information for articles.
  *
- * @Object
+ * @ObjectType
  */
 class LocalizationStateViewObject
 {

--- a/Document/MediaViewObject.php
+++ b/Document/MediaViewObject.php
@@ -11,14 +11,14 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
-use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\ObjectType;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 use Sulu\Bundle\MediaBundle\Api\Media;
 
 /**
  * Contains the ids and display-options.
  *
- * @Object
+ * @ObjectType
  */
 class MediaViewObject
 {

--- a/Document/SeoViewObject.php
+++ b/Document/SeoViewObject.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
-use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\ObjectType;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 
 /**
  * Contains seo information for articles.
  *
- * @Object
+ * @ObjectType
  */
 class SeoViewObject
 {

--- a/Document/TagViewObject.php
+++ b/Document/TagViewObject.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document;
 
-use ONGR\ElasticsearchBundle\Annotation\Object;
+use ONGR\ElasticsearchBundle\Annotation\ObjectType;
 use ONGR\ElasticsearchBundle\Annotation\Property;
 
 /**
  * Contains excerpt information for articles.
  *
- * @Object
+ * @ObjectType
  */
 class TagViewObject
 {

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For detailed requirements see [composer.json](https://github.com/sulu/SuluArticl
 Our dependency `ongr/elasticsearch-bundle`
 (see [ongr-io/ElasticsearchBundle#832](https://github.com/ongr-io/ElasticsearchBundle/issues/832) and 
 [ongr-io/ElasticsearchBundle#828](https://github.com/ongr-io/ElasticsearchBundle/issues/828)) isn't supporting
-PHP `^7.2` and Elasticsearch `^6.0`.
+Elasticsearch `^6.0`.
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "sulu/sulu": "^1.6.8",
-        "ongr/elasticsearch-bundle": "^1.2.9 || ~5.0",
+        "ongr/elasticsearch-bundle": "^1.2.9 || ^5.2",
         "ongr/elasticsearch-dsl": "^2.2.2 || ~5.0",
         "jackalope/jackalope": "^1.2.8 || >=1.3.3",
         "jms/serializer-bundle": "^1.1 || ^2.0"
@@ -22,10 +22,6 @@
         "sulu/automation-bundle": "^1.2",
         "php-task/task-bundle": "^1.2",
         "php-task/php-task": "^1.2"
-    },
-    "conflict": {
-        "php": "^7.2",
-        "ongr/elasticsearch-bundle": "^5.0.6"
     },
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | #304 (the "PHP 7.2" part)
| License | MIT

#### What's in this PR?

Ensures compatiblity with PHP 7.2 by raising ongr/elasticsearch-bundle version to ^5.2, which is certified to work with PHP 7.2. Also contains the necessary renaming of the "Object" annotation to "ObjectType" (object is a reserved keyword starting in PHP 7.2)

#### Why?

SuluArticleBundle should be able to work with the most current supported PHP version.

#### Example Usage

Just do it.

#### BC Breaks/Deprecations

None that I am aware of

#### To Do

?