### PR TITLE
Fix Smart-Content syntax in documentation example

### DIFF
--- a/Resources/doc/article-types.md
+++ b/Resources/doc/article-types.md
@@ -33,7 +33,7 @@ This key can the be used to translate the key with the
 The type can also be used to predefine a filter for the smart-content provider for articles. You can simply add the following param to the template definition:
 
 ```xml
-<property name="articles" type="smart-content">
+<property name="articles" type="smart_content">
     <params>
         <param name="types" value="my_article_type,my_custom_article_type"/>
     </params>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #334 
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

A simple documentation typo fix
