### PR TITLE
Fix travis for php 5.5 and symfony < 3.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,14 @@ addons:
 before_install:
   - sudo update-java-alternatives -s java-8-oracle
   - export JAVA_HOME=/usr/lib/jvm/java-8-oracle/jre
+  - if [[ -z $CODE_COVERAGE ]]; then phpenv config-rm xdebug.ini ; fi
+  - phpenv config-add Tests/travis.php.ini
+  - composer self-update
+
+install:
+  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan --no-update ; fi
+  - composer update $COMPOSER_FLAGS
+  - composer info -i
   - java -version
   - |
     if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then
@@ -45,17 +53,9 @@ before_install:
         fi
         java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
     fi
-  - if [[ -z $CODE_COVERAGE ]]; then phpenv config-rm xdebug.ini ; fi
-  - phpenv config-add Tests/travis.php.ini
-  - composer self-update
   - curl -L -o elasticsearch.zip ${ES_DOWNLOAD_URL}
   - unzip elasticsearch.zip
   - ./elasticsearch-*/bin/elasticsearch -d
-
-install:
-  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan --no-update ; fi
-  - composer update $COMPOSER_FLAGS
-  - composer info -i
   - ./Tests/app/console doctrine:database:create
   - ./Tests/app/console doctrine:schema:update --force
   - ./Tests/app/console sulu:document:initialize

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,11 @@ before_install:
   - if [[ -z $CODE_COVERAGE ]]; then phpenv config-rm xdebug.ini ; fi
   - phpenv config-add Tests/travis.php.ini
   - | # enable swap
-    /bin/dd if=/dev/zero of=/var/swap.1 bs=1M count=1024
-    /sbin/mkswap /var/swap.1
-    /sbin/swapon /var/swap.1
+    sudo fallocate -l 4G /swapfile
+    sudo chmod 600 /swapfile
+    sudo mkswap /swapfile
+    sudo swapon /swapfile
+    sudo sysctl vm.swappiness=10
   - composer self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction -vvv"
         - ES_VERSION="2.4.4"
         - ES_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.zip"
+        - ENABLE_SWAP=true
     - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
@@ -38,11 +39,13 @@ before_install:
   - if [[ -z $CODE_COVERAGE ]]; then phpenv config-rm xdebug.ini ; fi
   - phpenv config-add Tests/travis.php.ini
   - | # enable swap
-    sudo fallocate -l 4G /swapfile
-    sudo chmod 600 /swapfile
-    sudo mkswap /swapfile
-    sudo swapon /swapfile
-    sudo sysctl vm.swappiness=10
+    if [[ $ENABLE_SWAP == 'true' ]]; then
+        sudo fallocate -l 4G /swapfile
+        sudo chmod 600 /swapfile
+        sudo mkswap /swapfile
+        sudo swapon /swapfile
+        sudo sysctl vm.swappiness=10
+    fi
   - composer self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   include:
     - php: 5.5
       env:
-        - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
+        - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction -vvv"
         - ES_VERSION="2.4.4"
         - ES_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.zip"
     - php: 7.2
@@ -53,7 +53,8 @@ before_install:
   - ./elasticsearch-*/bin/elasticsearch -d
 
 install:
-  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan $COMPOSER_FLAGS ; else travis_retry composer update $COMPOSER_FLAGS ; fi
+  - if [[ $PHPSTAN == 'true' ]]; then travis_retry composer require --dev phpstan/phpstan --no-update ; fi
+  - composer update $COMPOSER_FLAGS
   - composer info -i
   - ./Tests/app/console doctrine:database:create
   - ./Tests/app/console doctrine:schema:update --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ before_install:
   - export JAVA_HOME=/usr/lib/jvm/java-8-oracle/jre
   - if [[ -z $CODE_COVERAGE ]]; then phpenv config-rm xdebug.ini ; fi
   - phpenv config-add Tests/travis.php.ini
+  - | # enable swap
+    /bin/dd if=/dev/zero of=/var/swap.1 bs=1M count=1024
+    /sbin/mkswap /var/swap.1
+    /sbin/swapon /var/swap.1
   - composer self-update
 
 install:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
                             return ['default' => $v];
                         })
                     ->end()
-                    ->prototype('array')->useAttributeAsKey('locale')->scalarPrototype()->end()->end()
+                    ->prototype('array')->useAttributeAsKey('locale')->prototype('scalar')->end()->end()
                     ->defaultValue([])
                 ->end()
                 ->arrayNode('smart_content')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
                             return ['default' => $v];
                         })
                     ->end()
-                    ->arrayPrototype()->useAttributeAsKey('locale')->scalarPrototype()->end()->end()
+                    ->prototype('array')->useAttributeAsKey('locale')->scalarPrototype()->end()->end()
                     ->defaultValue([])
                 ->end()
                 ->arrayNode('smart_content')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added debug output for composer install for php 5.5.
Fix incompatibility to symfony < 3.3 with arrayPrototype.

#### Why?

To avoid stalled build on travis and fix compatibility to symfony <3.3.

