### PR TITLE
Fix compatibility to symfony 3.4.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           keys:
             - composer-v2-{{ checksum "composer.json" }}
             - composer-v2-
-      - run: php -d memory_limit=2G /usr/local/bin/composer install -n --prefer-dist
+      - run: php -d memory_limit=-1 /usr/local/bin/composer install -n --prefer-dist
       - save_cache:
           key: composer-v2-{{ checksum "composer.json" }}
           paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - ES_VERSION="2.4.4"
         - ES_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.zip"
         - ENABLE_SWAP=true
-    - php: 7.2
+    - php: 7.3
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit

--- a/Document/Form/ArticleDocumentType.php
+++ b/Document/Form/ArticleDocumentType.php
@@ -34,7 +34,7 @@ class ArticleDocumentType extends AbstractStructureBehaviorType
         parent::buildForm($builder, $options);
 
         // extensions
-        $builder->add('extensions', TextType::class, ['property_path' => 'extensionsData']);
+        $builder->add('extensions', UnstructuredType::class, ['property_path' => 'extensionsData']);
         $builder->add('shadowLocaleEnabled', CheckboxType::class);
         $builder->add('shadowLocale', TextType::class);
         $builder->add('mainWebspace', TextType::class);

--- a/Document/Form/UnstructuredType.php
+++ b/Document/Form/UnstructuredType.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @internal
+ */
+class UnstructuredType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'compound' => false,
+            'multiple' => true,
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "phpunit/phpunit": "^4.8 || ^5.0",
         "sulu/automation-bundle": "^1.2",
         "php-task/task-bundle": "^1.2",
-        "php-task/php-task": "^1.2"
+        "php-task/php-task": "^1.2",
+        "doctrine/data-fixtures": "^1.0"
     },
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/4349
| License | MIT

#### What's in this PR?

Use unstructured form type for extensions to avoid an error which happens with only scalar values mapping for TextType. And test article bundle as on php 7.3 as now elasticsearch client supports.

#### Why?

Fix compatibility to symfony 3.4.21
