### PR TITLE
Add protected function to allow overwrite the sitemap-url creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,7 @@ matrix:
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit
         - PHPSTAN=true
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
-
 before_install:
-  - sudo update-java-alternatives -s java-8-oracle
-  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle/jre
   - if [[ -z $CODE_COVERAGE ]]; then phpenv config-rm xdebug.ini ; fi
   - phpenv config-add Tests/travis.php.ini
   - | # enable swap


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR enhances the possibility to overwrite the sitemap provider.

#### Why?

When using an own sitemap-template its neccessary to add attributes to a single `SitemapUrl`.