### PR TITLE
Fix getUuid for article-bridge used in content resolver

### DIFF
--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -24,11 +24,32 @@ class ArticleBridge extends StructureBridge
     private $webspaceKey = null;
 
     /**
+     * @var string
+     */
+    private $uuid;
+
+    /**
      * {@inheritdoc}
      */
     public function getView()
     {
         return $this->structure->view;
+    }
+
+    public function getUuid()
+    {
+        // is set for structure loaded with document from document-manager
+        // is not set when using structure with view-document
+        if ($this->document) {
+            return parent::getUuid();
+        }
+
+        return $this->uuid;
+    }
+
+    public function setUuid($uuid)
+    {
+        $this->uuid = $uuid;
     }
 
     /**

--- a/EventListener/ContentProxyListener.php
+++ b/EventListener/ContentProxyListener.php
@@ -51,6 +51,7 @@ class ContentProxyListener
         }
 
         $structure = $this->structureManager->getStructure($document->getStructureType(), 'article');
+        $structure->setUuid($document->getUuid());
         $structure->setLanguageCode($document->getLocale());
 
         list($content, $view) = $this->getProxies($document->getContentData(), $structure);
@@ -59,6 +60,7 @@ class ContentProxyListener
         $document->setView($view);
 
         foreach ($document->getPages() as $page) {
+            $structure->setUuid($page->uuid);
             list($page->content, $page->view) = $this->getProxies($page->contentData, $structure);
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR add the `getUuid` function to `ArticleBridge` because this function is used for resolving content.