### PR TITLE
Removed preview

### DIFF
--- a/Admin/ArticleAdmin.php
+++ b/Admin/ArticleAdmin.php
@@ -139,7 +139,7 @@ class ArticleAdmin extends Admin
                 ->setBackRoute(static::LIST_ROUTE)
                 ->setTitleProperty('title')
                 ->getRoute(),
-            $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_article.edit_form.details', '/details')
+            $this->routeBuilderFactory->createFormRouteBuilder('sulu_article.edit_form.details', '/details')
                 ->setResourceKey('articles')
                 ->setFormKey('article')
                 ->setTabTitle('sulu_admin.details')
@@ -147,14 +147,14 @@ class ArticleAdmin extends Admin
                 ->addToolbarActions($formToolbarActionsWithType)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
-            $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_article.edit_form.seo', '/seo')
+            $this->routeBuilderFactory->createFormRouteBuilder('sulu_article.edit_form.seo', '/seo')
                 ->setResourceKey('articles')
                 ->setFormKey('page_seo')
                 ->setTabTitle('sulu_page.seo')
                 ->addToolbarActions($formToolbarActionsWithoutType)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
-            $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_article.edit_form.excerpt', '/excerpt')
+            $this->routeBuilderFactory->createFormRouteBuilder('sulu_article.edit_form.excerpt', '/excerpt')
                 ->setResourceKey('articles')
                 ->setFormKey('page_excerpt')
                 ->setBackRoute(static::LIST_ROUTE)
@@ -162,7 +162,7 @@ class ArticleAdmin extends Admin
                 ->addToolbarActions($formToolbarActionsWithoutType)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
-            $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_article.edit_form.settings', '/settings')
+            $this->routeBuilderFactory->createFormRouteBuilder('sulu_article.edit_form.settings', '/settings')
                 ->setResourceKey('articles')
                 ->setFormKey('article_settings')
                 ->setBackRoute(static::LIST_ROUTE)

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -151,7 +151,8 @@ class ArticleController extends RestController implements ClassResourceInterface
             $searchFields = ['title'];
         }
 
-        if (!empty($searchPattern = $restHelper->getSearchPattern())) {
+        $searchPattern = $restHelper->getSearchPattern();
+        if (!empty($sarchPattern)) {
             $boolQuery = new BoolQuery();
             foreach ($searchFields as $searchField) {
                 $boolQuery->add(new MatchPhrasePrefixQuery($searchField, $searchPattern), BoolQuery::SHOULD);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Disabled the preview for articles in the Sulu admin.

#### Why?

The preview is not implemented at the moment and therefore an error (dev environment) or an empty preview (prod environment) is shown which is confusing for the user.

#### To Do

- [ ] Add documentation page
