### PR TITLE
Avoid prepend of ongr analyzers

### DIFF
--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -242,18 +242,6 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
             $hosts = $config['hosts'];
 
             $ongrElasticSearchConfig = [
-                'analysis' => [
-                    'tokenizer' => [
-                        'pathTokenizer' => [
-                            'type' => 'path_hierarchy',
-                        ],
-                    ],
-                    'analyzer' => [
-                        'pathAnalyzer' => [
-                            'tokenizer' => 'pathTokenizer',
-                        ],
-                    ],
-                ],
                 'managers' => [
                     'default' => [
                         'index' => [

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -47,6 +47,16 @@ sulu_core:
 sulu_article:
     index_name: su_articles
     hosts: ['127.0.0.1:9200']
+
+# config/packages/ongr_elasticsearch.yaml
+ongr_elasticsearch:
+    analysis:
+        tokenizer:
+            pathTokenizer:
+                type: path_hierarchy
+        analyzer:
+            pathAnalyzer:
+                tokenizer: pathTokenizer
 ```
 
 ### Configure the routing

--- a/Tests/Application/config/config.yml
+++ b/Tests/Application/config/config.yml
@@ -43,3 +43,12 @@ sulu_article:
     index_name: "su_articles_tests"
     hosts: ["%elasticsearch_host%"]
     default_main_webspace: 'sulu_io'
+
+ongr_elasticsearch:
+    analysis:
+        tokenizer:
+            pathTokenizer:
+                type: path_hierarchy
+        analyzer:
+            pathAnalyzer:
+                tokenizer: pathTokenizer


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Removed analysis from ONGR ElasticSearch config.

#### Why?

To fix configuration issues.