### PR TITLE
Fixed article type in example article template.

### DIFF
--- a/Resources/doc/article_default.xml
+++ b/Resources/doc/article_default.xml
@@ -15,7 +15,7 @@
         <title lang="de">Standard</title>
     </meta>
 
-    <tag name="sulu_article.type" type="article"/>
+    <tag name="sulu_article.type" type="article_default"/>
 
     <properties>
         <section name="highlight">


### PR DESCRIPTION
The sulu_article.type now reflects the suggested default configuration that is using "article_default" as the article type.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| Related issues/PRs | N/A
| License | MIT

#### What's in this PR?

Added a fix to the `article_default.xml` template present in the documentation.

#### Why?

The default template suggested by the documentation was using a `sulu_article.type` tag that did not match the proposed configuration which is using `article_default`. This was causing issues when loading the articles list and creating new articles as the queries were using a wrong type identifier.

#### Example Usage

Nothing special, the default template can now be used event without overriding the article type.

#### BC Breaks/Deprecations

N/A

#### To Do

N/A