### PR TITLE
fix some incorrect type annotations

### DIFF
--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -106,7 +106,7 @@ class ReindexCommand extends Command
         if (!$this->dropIndex($indexer, $input, $output)) {
             // Drop was canceled by user.
 
-            return;
+            return 0;
         }
 
         $indexer->createIndex();

--- a/Content/ArticleDataItem.php
+++ b/Content/ArticleDataItem.php
@@ -83,6 +83,6 @@ class ArticleDataItem implements ItemInterface
      */
     public function getImage()
     {
-        return;
+        return '';
     }
 }

--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Content;
 
+use ONGR\ElasticsearchBundle\Result\DocumentIterator;
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
@@ -202,7 +203,7 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
      */
     public function resolveDatasource($datasource, array $propertyParameter, array $options)
     {
-        return;
+        return null;
     }
 
     /**
@@ -259,7 +260,7 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
      * @param string $locale
      * @param null|string $webspaceKey
      *
-     * @return \Countable
+     * @return DocumentIterator|\ArrayIterator
      */
     private function getSearchResult(array $filters, $limit, $page, $pageSize, $locale, $webspaceKey)
     {
@@ -298,7 +299,7 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
      * @param array $filters
      * @param string $locale
      *
-     * @return Search
+     * @return Search|null
      */
     protected function createSearch(Search $search, array $filters, $locale)
     {

--- a/Content/PageTreeArticleDataProvider.php
+++ b/Content/PageTreeArticleDataProvider.php
@@ -36,7 +36,7 @@ class PageTreeArticleDataProvider extends ArticleDataProvider
     public function resolveDatasource($datasource, array $propertyParameter, array $options)
     {
         if (!$datasource) {
-            return;
+            return null;
         }
 
         $document = $this->documentManager->find($datasource, $options['locale']);
@@ -50,7 +50,7 @@ class PageTreeArticleDataProvider extends ArticleDataProvider
     protected function createSearch(Search $search, array $filters, $locale)
     {
         if (!array_key_exists('dataSource', $filters) || !$filters['dataSource']) {
-            return;
+            return null;
         }
 
         $search = parent::createSearch($search, $filters, $locale);

--- a/Content/PageTreeRouteContentType.php
+++ b/Content/PageTreeRouteContentType.php
@@ -189,19 +189,19 @@ class PageTreeRouteContentType extends SimpleContentType
      * @param string $propertyName
      * @param NodeInterface $node
      *
-     * @return array
+     * @return array|null
      */
     private function readPage($propertyName, NodeInterface $node)
     {
         $pagePropertyName = $propertyName . '-page';
         if (!$node->hasProperty($pagePropertyName)) {
-            return;
+            return null;
         }
 
         try {
             $pageUuid = $node->getPropertyValue($pagePropertyName, PropertyType::STRING);
         } catch (ItemNotFoundException $exception) {
-            return;
+            return null;
         }
 
         return [

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -434,7 +434,7 @@ class ArticleController extends RestController implements ClassResourceInterface
      *
      * @Post("/articles/{id}")
      *
-     * @param string $uuid
+     * @param string $id
      * @param Request $request
      *
      * @return Response

--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -102,7 +102,7 @@ class WebsiteArticleController extends Controller
      *
      * @param ArticleInterface $object
      *
-     * @return ArticleDocument
+     * @return ArticleDocument|ArticleInterface
      */
     protected function normalizeArticle(ArticleInterface $object)
     {
@@ -156,7 +156,6 @@ class WebsiteArticleController extends Controller
         $twig = $this->get('twig');
         $attributes = $twig->mergeGlobals($attributes);
 
-        /** @var Template $template */
         $template = $twig->loadTemplate($template);
 
         $level = ob_get_level();

--- a/Document/Form/Listener/DataNormalizer.php
+++ b/Document/Form/Listener/DataNormalizer.php
@@ -22,8 +22,7 @@ class DataNormalizer
     /**
      * Normalize incoming data from the legacy node controller.
      *
-     * @param mixed $data
-     * @param mixed $state Translates to the workflow state
+     * @param FormEvent $event
      */
     public static function normalize(FormEvent $event)
     {

--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -333,13 +333,13 @@ class RoutableSubscriber implements EventSubscriberInterface
      * @param RoutablePageBehavior $document
      * @param string $locale
      *
-     * @return RouteInterface
+     * @return RouteInterface|null
      */
     private function reallocateExistingRoute(RoutablePageBehavior $document, $locale)
     {
         $newRoute = $this->routeRepository->findByPath($document->getRoutePath(), $locale);
         if (!$newRoute) {
-            return;
+            return null;
         }
 
         $oldRoute = $this->routeRepository->findByEntity(get_class($document), $document->getUuid(), $locale);

--- a/PageTree/PageTreeRepository.php
+++ b/PageTree/PageTreeRepository.php
@@ -196,7 +196,7 @@ class PageTreeRepository implements PageTreeUpdaterInterface, PageTreeMoverInter
      *
      * @param StructureMetadata $metadata
      *
-     * @return PropertyMetadata
+     * @return PropertyMetadata|null
      */
     private function getRoutePathPropertyName(StructureMetadata $metadata)
     {
@@ -205,7 +205,7 @@ class PageTreeRepository implements PageTreeUpdaterInterface, PageTreeMoverInter
         }
 
         if (!$metadata->hasProperty(self::ROUTE_PROPERTY)) {
-            return;
+            return null;
         }
 
         return $metadata->getProperty(self::ROUTE_PROPERTY);

--- a/Preview/ArticleObjectProvider.php
+++ b/Preview/ArticleObjectProvider.php
@@ -43,7 +43,7 @@ class ArticleObjectProvider implements PreviewObjectProviderInterface
     /**
      * @param DocumentManagerInterface $documentManager
      * @param SerializerInterface $serializer
-     * @param $articleDocumentClass
+     * @param string $articleDocumentClass
      */
     public function __construct(
         DocumentManagerInterface $documentManager,
@@ -143,8 +143,6 @@ class ArticleObjectProvider implements PreviewObjectProviderInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @param ArticleDocument $object
      */
     public function deserialize($serializedObject, $objectClass)
     {
@@ -168,6 +166,7 @@ class ArticleObjectProvider implements PreviewObjectProviderInterface
 
         $children = array_values($article->getChildren());
 
+        /* @var ArticleDocument $object */
         $object = $children[$result['pageNumber'] - 2];
 
         return $object;

--- a/Resolver/ArticleContentResolver.php
+++ b/Resolver/ArticleContentResolver.php
@@ -88,7 +88,7 @@ class ArticleContentResolver implements ArticleContentResolverInterface
      * @param ArticleDocument $article
      * @param int $pageNumber
      *
-     * @return ArticleDocument
+     * @return ArticleDocument|ArticlePageDocument
      */
     private function getArticleForPage(ArticleDocument $article, $pageNumber)
     {

--- a/Teaser/ArticleTeaserProvider.php
+++ b/Teaser/ArticleTeaserProvider.php
@@ -45,7 +45,7 @@ class ArticleTeaserProvider implements TeaserProviderInterface
     /**
      * @param Manager $searchManager
      * @param TranslatorInterface $translator
-     * @param $articleDocumentClass
+     * @param string $articleDocumentClass
      */
     public function __construct(Manager $searchManager, TranslatorInterface $translator, $articleDocumentClass)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?
It has come to my attention that several type annotations are incorrect.
This pull request solves several of the issues within the SuluArticleBundle.

#### Why?

Sometimes things are hard to read and to use when something unexpected is returned.
I also like a plugin that is called "Php Inspections ​(EA Extended)" and it often shows me something is not as good as it could be.

#### Example Usage

Compare output between before and after running phpstan.
``php -d memory_limit=1G vendor/bin/phpstan analyze -l 3``