### PR TITLE
Fix typo in the variable name

### DIFF
--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -209,17 +209,17 @@ class ReindexCommand extends Command
             return;
         }
 
-        $progessBar = new ProgressBar($output, $count);
-        $progessBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%');
-        $progessBar->start();
+        $progressBar = new ProgressBar($output, $count);
+        $progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%');
+        $progressBar->start();
 
         foreach ($documents as $document) {
             $indexer->index($document);
-            $progessBar->advance();
+            $progressBar->advance();
         }
 
         $indexer->flush();
-        $progessBar->finish();
+        $progressBar->finish();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #352
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

This PR fixes the spelling of a variable.

| Step | Variable name
| --- | ---
| Before | $progessBar
| After | $prog**r**essBar

#### Why?

There is a typo in the variable name.