### PR TITLE
Add the JSON extension to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": "^7.2",
+        "ext-json": "*",
         "elasticsearch/elasticsearch": "~5.0 || ~6.0",
         "jms/serializer": "^3.3",
         "jms/serializer-bundle": "^3.3",


### PR DESCRIPTION
… work without the extension

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Add the JSON extension of PHP to the composer.json file.
Please note the order of other entries change, too because the composer option "sort-packages" was ignored before. That'll likely happen when someone manually edits the file.

#### Why?

Although PHP ships with the JSON extension by default this may not be always the case.
https://www.php.net/manual/en/json.installation.php

It is better to check if the system fulfills the dependencies _before_ installing.

#### Example Usage

~~~bash
php -d memory_limit=1G composer.phar install
~~~
