### PR TITLE
Dispatch index event for ghost articles

### DIFF
--- a/Document/Index/ArticleGhostIndexer.php
+++ b/Document/Index/ArticleGhostIndexer.php
@@ -146,6 +146,7 @@ class ArticleGhostIndexer extends ArticleIndexer
             );
 
             if ($article) {
+                $this->dispatchIndexEvent($ghostDocument, $article);
                 $this->manager->persist($article);
             }
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Dispatches the index event for ghost articles.

#### Why?

To allow programmers to edit or add fields before indexing them.
