### PR TITLE
Update PageTreeArticleDataProvider datasource and translation keys

### DIFF
--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -120,11 +120,11 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
             ->enablePresentAs()
             ->enableSorting(
                 [
-                    ['column' => 'published', 'title' => 'sulu_article.smart-content.published'],
-                    ['column' => 'authored', 'title' => 'sulu_article.smart-content.authored'],
-                    ['column' => 'created', 'title' => 'sulu_article.smart-content.created'],
-                    ['column' => 'title', 'title' => 'sulu_article.smart-content.title'],
-                    ['column' => 'author_full_name', 'title' => 'sulu_article.smart-content.author-full-name'],
+                    ['column' => 'published', 'title' => 'sulu_admin.published'],
+                    ['column' => 'authored', 'title' => 'sulu_admin.authored'],
+                    ['column' => 'created', 'title' => 'sulu_admin.created'],
+                    ['column' => 'title.raw', 'title' => 'sulu_admin.title'],
+                    ['column' => 'author_full_name.raw', 'title' => 'sulu_admin.author'],
                 ]
             );
     }

--- a/Content/PageTreeArticleDataProvider.php
+++ b/Content/PageTreeArticleDataProvider.php
@@ -26,7 +26,7 @@ class PageTreeArticleDataProvider extends ArticleDataProvider
     public function getConfiguration()
     {
         return $this->getConfigurationBuilder()
-            ->enableDatasource('articles', 'articles', 'table')
+            ->enableDatasource('pages', 'pages', 'column_list')
             ->getConfiguration();
     }
 

--- a/Tests/Functional/Content/PageTreeArticleDataProviderTest.php
+++ b/Tests/Functional/Content/PageTreeArticleDataProviderTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\ArticleBundle\Tests\Functional\Content;
 use Ferrandini\Urlizer;
 use ONGR\ElasticsearchBundle\Service\Manager;
 use Ramsey\Uuid\Uuid;
+use Sulu\Bundle\ArticleBundle\Content\PageTreeArticleDataProvider;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\SmartContent\DataProviderResult;
@@ -55,6 +56,37 @@ class PageTreeArticleDataProviderTest extends SuluTestCase
         $this->assertInstanceOf(DataProviderResult::class, $result);
         $this->assertCount(1, $result->getItems());
         $this->assertEquals($articles[0]['id'], $result->getItems()[0]->getId());
+    }
+
+    public function testSortByTitle()
+    {
+        $page1 = $this->createPage('Test Page', '/page-1');
+
+        $articles = [
+            $this->createArticle($page1, 'Test A'),
+            $this->createArticle($page1, 'Test B'),
+        ];
+
+        $filters = [
+            'dataSource' => $page1->getUuid(),
+            'sortBy' => 'title.raw',
+            'sortMethod' => 'asc',
+        ];
+
+        /** @var PageTreeArticleDataProvider $dataProvider */
+        $dataProvider = $this->getContainer()->get('sulu_article.content.page_tree_data_provider');
+        $result = $dataProvider->resolveDataItems($filters, [], ['locale' => 'de']);
+
+        $this->assertInstanceOf(DataProviderResult::class, $result);
+        $this->assertEquals($articles[0]['title'], $result->getItems()[0]->getTitle());
+        $this->assertEquals($articles[1]['title'], $result->getItems()[1]->getTitle());
+
+        $filters['sortMethod'] = 'desc';
+
+        $result = $dataProvider->resolveDataItems($filters, [], ['locale' => 'de']);
+        $this->assertInstanceOf(DataProviderResult::class, $result);
+        $this->assertEquals($articles[0]['title'], $result->getItems()[1]->getTitle());
+        $this->assertEquals($articles[1]['title'], $result->getItems()[0]->getTitle());
     }
 
     public function testResolveDataSource()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Changes the `PageTreeArticleDataProvider` datasource from `articles` to `pages`.
Adjusts the sulu-translations to existing ones.
Adds a test for sorting the smart-content for title.

#### Why?

Because the datasource for the `PageTreeArticleDataProvider` should be a page and not articles.