### PR TITLE
fix urls

### DIFF
--- a/Document/Serializer/WebsiteArticleUrlsSubscriber.php
+++ b/Document/Serializer/WebsiteArticleUrlsSubscriber.php
@@ -54,7 +54,7 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
         return [
             [
                 'event' => Events::POST_SERIALIZE,
-                'format' => 'array',
+                'format' => 'json',
                 'method' => 'addUrlsOnPostSerialize',
             ],
         ];
@@ -72,7 +72,7 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
         $context = $event->getContext();
         $request = $this->requestStack->getCurrentRequest();
 
-        if (!$article instanceof ArticleDocument || !$context->hasAttribute('website') || !$request) {
+        if (!$article instanceof ArticleDocument || !$context->hasAttribute('urls') || !$request) {
             return;
         }
 

--- a/Resolver/ArticleContentResolver.php
+++ b/Resolver/ArticleContentResolver.php
@@ -62,6 +62,7 @@ class ArticleContentResolver implements ArticleContentResolverInterface
                 ->setSerializeNull(true)
                 ->setGroups(['website', 'content'])
                 ->setAttribute('pageNumber', $pageNumber)
+                ->setAttribute('urls', true)
         );
 
         if ($article instanceof ArticlePageDocument) {

--- a/Tests/Unit/Document/Serializer/WebsiteArticleUrlsSubscriberTest.php
+++ b/Tests/Unit/Document/Serializer/WebsiteArticleUrlsSubscriberTest.php
@@ -73,7 +73,7 @@ class WebsiteArticleUrlsSubscriberTest extends TestCase
         $visitor = $this->prophesize(SerializationVisitorInterface::class);
 
         $context = $this->prophesize(SerializationContext::class);
-        $context->hasAttribute('website')->willReturn(true);
+        $context->hasAttribute('urls')->willReturn(true);
 
         $entityId = '123-123-123';
         $article->getUuid()->willReturn($entityId);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

A fix for `urls` property

#### Why?

Because `urls` returned an array of the same urls for each locale.
