### PR TITLE
Add support for elasticsearch 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
     docker:
       - image: circleci/php:7.1-node-browsers
         environment:
-          - ES_VERSION=6.5.4
           - ARTICLE_TEST_CASE=extend
       - image: circleci/mysql:5.7
         environment:
@@ -13,6 +12,14 @@ jobs:
           - MYSQL_PASSWORD=
           - MYSQL_ALLOW_EMPTY_PASSWORD=true
           - MYSQL_DATABASE=circle_test
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+        environment:
+          - cluster.name: es-test-cluster
+          - xpack.security.enabled: false
+          - transport.host: localhost
+          - network.host: 127.0.0.1
+          - http.port: 9200
+          - discovery.type: single-node
     steps:
       - checkout
       - run: 
@@ -21,28 +28,17 @@ jobs:
             sudo apt-get install -y libpng-dev
             sudo docker-php-ext-install pdo_mysql gd
           parallel: true
-      - run:
-          name: Install Elasticsearch
-          command: |
-            curl -L -o elasticsearch.zip https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip
-            unzip elasticsearch.zip
-          parallel: true
-      - run: sudo composer self-update
+      - run: sudo composer self-update --snapshot
       - restore_cache:
           keys:
             - composer-v2-{{ checksum "composer.json" }}
             - composer-v2-
-      - run: php -d memory_limit=-1 /usr/local/bin/composer install -n --prefer-dist
+      - run: php -d memory_limit=2G /usr/local/bin/composer install -n --prefer-dist
       - save_cache:
           key: composer-v2-{{ checksum "composer.json" }}
           paths:
             - vendor
             - ~/.composer/cache
-      - run:
-          name: Run Elasticsearch
-          command: |
-            ES_JAVA_OPTS="-Xms512m -Xmx1024m" ./elasticsearch-${ES_VERSION}/bin/elasticsearch
-          background: true
       - run:
           name: Test Elasticsearch
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ env:
   global:
     - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
     - JACKRABBIT_VERSION=2.12.0
-    - SYMFONY__PHPCR__TRANSPORT=doctrinedbal
     - SYMFONY__DATABASE__VERSION=5.5.39
-    - ES_VERSION="6.5.4"
-    - ES_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip"
 
 cache:
   directories:
@@ -23,12 +20,13 @@ matrix:
     - php: 5.6
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction -vvv"
-        - ES_VERSION="5.6.14"
-        - ES_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip"
+        - ES_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.14.tar.gz"
+        - SYMFONY__PHPCR__TRANSPORT=doctrinedbal
         - ENABLE_SWAP=true
     - php: 7.3
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
+        - ES_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.2-linux-x86_64.tar.gz"
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit
         - PHPSTAN=true
 
@@ -60,7 +58,7 @@ install:
         java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
     fi
   - wget ${ES_DOWNLOAD_URL}
-  - unzip elasticsearch-*.zip
+  - tar xvzf elasticsearch-*.tar.gz
   - cd ./elasticsearch-*
   - bin/elasticsearch -d
   - cd ..

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Additional features included:
 * Composer
 * PHP `^5.5 || ^7.0`
 * Sulu `^1.6`
-* Elasticsearch `^5.0 || ^6.0`
+* Elasticsearch `^5.0 || ^6.0 || ^7.0`
 
 For detailed requirements see [composer.json](https://github.com/sulu/SuluArticleBundle/blob/master/composer.json).
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -2,13 +2,14 @@
 
 ### ElasticSearch
 
-The SuluArticleBundle requires a running elasticsearch `^5.0` or `^6.0`.
+The SuluArticleBundle requires a running elasticsearch `^5.0`, `^6.0` or `^7.0`.
 
 For elasticsearch `^2.0` see the [1.0.x](https://github.com/sulu/SuluArticleBundle/tree/release/1.0) version of the bundle.
 
-## Install the bundle
+## Install dependencies
 
 ```bash
+composer require elasticsearch/elasticsearch:^7.0 # use matching elasticsearch version
 composer require sulu/article-bundle
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,14 @@
         "php": "^5.6 || ^7.0",
         "sulu/sulu": "^1.6.8",
         "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.2",
-        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1",
+        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
         "jackalope/jackalope": "^1.2.8 || >=1.3.3",
         "jms/serializer-bundle": "^1.1 || ^2.0"
     },
     "require-dev": {
+        "elasticsearch/elasticsearch": "^5.0 || ^6.0 || ^7.0",
         "massive/build-bundle": "~0.3.0",
-        "zendframework/zend-stdlib": "~2.3",
-        "zendframework/zendsearch": "@dev",
+        "handcraftedinthealps/zendsearch": "^2.0",
         "symfony/monolog-bundle": "^2.8.7 || ^3.0",
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
         "jackalope/jackalope-jackrabbit": "^1.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #431, fixes #485 
| Related issues/PRs | https://github.com/ongr-io/ElasticsearchBundle/pull/909,  <br/> https://github.com/ongr-io/ElasticsearchDSL/pull/324, <br/> https://github.com/ongr-io/ElasticsearchBundle/pull/946
| License | MIT

#### What's in this PR?

Test Travis with ES7.

#### Why?

Add support for elasticsearch 7.

#### Example Usage

Use ES7 and run tests.

#### To Do

- [x] Add documentation page
- [x] Update README.md