### PR TITLE
Add edit dropdown button with remove draft and publish to toolbar

### DIFF
--- a/Admin/ArticleAdmin.php
+++ b/Admin/ArticleAdmin.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\ArticleBundle\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -113,10 +114,46 @@ class ArticleAdmin extends Admin
             )
         );
 
+        $publishDisplayCondition = '(!_permissions || _permissions.live)';
+
         $formToolbarActionsWithType = [
-            new ToolbarAction('sulu_admin.save_with_publishing'),
-            new ToolbarAction('sulu_admin.type'),
-            new ToolbarAction('sulu_admin.delete'),
+            new ToolbarAction(
+                'sulu_admin.save_with_publishing',
+                [
+                    'publish_visible_condition' => '(!_permissions || _permissions.live)',
+                    'save_visible_condition' => '(!_permissions || _permissions.edit)',
+                ]
+            ),
+            new ToolbarAction(
+                'sulu_admin.type',
+                [
+                    'disabled_condition' => '(_permissions && !_permissions.edit)',
+                ]
+            ),
+            new ToolbarAction(
+                'sulu_admin.delete',
+                [
+                    'visible_condition' => '(!_permissions || _permissions.delete)',
+                ]
+            ),
+            new DropdownToolbarAction(
+                'sulu_admin.edit',
+                'su-pen',
+                [
+                    new ToolbarAction(
+                        'sulu_admin.delete_draft',
+                        [
+                            'visible_condition' => $publishDisplayCondition,
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.set_unpublished',
+                        [
+                            'visible_condition' => $publishDisplayCondition,
+                        ]
+                    ),
+                ]
+            ),
         ];
 
         $formToolbarActionsWithoutType = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR add the edit button to the article form and set the disables/visible conditions to the other buttons.

#### Why?

This is a missing feature in 2.0

