### PR TITLE
Add StructureManager to admin service configuration

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -27,6 +27,7 @@
             <argument type="service" id="sulu_admin.view_builder_factory"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.core.localization_manager"/>
+            <argument type="service" id="sulu.content.structure_manager"/>
             <argument>%kernel.bundles%</argument>
 
             <tag name="sulu.admin"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Adds the missing StructureManager to ArticleAdmin in the service configuration.