### PR TITLE
Fix locale specific indexing of articles

### DIFF
--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -146,7 +146,7 @@ class ArticleSubscriber implements EventSubscriberInterface
             $document = $document->getParent();
         }
 
-        $this->documents[$document->getUuid()] = [
+        $this->documents[$document->getUuid() . '_' . $document->getLocale()] = [
             'uuid' => $document->getUuid(),
             'locale' => $document->getLocale(),
         ];
@@ -166,7 +166,7 @@ class ArticleSubscriber implements EventSubscriberInterface
             $document = $document->getParent();
         }
 
-        $this->liveDocuments[$document->getUuid()] = [
+        $this->liveDocuments[$document->getUuid() . '_' . $document->getLocale()] = [
             'uuid' => $document->getUuid(),
             'locale' => $document->getLocale(),
         ];
@@ -245,7 +245,7 @@ class ArticleSubscriber implements EventSubscriberInterface
         $document->setWorkflowStage(WorkflowStage::TEST);
         $this->documentManager->persist($document, $this->documentInspector->getLocale($document));
 
-        $this->documents[$document->getUuid()] = [
+        $this->documents[$document->getUuid() . '_' . $document->getLocale()] = [
             'uuid' => $document->getUuid(),
             'locale' => $document->getLocale(),
         ];
@@ -438,7 +438,7 @@ class ArticleSubscriber implements EventSubscriberInterface
         }
 
         $document = $document->getParent();
-        $this->documents[$document->getUuid()] = [
+        $this->documents[$document->getUuid() . '_' . $document->getLocale()] = [
             'uuid' => $document->getUuid(),
             'locale' => $document->getLocale(),
         ];
@@ -485,7 +485,7 @@ class ArticleSubscriber implements EventSubscriberInterface
         }
 
         $uuid = $event->getCopiedNode()->getIdentifier();
-        $this->documents[$uuid] = [
+        $this->documents[$uuid . '_' . $document->getLocale()] = [
             'uuid' => $uuid,
             'locale' => $document->getLocale(),
         ];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix locale specific indexing of articles.

#### Why?

If you create in the same request or command an article in different languages the other language will accidently overwrite the first language and at the end the index result will not contain any urls strangely.

