### PR TITLE
Better error message when structure not longer exist

### DIFF
--- a/EventListener/ContentProxyListener.php
+++ b/EventListener/ContentProxyListener.php
@@ -49,6 +49,14 @@ class ContentProxyListener
         }
 
         $structure = $this->structureManager->getStructure($document->getStructureType(), 'article');
+
+        if (!$structure) {
+            throw new \RuntimeException(sprintf(
+                'Could not find article structure from type "%s".',
+                $document->getStructureType()
+            ));
+        }
+
         $structure->setUuid($document->getUuid());
         $structure->setLanguageCode($document->getLocale());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Better error message when structure not longer exist.

#### Why?

When the Structure not longer exist the ContentProxyListener does currently throw a strange call `setUuid` on null error message.