### PR TITLE
Add ghost indicator for articles

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -325,6 +325,11 @@ class ArticleController extends AbstractRestController implements ClassResourceI
         $result = [];
         foreach ($searchResult as $document) {
             $documentData = $this->normalize($document['_source'], $fieldDescriptors);
+
+            if ('ghost' == $documentData['localizationState']['state']) {
+                $documentData['ghostLocale'] = $documentData['localizationState']['locale'];
+            }
+
             if (false !== ($index = array_search($documentData['id'], $ids))) {
                 $result[$index] = $documentData;
             } else {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/issues/462
| License | MIT

#### What's in this PR?

Adds the ghostLocale attribute for articles, so that the frontend is able to show the ghost indicator
