### PR TITLE
Use load instead LoadTemplate for compatibility with Twig 3

### DIFF
--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -159,7 +159,7 @@ class WebsiteArticleController extends AbstractController
         $twig = $this->getTwig();
 
         $attributes = $twig->mergeGlobals($attributes);
-        $template = $twig->loadTemplate($template);
+        $template = $twig->load($template);
 
         $level = ob_get_level();
         ob_start();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Method loadTemplate was deprecated in Twig 1.28 only for internal use, see this
https://twig.symfony.com/doc/1.x/api.html#rendering-templates and https://twig.symfony.com/doc/1.x/tags/include.html 
With Twig 3.0 this method fail:
```
Too few arguments to function Twig\Environment::loadTemplate(), 1 passed in /var/www/html/vendor/sulu/article-bundle/Controller/WebsiteArticleController.php on line 162 and at least 2 expected
```

#### BC Breaks/Deprecations

No BC Breaks. This bundle requires ^1.41

