### PR TITLE
Fix multiple types filter

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -241,7 +241,7 @@ class ArticleController extends AbstractRestController implements ClassResourceI
 
             if (count($types) > 1) {
                 $query = new BoolQuery();
-                
+
                 foreach ($types as $type) {
                     $query->add(new MatchQuery('type', $type), BoolQuery::SHOULD);
                 }

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -241,10 +241,11 @@ class ArticleController extends AbstractRestController implements ClassResourceI
 
             if (count($types) > 1) {
                 $query = new BoolQuery();
-
+                
                 foreach ($types as $type) {
-                    $query->add(new TermQuery('type', $type));
+                    $query->add(new MatchQuery('type', $type), BoolQuery::SHOULD);
                 }
+                $search->addQuery($query);
             } elseif ($types[0]) {
                 $search->addQuery(new TermQuery('type', $types[0]));
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

A fix about multiple filter types

#### Why?

When i've used this config :

```xml
<property name="articleLink1" type="single_article_selection" mandatory="false">
	    <meta>
	        <title lang="fr">Article 1</title>
	    </meta>
	    <params>
        	<param name="types" value="former,accompagner"/>      	
        </params>        
</property>
```

The filter not working anymore on the article picker, but it was ok with just one value

#### Example Usage

~~~php
// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)

$foo = new Foo();

// Now we can do
$foo->doSomething();
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Add documentation page
