### PR TITLE
Fix nullable excerpt images

### DIFF
--- a/Document/Index/Factory/ExcerptFactory.php
+++ b/Document/Index/Factory/ExcerptFactory.php
@@ -62,8 +62,8 @@ class ExcerptFactory
         $excerpt->description = $data['description'];
         $excerpt->tags = $this->tagCollectionFactory->create($data['tags']);
         $excerpt->categories = $this->categoryCollectionFactory->create($data['categories'], $locale);
-        $excerpt->icon = $this->mediaCollectionFactory->create($data['icon'], $locale);
-        $excerpt->images = $this->mediaCollectionFactory->create($data['images'], $locale);
+        $excerpt->icon = $this->mediaCollectionFactory->create($data['icon'] ?? [], $locale);
+        $excerpt->images = $this->mediaCollectionFactory->create($data['images'] ?? [], $locale);
 
         return $excerpt;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

The images/icons of the excerpt can be empty by the database.

#### Why?

The MediaCollectionFactory requires the array type for the data parameter.