### PR TITLE
Fix mapping of article-media object

### DIFF
--- a/Document/MediaViewObject.php
+++ b/Document/MediaViewObject.php
@@ -46,7 +46,7 @@ class MediaViewObject
     /**
      * @var string
      *
-     * @Property(type="keyword")
+     * @Property(type="binary")
      */
     protected $formats = '{}';
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,17 @@
 # Upgrade
 
-## dev-master
+## dev-release/2.0
+
+### Mapping of index changed
+
+Because the length of the indexed formats of the MediaViewObject the type has been changed to `binary`.
+
+To upgrade it run following commands:
+
+```bash
+bin/websiteconsole sulu:article:reindex --drop
+bin/adminconsole sulu:article:reindex --drop
+``` 
 
 ### Teaser Migrations
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

The index data of the formats field can be to long for the default configuraiton of version 6.8.