### PR TITLE
Remove installation instructions that are not necessary anymore

### DIFF
--- a/Resources/doc/default.html.twig
+++ b/Resources/doc/default.html.twig
@@ -1,15 +1,5 @@
 {% extends "base.html.twig" %}
 
-{% block meta %}
-    {% include "SuluWebsiteBundle:Extension:seo.html.twig" with {
-        "seo": extension.seo|default([]),
-        "content": content|default([]),
-        "urls": urls|default([]),
-        "shadowBaseLocale": shadowBaseLocale|default(),
-        "defaultLocale": request.defaultLocale|default('de')
-    } %}
-{% endblock %}
-
 {% block content %}
     <h1>{{ content.title }}</h1>
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -2,23 +2,12 @@
 
 ### ElasticSearch
 
-The SuluArticleBundle requires a running elasticsearch `^5.0`.
+The SuluArticleBundle requires a running elasticsearch `^5.0` or `^6.0`.
 
 ## Install the bundle
 
 ```bash
 composer require sulu/article-bundle
-```
-
-### Add bundles to AbstractKernel
-
-The bundle need to be registered after the `SuluCoreBundle` and `SuluDocumentManagerBundle`.
-
-```php
-/* config/bundles.php */
-
-Sulu\Bundle\ArticleBundle\SuluArticleBundle::class => ['all' => true],
-ONGR\ElasticsearchBundle\ONGRElasticsearchBundle::class => ['all' => true],
 ```
 
 ### Configure SuluArticleBundle and sulu core

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -192,3 +192,17 @@ sulu_article:
         - excerpt.seo.keywords
         - teaser_description
 ```
+
+## Troubleshooting
+
+### Add bundles to AbstractKernel
+
+The bundle need to be registered after the `SuluCoreBundle` and `SuluDocumentManagerBundle`. This should be done
+automatically by Symfony Flex, if that fails for some reason you have to do it manually:
+
+```php		
+/* config/bundles.php */
+       	
+Sulu\Bundle\ArticleBundle\SuluArticleBundle::class => ['all' => true],
+ONGR\ElasticsearchBundle\ONGRElasticsearchBundle::class => ['all' => true],
+```


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT

#### What's in this PR?

This PR adjusts the installation instructions that are not true anymore.

#### Why?

Because otherwise people receive an error while running them, which might confuse them.