### PR TITLE
Set routePath as URL for the search

### DIFF
--- a/Search/ArticleSearchSubscriber.php
+++ b/Search/ArticleSearchSubscriber.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\ArticleBundle\Search;
 use Massive\Bundle\SearchBundle\Search\Event\PreIndexEvent;
 use Massive\Bundle\SearchBundle\Search\Field;
 use Massive\Bundle\SearchBundle\Search\SearchEvents;
-use Sulu\Bundle\ArticleBundle\Document\Behavior\WebspaceBehavior;
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Document\Resolver\WebspaceResolver;
 use Sulu\Bundle\SearchBundle\Search\Factory;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -58,9 +58,11 @@ class ArticleSearchSubscriber implements EventSubscriberInterface
         $subject = $event->getSubject();
         $document = $event->getDocument();
 
-        if (!$subject instanceof WebspaceBehavior) {
+        if (!$subject instanceof ArticleDocument) {
             return;
         }
+
+        $document->setUrl($subject->getRoutePath());
 
         $document->addField(
             $this->factory->createField(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #486
| License | MIT

#### What's in this PR?

Set article routePath as url in the ArticleSearchSubscriber.

#### Why?

To get the correct article url for the search.
