### PR TITLE
Fix pagination default limit for smart content

### DIFF
--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -234,8 +234,14 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
     private function hasNextPage(\Countable $queryResult, $limit, $page, $pageSize)
     {
         $count = $queryResult->count();
-        if ($limit && $limit < $count) {
-            $count = $limit;
+
+        if (null === $pageSize || $pageSize > $this->defaultLimit) {
+            $pageSize = $this->defaultLimit;
+        }
+
+        $offset = ($page - 1) * $pageSize;
+        if ($limit && $offset + $pageSize > $limit) {
+            return false;
         }
 
         return $count > ($page * $pageSize);
@@ -427,22 +433,18 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
      */
     private function addPagination(Search $search, $pageSize, $page, $limit)
     {
-        $offset = 0;
-        if ($pageSize) {
-            $pageSize = intval($pageSize);
-            $offset = ($page - 1) * $pageSize;
+        if (null === $pageSize || $pageSize > $this->defaultLimit) {
+            $pageSize = $this->defaultLimit;
         }
 
-        if (null === $limit) {
-            $limit = $this->defaultLimit;
-        }
+        $offset = ($page - 1) * $pageSize;
 
-        if (null === $pageSize || $offset + $pageSize > $limit) {
+        if ($limit && $offset + $pageSize > $limit) {
             $pageSize = $limit - $offset;
+        }
 
-            if ($pageSize < 0) {
-                $pageSize = 0;
-            }
+        if ($pageSize < 0) {
+            $pageSize = 0;
         }
 
         $search->setFrom($offset);

--- a/Tests/Functional/Content/ArticleDataProviderTest.php
+++ b/Tests/Functional/Content/ArticleDataProviderTest.php
@@ -202,6 +202,34 @@ class ArticleDataProviderTest extends SuluTestCase
         $this->assertFalse($result->getHasNextPage());
     }
 
+    public function testResolveResourceItemsPaginationWithPageSizeSmallerThanDefaultLimit()
+    {
+        $items = [
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+            $this->createArticle(),
+        ];
+
+        /** @var DataProviderInterface $dataProvider */
+        $dataProvider = $this->getContainer()->get('sulu_article.content.data_provider');
+
+        $reflectionClass = new \ReflectionClass($dataProvider);
+        $reflectionProperty = $reflectionClass->getProperty('defaultLimit');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($dataProvider, 3);
+
+        $pageSize = 20; // need to be bigger as default limit and should have no effect then
+
+        $result = $dataProvider->resolveResourceItems([], [], ['locale' => 'de', 'webspaceKey' => 'sulu_io'], null, 1, $pageSize);
+        $this->assertCount(3, $result->getItems());
+        $this->assertTrue($result->getHasNextPage());
+
+        $result = $dataProvider->resolveResourceItems([], [], ['locale' => 'de', 'webspaceKey' => 'sulu_io'], null, 2, $pageSize);
+        $this->assertCount(1, $result->getItems());
+        $this->assertFalse($result->getHasNextPage());
+    }
+
     public function testResolveResourceItemsPaginationWithLimit()
     {
         $items = [
@@ -217,6 +245,7 @@ class ArticleDataProviderTest extends SuluTestCase
         $result = $dataProvider->resolveResourceItems([], [], ['locale' => 'de', 'webspaceKey' => 'sulu_io'], 3, 1, 2);
         $this->assertCount(2, $result->getItems());
         $this->assertTrue($result->getHasNextPage());
+
         $result = $dataProvider->resolveResourceItems([], [], ['locale' => 'de', 'webspaceKey' => 'sulu_io'], 3, 2, 2);
         $this->assertCount(1, $result->getItems());
         $this->assertFalse($result->getHasNextPage());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

The defaultLimit should not have any effect on paginated smart content it should just limit the pageSize not the whole totals.

#### Why?

Currently pagination over the default limit doesn't work and will not return all articles. So for example a smart content with `12` per page and 118 articles will just return the first 100 articles, show hasNextPage as true but will fail with OutofBoundException on Page 10. 
