### PR TITLE
Remove template default type definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-sudo: false
+os: linux
 dist: trusty
-
 language: php
 
 services:
@@ -20,7 +19,7 @@ cache:
     - "downloads"
     - "$HOME/.composer/cache/files"
 
-matrix:
+jobs:
   include:
     - php: 7.2
       env:

--- a/DependencyInjection/StructureValidatorCompilerPass.php
+++ b/DependencyInjection/StructureValidatorCompilerPass.php
@@ -30,6 +30,10 @@ class StructureValidatorCompilerPass implements CompilerPassInterface
         $defaultTypes = $container->getParameter('sulu.content.structure.default_types');
         $structureFactory = $container->get('sulu_page.structure.factory');
 
+        if (!isset($defaultTypes[$type])) {
+            return null;
+        }
+
         try {
             $structureFactory->getStructureMetadata($type, $defaultTypes[$type]);
         } catch (StructureTypeNotFoundException $exception) {

--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -51,10 +51,6 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
                                     'type' => 'article_page',
                                 ],
                             ],
-                            'default_type' => [
-                                'article' => 'default',
-                                'article_page' => 'default',
-                            ],
                             'type_map' => [
                                 'article' => ArticleBridge::class,
                                 'article_page' => ArticlePageBridge::class,
@@ -339,8 +335,10 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sulu.content.structure.paths', $paths);
 
         $defaultTypes = $container->getParameter('sulu.content.structure.default_types');
-        $defaultTypes['article_page'] = $defaultTypes['article'];
-        $container->setParameter('sulu.content.structure.default_types', $defaultTypes);
+        if (isset($defaultTypes['article'])) {
+            $defaultTypes['article_page'] = $defaultTypes['article'];
+            $container->setParameter('sulu.content.structure.default_types', $defaultTypes);
+        }
     }
 
     /**

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -28,12 +28,6 @@ sulu_route:
                 route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
                 parent: "{object.getParent().getRoutePath()}"
 
-sulu_core:
-    content:
-        structure:
-            default_type:
-                article: "default"
-
 sulu_article:
     index_name: su_articles
     hosts: ['127.0.0.1:9200']

--- a/Tests/Application/config/templates/articles/default_pages.xml
+++ b/Tests/Application/config/templates/articles/default_pages.xml
@@ -18,7 +18,7 @@
             <tag name="sulu_article.article_route"/>
         </property>
 
-        <property name="pageTitle" type="text_line" mandatory="true">
+        <property name="pageTitle" type="text_line">
             <tag name="sulu_article.page_title"/>
         </property>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #473 
| License | MIT

#### What's in this PR?

Remove template default type definition.

> Attention this is currently just a workaround for multiple type issue!!!

The hack should be removed when https://github.com/sulu/sulu/pull/5381 is merged.

#### Why?

The default type definition does not work with multiple article types.
