### PR TITLE
Fix filter by multiple types

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -243,8 +243,10 @@ class ArticleController extends AbstractRestController implements ClassResourceI
                 $query = new BoolQuery();
 
                 foreach ($types as $type) {
-                    $query->add(new TermQuery('type', $type));
+                    $query->add(new TermQuery('type', $type), BoolQuery::SHOULD);
                 }
+
+                $search->addQuery($query);
             } elseif ($types[0]) {
                 $search->addQuery(new TermQuery('type', $types[0]));
             }

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -43,7 +43,7 @@ class ArticleControllerTest extends SuluTestCase
 {
     use ArticleViewDocumentIdTrait;
 
-    private static $typeMap = ['default' => 'blog', 'simple' => 'video'];
+    private static $typeMap = ['default' => 'blog', 'simple' => 'video', 'default_fallback' => 'other'];
 
     /**
      * @var Client
@@ -934,6 +934,22 @@ class ArticleControllerTest extends SuluTestCase
         );
 
         $this->assertContains([$article2['id'], $article2['title']], $items);
+    }
+
+    public function testCGetMultipleTypes()
+    {
+        $article1 = $this->testPost('Sulu', 'default');
+        $article2 = $this->testPost('Sulu is awesome', 'simple');
+        $article3 = $this->testPost('Sulu is great', 'default_fallback');
+        $this->flush();
+
+        $this->client->request('GET', '/api/articles?locale=de&types=blog,video&fields=title');
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(2, $response['total']);
     }
 
     public function testCGetFilterByContactId()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #474
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix filter by multiple types.

#### Why?

Currently the types filter has no effect when give more than one.

