### PR TITLE
Remove unused sulu_article.article_title from article templates

### DIFF
--- a/Resources/doc/default.xml
+++ b/Resources/doc/default.xml
@@ -27,8 +27,6 @@
             <params>
                 <param name="headline" value="true"/>
             </params>
-
-            <tag name="sulu_article.article_title"/>
         </property>
 
         <property name="routePath" type="route">

--- a/Tests/Application/config/templates/articles/default_pages.xml
+++ b/Tests/Application/config/templates/articles/default_pages.xml
@@ -10,9 +10,7 @@
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>
-        <property name="title" type="text_line" mandatory="true">
-            <tag name="sulu_article.article_title"/>
-        </property>
+        <property name="title" type="text_line" mandatory="true"/>
 
         <property name="routePath" type="route">
             <tag name="sulu_article.article_route"/>

--- a/Tests/Application/config/templates/articles/default_with_route.xml
+++ b/Tests/Application/config/templates/articles/default_with_route.xml
@@ -12,9 +12,7 @@
     <tag name="sulu_article.type" type="blog"/>
 
     <properties>
-        <property name="title" type="text_line" mandatory="true">
-            <tag name="sulu_article.article_title"/>
-        </property>
+        <property name="title" type="text_line" mandatory="true"/>
 
         <property name="routePath" type="route">
             <tag name="sulu_article.article_route"/>


### PR DESCRIPTION
It looks like the `sulu_article.article_title` is not used in the codebase of the bundle. Therefore, I dont think we should include it in our templates.