### PR TITLE
Changed translation domain from backend to admin

### DIFF
--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -155,7 +155,7 @@ class ArticleIndexer implements IndexerInterface
 
         $typeTranslationKey = $this->typeConfiguration[$type]['translation_key'];
 
-        return $this->translator->trans($typeTranslationKey, [], 'backend');
+        return $this->translator->trans($typeTranslationKey, [], 'admin');
     }
 
     protected function dispatchIndexEvent(ArticleDocument $document, ArticleViewDocumentInterface $article): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #492
| Related issues/PRs | #492
| License | MIT

#### What's in this PR?

Changed the translation domain from 'backend' tot 'admin'
