### PR TITLE
Add xliff export for articles

### DIFF
--- a/Command/ArticleExportCommand.php
+++ b/Command/ArticleExportCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Command;
+
+use Sulu\Bundle\ArticleBundle\Export\ArticleExportInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class ArticleExportCommand extends Command
+{
+    protected static $defaultName = 'sulu:article:export';
+
+    /**
+     * @var ArticleExportInterface
+     */
+    private $articleExporter;
+
+    public function __construct(ArticleExportInterface $articleExporter)
+    {
+        parent::__construct();
+
+        $this->articleExporter = $articleExporter;
+    }
+
+    protected function configure()
+    {
+        $this->addArgument('target', InputArgument::REQUIRED, 'export.xliff')
+            ->addArgument('locale', InputArgument::REQUIRED)
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, '', '1.2.xliff')
+            ->setDescription('Export Articles');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $target = $input->getArgument('target');
+        if (0 === !\strpos($target, '/')) {
+            $target = \getcwd() . '/' . $target;
+        }
+        $locale = $input->getArgument('locale');
+        $format = $input->getOption('format');
+
+        $output->writeln([
+            '<info>Article Language Export</info>',
+            '<info>=======================</info>',
+            '',
+            '<info>Options</info>',
+            'Target: ' . $target,
+            'Locale: ' . $locale,
+            'Format: ' . $format,
+            '---------------',
+            '',
+        ]);
+
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('<question>Continue with this options?(y/n)</question> ', false);
+
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln('<error>Abort!</error>');
+
+            return 0;
+        }
+
+        $output->writeln('<info>Continue!</info>');
+
+        $file = $this->articleExporter->export($locale, $format, $output);
+
+        \file_put_contents($target, $file);
+
+        return 0;
+    }
+}

--- a/Export/ArticleExport.php
+++ b/Export/ArticleExport.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Export;
+
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\PageBundle\Content\Structure\ExcerptStructureExtension;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Document\Extension\ExtensionContainer;
+use Sulu\Component\Content\Extension\ExportExtensionInterface;
+use Sulu\Component\Content\Extension\ExtensionManagerInterface;
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\Export\Export;
+use Sulu\Component\Export\Manager\ExportManagerInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Twig\Environment;
+
+class ArticleExport extends Export implements ArticleExportInterface
+{
+    /**
+     * @var StructureManagerInterface
+     */
+    protected $structureManager;
+
+    /**
+     * @var ExtensionManagerInterface
+     */
+    protected $extensionManager;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function __construct(
+        Environment $templating,
+        DocumentManagerInterface $documentManager,
+        DocumentInspector $documentInspector,
+        StructureManagerInterface $structureManager,
+        ExtensionManagerInterface $extensionManager,
+        ExportManagerInterface $exportManager,
+        array $formatFilePaths
+    ) {
+        parent::__construct($templating, $documentManager, $documentInspector, $exportManager, $formatFilePaths);
+
+        $this->structureManager = $structureManager;
+        $this->extensionManager = $extensionManager;
+    }
+
+    public function export(string $locale, string $format = '1.2.xliff', ?OutputInterface $output = null): string
+    {
+        $this->exportLocale = $locale;
+        $this->format = $format;
+        $this->output = $output;
+
+        if (!$this->output) {
+            $this->output = new NullOutput();
+        }
+
+        $this->output->writeln('<info>Loading Data…</info>');
+
+        $exportData = $this->getExportData($locale);
+
+        $this->output->writeln([
+            '',
+            '<info>Render Xliff…</info>',
+        ]);
+
+        return $this->templating->render(
+            $this->getTemplate($this->format),
+            $exportData
+        );
+    }
+
+    public function getExportData(string $locale): array
+    {
+        /** @var ArticleDocument[] $documents */
+        $documents = $this->getDocuments($locale);
+
+        $progress = new ProgressBar($this->output, \count($documents));
+        $progress->start();
+
+        $documentData = [];
+        foreach ($documents as $key => $document) {
+            $contentData = $this->getContentData($document, $this->exportLocale);
+            $extensionData = $this->getExtensionData($document);
+            $settingData = $this->getSettingData($document);
+
+            $documentData[] = [
+                'uuid' => $document->getUuid(),
+                'locale' => $document->getLocale(),
+                'content' => $contentData,
+                'settings' => $settingData,
+                'extensions' => $extensionData,
+            ];
+
+            $progress->advance();
+        }
+
+        $progress->finish();
+
+        return [
+            'locale' => $locale,
+            'format' => $this->format,
+            'documents' => $documentData,
+        ];
+    }
+
+    protected function getExtensionData(ArticleDocument $document): array
+    {
+        $data = $document->getExtensionsData();
+        if ($data instanceof ExtensionContainer) {
+            $data = $data->toArray();
+        }
+
+        $extensionData = [];
+        foreach ($data as $extensionName => $extensionProperties) {
+            /** @var ExcerptStructureExtension $extension */
+            $extension = $this->extensionManager->getExtension($document->getStructureType(), $extensionName);
+
+            if ($extension instanceof ExportExtensionInterface) {
+                $extensionData[$extensionName] = $extension->export($extensionProperties, $this->format);
+            }
+        }
+
+        return $extensionData;
+    }
+
+    protected function getSettingData(ArticleDocument $document): array
+    {
+        if ($created = $document->getCreated()) {
+            $created = $created->format('c');
+        }
+
+        if ($changed = $document->getChanged()) {
+            $changed = $changed->format('c');
+        }
+
+        if ($published = $document->getPublished()) {
+            $published = $published->format('c');
+        }
+
+        if (($authored = $document->getAuthored()) && $authored instanceof \DateTime) {
+            $authored = $authored->format('c');
+        }
+
+        $settingOptions = [];
+        if ('1.2.xliff' === $this->format) {
+            $settingOptions = ['translate' => false];
+        }
+
+        return [
+            'structureType' => $this->createProperty('structureType', $document->getStructureType(), $settingOptions),
+            'published' => $this->createProperty('published', $published, $settingOptions),
+            'created' => $this->createProperty('created', $created, $settingOptions),
+            'changed' => $this->createProperty('changed', $changed, $settingOptions),
+            'creator' => $this->createProperty('creator', $document->getCreator(), $settingOptions),
+            'changer' => $this->createProperty('changer', $document->getChanger(), $settingOptions),
+            'locale' => $this->createProperty('locale', $document->getLocale(), $settingOptions),
+            'shadowLocale' => $this->createProperty('shadowLocale', $document->getShadowLocale(), $settingOptions),
+            'originalLocale' => $this->createProperty('originalLocale', $document->getOriginalLocale(), $settingOptions),
+            'routePath' => $this->createProperty('routePath', $document->getRoutePath(), $settingOptions),
+            'workflowStage' => $this->createProperty('workflowStage', $document->getWorkflowStage(), $settingOptions),
+            'path' => $this->createProperty('path', $document->getPath(), $settingOptions),
+            'mainWebspace' => $this->createProperty('mainWebspace', $document->getMainWebspace(), $settingOptions),
+            'additionalWebspaces' => $this->createProperty('additionalWebspaces', \json_encode($document->getAdditionalWebspaces()), $settingOptions),
+            'author' => $this->createProperty('author', $document->getAuthor(), $settingOptions),
+            'authored' => $this->createProperty('authored', $authored, $settingOptions),
+        ];
+    }
+
+    protected function getDocuments(string $locale): QueryResultCollection
+    {
+        $query = $this->documentManager->createQuery(
+            'SELECT * FROM [nt:unstructured] AS a WHERE [jcr:mixinTypes] = "sulu:article"',
+            $locale
+        );
+
+        return $query->execute();
+    }
+
+    protected function getTemplate($format)
+    {
+        if (!isset($this->formatFilePaths[$format])) {
+            throw new ExportFormatNotFoundException(sprintf('No format "%s" configured for Snippet export', $format));
+        }
+
+        return $this->formatFilePaths[$format];
+    }
+}

--- a/Export/ArticleExportInterface.php
+++ b/Export/ArticleExportInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Export;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface ArticleExportInterface
+{
+    public function export(string $locale, string $format = '1.2.xliff', ?OutputInterface $output = null): string;
+}

--- a/Export/ExportFormatNotFoundException.php
+++ b/Export/ExportFormatNotFoundException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Export;
+
+class ExportFormatNotFoundException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $format;
+
+    public function __construct(string $format, int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct(sprintf('No format "%s" configured for Snippet export', $format), $code, $previous);
+
+        $this->format = $format;
+    }
+
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -2,6 +2,12 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sulu_article.export.article.formats" type="collection">
+            <parameter key="1.2.xliff">@SuluArticle/Export/Article/1.2.xliff.twig</parameter>
+        </parameter>
+    </parameters>
+
     <services>
         <service id="sulu_article.reindex_command" class="Sulu\Bundle\ArticleBundle\Command\ReindexCommand">
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
@@ -453,6 +459,23 @@
             <argument type="service" id="sulu_article.resolver.webspaces"/>
 
             <tag name="kernel.event_subscriber" />
+        </service>
+
+        <!-- Export -->
+        <service id="sulu_article.export.command" class="Sulu\Bundle\ArticleBundle\Command\ArticleExportCommand">
+            <argument type="service" id="sulu_article.export.exporter"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="sulu_article.export.exporter" class="Sulu\Bundle\ArticleBundle\Export\ArticleExport">
+            <argument type="service" id="twig"/>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
+            <argument type="service" id="sulu.content.structure_manager"/>
+            <argument type="service" id="sulu_page.extension.manager"/>
+            <argument type="service" id="sulu_page.export.manager"/>
+            <argument>%sulu_article.export.article.formats%</argument>
         </service>
     </services>
 </container>

--- a/Resources/doc/README.md
+++ b/Resources/doc/README.md
@@ -14,3 +14,4 @@ This documentation covers basic-topics to install and use this bundle.
 * [Author](author.md)
 * [Article Types](article-types.md)
 * [Multi Webspaces](multi-webspaces.md)
+* [XLIFF Export / Import](xliff.md)

--- a/Resources/doc/xliff.md
+++ b/Resources/doc/xliff.md
@@ -1,0 +1,33 @@
+# XLIFF Export / Import
+
+The SuluArticleBundle is able to export the content of the articles into a XLIFF format. The resulting file can be used
+by a translation tool or send to a translation agency.
+
+They can extend the file with the translation and after that imported by the developer.  
+
+__Export:__
+
+```bash
+$ bin/adminconsole sulu:article:export export.xliff en
+
+Article Language Export
+=======================
+
+Options
+Target: export.xliff
+Locale: en
+Format: 1.2.xliff
+---------------
+
+Continue with this options?(y/n) y
+Continue!
+Loading Data…
+ 30/30 [============================] 100%
+Render Xliff…
+```
+
+__Import:__
+
+```bash
+TODO ...
+```

--- a/Resources/views/Export/Article/1.2.xliff.twig
+++ b/Resources/views/Export/Article/1.2.xliff.twig
@@ -1,0 +1,42 @@
+{% extends "@SuluArticle/Export/Article/base.export.twig" %}
+
+{% block main %}
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+{{ parent() }}
+</xliff>
+{% endblock main %}
+
+{% block article %}
+    <file source-language="{{ document.locale }}" datatype="plaintext" original="{{ document.uuid }}">
+        <body>
+        {{- parent() -}}
+        </body>
+    </file>
+{% endblock article %}
+
+{# view #}
+{%- block view -%}
+    {% apply spaceless %}
+    {% set attributes = '' %}
+    {% set target = '' %}
+    {%- if value is iterable -%}
+        {% set value = value|json_encode %}
+    {%- endif -%}
+    {%- if options.translate is defined and not options.translate -%}
+        {% set attributes = attributes  ~ ' translate="no"' %}
+        {% set target = value %}
+    {%- endif -%}
+    {% if type == 'text_editor' %}
+        {% set attributes = attributes ~ ' datatype="html"' %}
+    {% endif %}
+    {% endapply %}
+    {% autoescape false %}
+
+            <!-- {{ name }}: {{ type }} -->
+            <trans-unit id="{{ sulu_content_type_export_counter() }}" resname="{{ name }}"{{ attributes }}>
+                <source>{{ sulu_content_type_export_escape(value) }}</source>
+                <target>{{ sulu_content_type_export_escape(target) }}</target>
+            </trans-unit>
+    {% endautoescape %}
+{%- endblock view -%}

--- a/Resources/views/Export/Article/base.export.twig
+++ b/Resources/views/Export/Article/base.export.twig
@@ -1,0 +1,77 @@
+{% block main %}
+    {{ block('articles') }}
+{% endblock main %}
+
+{% if false %} {# avoid output of block directly #}
+    {# Iterate over the articles #}
+    {%- block articles -%}
+        {%- for document in documents -%}
+            {% apply spaceless %}
+                {% set settings = document.settings %}
+                {% set content = document.content %}
+                {% set extensions = document.extensions %}
+                {% set prefix = '' %}
+            {% endapply %}{{ block('article') }}
+        {%- endfor -%}
+    {%- endblock articles -%}
+
+    {% block article %}
+        {{- block('content') -}}
+        {{- block('extensions') -}}
+        {{- block('settings') -}}
+    {% endblock article %}
+
+    {# Output content #}
+    {%- block content -%}
+        {% set properties = content %}
+        {{- block('properties') -}}
+    {%- endblock content -%}
+
+    {# Output extensions #}
+    {%- block extensions -%}
+        {%- for key, extension in extensions -%}
+            {% set prefixBefore = prefix %}
+            {% set prefix = prefix ~ key ~ '-' %}
+            {% set properties = extension %}
+            {{- block('properties') -}}
+            {% set prefix = prefixBefore %}
+        {%- endfor -%}
+    {%- endblock extensions -%}
+
+    {# Output settings #}
+    {%- block settings -%}
+        {% set properties = settings %}
+        {{- block('properties') -}}
+    {%- endblock settings -%}
+
+    {# Output properties #}
+    {%- block properties -%}
+        {%- for property in properties -%}
+            {% if property.value is defined %}
+                {{- block('model') -}}
+            {% endif %}
+            {%- if property.children is defined -%}
+                {%- for key, child in property.children -%}
+                    {% set prefixBefore = prefix %}
+                    {% set prefix = prefix ~ property.name ~ '#' ~ key ~ '-' %}
+                    {% set properties = child %}
+                    {{- block('properties') -}}
+                    {% set prefix = prefixBefore %}
+                {%- endfor -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endblock properties -%}
+
+    {# Output model #}
+    {%- block model -%}
+        {% apply spaceless %}
+            {% set name = prefix ~ property.name %}
+            {% set options = property.options|default('') %}
+            {% set value = property.value %}
+            {% set type = property.type|default('') %}
+        {% endapply %}{{- block('view') -}}
+    {%- endblock model -%}
+
+    {# View #}
+    {%- block view -%}{%- endblock view -%}
+{% endif %}

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -656,6 +656,10 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertNotEquals($article['title'], $response['title']);
         $this->assertEquals($title, $response['title']);
         $this->assertEquals($extensions['seo'], $response['ext']['seo']);
+
+        // is only available for sulu 2.1
+        unset($response['ext']['excerpt']['segment']);
+
         $this->assertEquals($extensions['excerpt'], $response['ext']['excerpt']);
     }
 

--- a/Tests/Functional/Export/ArticleExportTest.php
+++ b/Tests/Functional/Export/ArticleExportTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Functional\Export;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class ArticleExportTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = $this->createAuthenticatedClient();
+
+        $this->initPhpcr();
+        $this->purgeDatabase();
+    }
+
+    public function testExport(): void
+    {
+        $article = $this->createArticle('Test-Article', 'default', [
+            'mainWebspace' => 'sulu_io',
+            'additionalWebspaces' => ['sulu_io_blog'],
+            'ext' => [
+                'seo' => [
+                    'title' => 'Seo Title',
+                ],
+                'excerpt' => [
+                    'title' => 'Excerpt Title',
+                ],
+            ],
+        ]);
+
+        $exporter = $this->getContainer()->get('sulu_article.export.exporter');
+
+        $result = $exporter->export('de');
+
+        $expected = <<<EOT
+            <!-- title: text_line -->
+            <trans-unit id="(\d+)" resname="title">
+                <source>Test-Article<\/source>
+                <target><\/target>
+            <\/trans-unit>
+EOT;
+        $this->assertRegExp('/' . $expected . '/', $result);
+
+        $expected = <<<EOT
+            <!-- seo-title:  -->
+            <trans-unit id="(\d+)" resname="seo-title">
+                <source>Seo Title<\/source>
+                <target><\/target>
+            <\/trans-unit>
+EOT;
+        $this->assertRegExp('/' . $expected . '/', $result);
+
+        $expected = <<<EOT
+            <!-- excerpt-title: text_line -->
+            <trans-unit id="(\d+)" resname="excerpt-title">
+                <source>Excerpt Title<\/source>
+                <target><\/target>
+            <\/trans-unit>
+EOT;
+        $this->assertRegExp('/' . $expected . '/', $result);
+
+        $expected = <<<EOT
+            <!-- structureType:  -->
+            <trans-unit id="(\d+)" resname="structureType" translate="no">
+                <source>default<\/source>
+                <target>default<\/target>
+            <\/trans-unit>
+EOT;
+        $this->assertRegExp('/' . $expected . '/', $result);
+
+        $expected = <<<EOT
+            <!-- locale:  -->
+            <trans-unit id="(\d+)" resname="locale" translate="no">
+                <source>de<\/source>
+                <target>de<\/target>
+            <\/trans-unit>
+EOT;
+        $this->assertRegExp('/' . $expected . '/', $result);
+
+        $expected = <<<EOT
+            <!-- mainWebspace:  -->
+            <trans-unit id="(\d+)" resname="mainWebspace" translate="no">
+                <source>sulu_io<\/source>
+                <target>sulu_io<\/target>
+            <\/trans-unit>
+EOT;
+        $this->assertRegExp('/' . $expected . '/', $result);
+
+        $expected = <<<EOT
+            <!-- additionalWebspaces:  -->
+            <trans-unit id="(\d+)" resname="additionalWebspaces" translate="no">
+                <source><!\[CDATA\[\["sulu_io_blog"\]\]\]><\/source>
+                <target><!\[CDATA\[\["sulu_io_blog"\]\]\]><\/target>
+            <\/trans-unit>
+EOT;
+        $this->assertRegExp('/' . $expected . '/', $result);
+    }
+
+    private function createArticle($title = 'Test-Article', $template = 'default', $data = []): array
+    {
+        $this->client->request(
+            'POST',
+            '/api/articles?locale=de&action=publish',
+            array_merge($data, ['title' => $title, 'template' => $template])
+        );
+
+        return json_decode($this->client->getResponse()->getContent(), true);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu/pull/5494
| License | MIT

#### What's in this PR?

This PR add a command to export the articles as xliff export. In a following PR it will be possible to import the translated file again.

#### Why?

It should be possible to use the exported file to translate the articles with a tool or a translation agency.

#### Example Usage

~~~bash
$ bin/adminconsole sulu:article:export export.xliff en

Article Language Export
=======================

Options
Target: export.xliff
Locale: en
Format: 1.2.xliff
---------------

Continue with this options?(y/n) y
Continue!
Loading Data…
 30/30 [============================] 100%
Render Xliff…
~~~

#### To Do

- [x] Add documentation page
