### PR TITLE
Filter articles based on current segment in ArticleDataProvider

### DIFF
--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -261,6 +261,20 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
             $search->addQuery($webspaceQuery);
         }
 
+        $segmentKey = $filters['segmentKey'] ?? null;
+        if ($segmentKey && $webspaceKey) {
+            $matchingSegmentQuery = new TermQuery('excerpt.segments.assignment_key', $webspaceKey . '#' . $segmentKey);
+
+            $noSegmentQuery = new BoolQuery();
+            $noSegmentQuery->add(new TermQuery('excerpt.segments.webspace_key', $webspaceKey), BoolQuery::MUST_NOT);
+
+            $segmentQuery = new BoolQuery();
+            $segmentQuery->add($matchingSegmentQuery, BoolQuery::SHOULD);
+            $segmentQuery->add($noSegmentQuery, BoolQuery::SHOULD);
+
+            $search->addQuery($segmentQuery);
+        }
+
         return $repository->findDocuments($search);
     }
 

--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -21,6 +21,7 @@ use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
+use Sulu\Bundle\PageBundle\Content\Types\SegmentSelect;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -263,7 +264,10 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
 
         $segmentKey = $filters['segmentKey'] ?? null;
         if ($segmentKey && $webspaceKey) {
-            $matchingSegmentQuery = new TermQuery('excerpt.segments.assignment_key', $webspaceKey . '#' . $segmentKey);
+            $matchingSegmentQuery = new TermQuery(
+                'excerpt.segments.assignment_key',
+                $webspaceKey . SegmentSelect::SEPARATOR . $segmentKey
+            );
 
             $noSegmentQuery = new BoolQuery();
             $noSegmentQuery->add(new TermQuery('excerpt.segments.webspace_key', $webspaceKey), BoolQuery::MUST_NOT);

--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -17,7 +17,9 @@ use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
 use Sulu\Bundle\ArticleBundle\Resolver\ArticleContentResolverInterface;
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
 use Sulu\Bundle\PreviewBundle\Preview\Preview;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolverInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -62,8 +64,12 @@ class WebsiteArticleController extends AbstractController
 
         $content = $this->resolveArticle($object, $pageNumber);
 
-        $templateAttributeResolver = $this->getTemplateAttributeResolver();
-        $data = $templateAttributeResolver->resolve(array_merge($content, $attributes));
+        $data = $this->get('sulu_website.resolver.parameter')->resolve(
+            array_merge($content, $attributes),
+            $this->get('sulu_core.webspace.request_analyzer'),
+            null,
+            $preview
+        );
 
         try {
             if ($partial) {
@@ -200,6 +206,8 @@ class WebsiteArticleController extends AbstractController
         $subscribedServices['twig'] = Environment::class;
         $subscribedServices['sulu_website.resolver.template_attribute'] = TemplateAttributeResolverInterface::class;
         $subscribedServices['sulu_article.article_content_resolver'] = ArticleContentResolverInterface::class;
+        $subscribedServices['sulu_website.resolver.parameter'] = ParameterResolverInterface::class;
+        $subscribedServices['sulu_core.webspace.request_analyzer'] = RequestAnalyzerInterface::class;
 
         return $subscribedServices;
     }

--- a/Document/ExcerptViewObject.php
+++ b/Document/ExcerptViewObject.php
@@ -83,6 +83,13 @@ class ExcerptViewObject
     public $tags;
 
     /**
+     * @var SegmentViewObject[]|Collection
+     *
+     * @Embedded(class="Sulu\Bundle\ArticleBundle\Document\SegmentViewObject", multiple=true)
+     */
+    public $segments;
+
+    /**
      * @var MediaViewObject[]|Collection
      *
      * @Embedded(class="Sulu\Bundle\ArticleBundle\Document\MediaViewObject", multiple=true)
@@ -100,6 +107,7 @@ class ExcerptViewObject
     {
         $this->tags = new Collection();
         $this->categories = new Collection();
+        $this->segments = new Collection();
         $this->icon = new Collection();
         $this->images = new Collection();
     }

--- a/Document/Index/Factory/ExcerptFactory.php
+++ b/Document/Index/Factory/ExcerptFactory.php
@@ -69,7 +69,7 @@ class ExcerptFactory
         $excerpt->description = $data['description'];
         $excerpt->tags = $this->tagCollectionFactory->create($data['tags']);
         $excerpt->categories = $this->categoryCollectionFactory->create($data['categories'], $locale);
-        $excerpt->segments = $this->segmentCollectionFactory->create($data['segments']);
+        $excerpt->segments = $this->segmentCollectionFactory->create($data['segments'] ?? []);
         $excerpt->icon = $this->mediaCollectionFactory->create($data['icon'] ?? [], $locale);
         $excerpt->images = $this->mediaCollectionFactory->create($data['images'] ?? [], $locale);
 

--- a/Document/Index/Factory/ExcerptFactory.php
+++ b/Document/Index/Factory/ExcerptFactory.php
@@ -34,16 +34,23 @@ class ExcerptFactory
     private $mediaCollectionFactory;
 
     /**
+     * @var SegmentCollectionFactory
+     */
+    private $segmentCollectionFactory;
+
+    /**
      * ExcerptIndexerFactory constructor.
      */
     public function __construct(
         CategoryCollectionFactory $categoryCollectionFactory,
         TagCollectionFactory $tagCollectionFactory,
-        MediaCollectionFactory $mediaCollectionFactory
+        MediaCollectionFactory $mediaCollectionFactory,
+        SegmentCollectionFactory $segmentCollectionFactory
     ) {
         $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->tagCollectionFactory = $tagCollectionFactory;
         $this->mediaCollectionFactory = $mediaCollectionFactory;
+        $this->segmentCollectionFactory = $segmentCollectionFactory;
     }
 
     /**
@@ -62,6 +69,7 @@ class ExcerptFactory
         $excerpt->description = $data['description'];
         $excerpt->tags = $this->tagCollectionFactory->create($data['tags']);
         $excerpt->categories = $this->categoryCollectionFactory->create($data['categories'], $locale);
+        $excerpt->segments = $this->segmentCollectionFactory->create($data['segments']);
         $excerpt->icon = $this->mediaCollectionFactory->create($data['icon'] ?? [], $locale);
         $excerpt->images = $this->mediaCollectionFactory->create($data['images'] ?? [], $locale);
 

--- a/Document/Index/Factory/SegmentCollectionFactory.php
+++ b/Document/Index/Factory/SegmentCollectionFactory.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ArticleBundle\Document\Index\Factory;
 
 use ONGR\ElasticsearchBundle\Collection\Collection;
 use Sulu\Bundle\ArticleBundle\Document\SegmentViewObject;
+use Sulu\Bundle\PageBundle\Content\Types\SegmentSelect;
 
 class SegmentCollectionFactory
 {
@@ -23,7 +24,7 @@ class SegmentCollectionFactory
         foreach ($segments as $webspaceKey => $segmentKey) {
             if ($segmentKey) {
                 $segment = new SegmentViewObject();
-                $segment->assignmentKey = $webspaceKey . '#' . $segmentKey;
+                $segment->assignmentKey = $webspaceKey . SegmentSelect::SEPARATOR . $segmentKey;
                 $segment->webspaceKey = $webspaceKey;
                 $segment->segmentKey = $segmentKey;
 

--- a/Document/Index/Factory/SegmentCollectionFactory.php
+++ b/Document/Index/Factory/SegmentCollectionFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Index\Factory;
+
+use ONGR\ElasticsearchBundle\Collection\Collection;
+use Sulu\Bundle\ArticleBundle\Document\SegmentViewObject;
+
+class SegmentCollectionFactory
+{
+    public function create(array $segments): Collection
+    {
+        $collection = new Collection();
+
+        foreach ($segments as $webspaceKey => $segmentKey) {
+            if ($segmentKey) {
+                $segment = new SegmentViewObject();
+                $segment->assignmentKey = $webspaceKey . '#' . $segmentKey;
+                $segment->webspaceKey = $webspaceKey;
+                $segment->segmentKey = $segmentKey;
+
+                $collection[] = $segment;
+            }
+        }
+
+        return $collection;
+    }
+}

--- a/Document/SegmentViewObject.php
+++ b/Document/SegmentViewObject.php
@@ -19,41 +19,26 @@ use ONGR\ElasticsearchBundle\Annotation\Property;
  *
  * @ObjectType
  */
-class CategoryViewObject
+class SegmentViewObject
 {
-    /**
-     * @var int
-     *
-     * @Property(type="integer")
-     */
-    public $id;
-
     /**
      * @var string
      *
-     * @Property(
-     *     type="text",
-     *     options={
-     *        "fields"={
-     *            "raw"={"type"="keyword"},
-     *            "value"={"type"="text"}
-     *        }
-     *    }
-     * )
+     * @Property(type="keyword")
      */
-    public $name;
+    public $assignmentKey;
 
     /**
      * @var string
      *
      * @Property(type="keyword")
      */
-    public $key;
+    public $webspaceKey;
 
     /**
-     * @var string[]
+     * @var string
      *
-     * @Property(type="text")
+     * @Property(type="keyword")
      */
-    public $keywords = [];
+    public $segmentKey;
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -150,6 +150,9 @@
             <argument type="service" id="sulu_media.media_manager"/>
         </service>
 
+        <service id="sulu_article.elastic_search.factory.segment_collection"
+                 class="Sulu\Bundle\ArticleBundle\Document\Index\Factory\SegmentCollectionFactory"/>
+
         <service id="sulu_article.elastic_search.factory.tag_collection"
                  class="Sulu\Bundle\ArticleBundle\Document\Index\Factory\TagCollectionFactory">
             <argument type="service" id="sulu_tag.tag_manager"/>
@@ -165,6 +168,7 @@
             <argument type="service" id="sulu_article.elastic_search.factory.category_collection"/>
             <argument type="service" id="sulu_article.elastic_search.factory.tag_collection"/>
             <argument type="service" id="sulu_article.elastic_search.factory.media_collection"/>
+            <argument type="service" id="sulu_article.elastic_search.factory.segment_collection"/>
         </service>
 
         <!-- document -->

--- a/Tests/Functional/Content/ArticleDataProviderTest.php
+++ b/Tests/Functional/Content/ArticleDataProviderTest.php
@@ -258,6 +258,38 @@ class ArticleDataProviderTest extends SuluTestCase
         $this->assertFalse($result->getHasNextPage());
     }
 
+    public function testResolveResourceItemsWithSegments()
+    {
+        $items = [
+            $this->createArticle('Test Article 1', 'default', 'test', null, ['test' => 's']),
+            $this->createArticle('Test Article 2', 'default', 'test', null, ['test' => 'w']),
+            $this->createArticle('Test Article 3', 'default', 'test'),
+        ];
+
+        /** @var DataProviderInterface $dataProvider */
+        $dataProvider = $this->getContainer()->get('sulu_article.content.data_provider');
+
+        $result = $dataProvider->resolveResourceItems(
+            ['segmentKey' => 's'],
+            [],
+            ['locale' => 'de', 'webspaceKey' => 'test']
+        );
+        $items = $result->getItems();
+        $this->assertCount(2, $items);
+        $this->assertEquals('Test Article 1', $items[0]->getTitle());
+        $this->assertEquals('Test Article 3', $items[1]->getTitle());
+
+        $result = $dataProvider->resolveResourceItems(
+            ['segmentKey' => 'w'],
+            [],
+            ['locale' => 'de', 'webspaceKey' => 'test']
+        );
+        $items = $result->getItems();
+        $this->assertCount(2, $items);
+        $this->assertEquals('Test Article 2', $items[0]->getTitle());
+        $this->assertEquals('Test Article 3', $items[1]->getTitle());
+    }
+
     public function testResolveResourceItemsPagination()
     {
         $items = [
@@ -516,7 +548,8 @@ class ArticleDataProviderTest extends SuluTestCase
         $title = 'Test-Article',
         $template = 'default',
         $mainWebspace = null,
-        $additionalWebspaces = null
+        $additionalWebspaces = null,
+        $segments = null
     ) {
         $data = [
             'title' => $title,
@@ -529,6 +562,10 @@ class ArticleDataProviderTest extends SuluTestCase
 
         if ($additionalWebspaces) {
             $data['additionalWebspaces'] = $additionalWebspaces;
+        }
+
+        if ($segments) {
+            $data['ext'] = ['excerpt' => ['segments' => $segments]];
         }
 
         $this->client->request(

--- a/Tests/Functional/Content/ArticleDataProviderTest.php
+++ b/Tests/Functional/Content/ArticleDataProviderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\Tests\Functional\Content;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
+use Sulu\Bundle\PageBundle\Content\Types\SegmentSelect;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\SmartContent\DataProviderInterface;
@@ -260,6 +261,10 @@ class ArticleDataProviderTest extends SuluTestCase
 
     public function testResolveResourceItemsWithSegments()
     {
+        if (!class_exists(SegmentSelect::class)) {
+            $this->markTestSkipped('Segments did not exist in Sulu <2.2.');
+        }
+
         $items = [
             $this->createArticle('Test Article 1', 'default', 'test', null, ['test' => 's']),
             $this->createArticle('Test Article 2', 'default', 'test', null, ['test' => 'w']),

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -630,6 +630,7 @@ class ArticleControllerTest extends SuluTestCase
                     'ids' => [1],
                 ],
                 'audience_targeting_groups' => [],
+                'segments' => [],
             ],
         ]
     ) {

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -28,6 +28,7 @@ use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\PageBundle\Content\Types\SegmentSelect;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Bundle\SecurityBundle\UserManager\UserManager;
@@ -658,8 +659,10 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($title, $response['title']);
         $this->assertEquals($extensions['seo'], $response['ext']['seo']);
 
-        // segment is only returned for sulu versions >= 2.2
-        unset($response['ext']['excerpt']['segment']);
+        if (!class_exists(SegmentSelect::class)) {
+            // segment is only returned for sulu versions >= 2.2
+            unset($extensions['excerpt']['segments']);
+        }
 
         $this->assertEquals($extensions['excerpt'], $response['ext']['excerpt']);
     }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade
 
+## unreleased
+
+### Index mapping changed
+
+The mapping of the `CategoryViewObject` and `ExcerptViewObject` changed, therefore a reindex is
+necessary:
+
+```bash
+bin/websiteconsole sulu:article:reindex --drop
+bin/adminconsole sulu:article:reindex --drop
+``` 
+
 ## 2.1.0
 
 ### Elasticsearch Upgrade


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/5425
| License | MIT

#### What's in this PR?

This PR adjusts the `ArticleDataProvider` of the bundle to respect the current segment when filtering articles. With this PR, the `ArticleDataProvider` will return an article only if it is not assigned to a segment for the current webspace or if it is assigned to the current segment for the current webspace.

#### Why?

Because the `ArticleDataProvider` should behave similar to the `PageDataProvider`.

#### ToDo

- [ ] Fix missing `segments` variable in article twig rendering