### PR TITLE
Add annotation reader to dynamically add the document annotation

### DIFF
--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -19,7 +19,8 @@ use ONGR\ElasticsearchBundle\Annotation\Property;
 /**
  * Indexable document for articles.
  *
- * @Document(type="article")
+ * Following annotation will be set by the annotation reader if this document is used for mapping.
+ * Document(type="article")
  */
 class ArticleViewDocument implements ArticleViewDocumentInterface
 {

--- a/Elasticsearch/AnnotationReader.php
+++ b/Elasticsearch/AnnotationReader.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Elasticsearch;
+
+use Doctrine\Common\Annotations\Reader;
+use ONGR\ElasticsearchBundle\Annotation\Document;
+
+class AnnotationReader implements Reader
+{
+    /**
+     * @var Reader
+     */
+    private $inner;
+
+    /**
+     * @var string
+     */
+    private $articleViewDocumentClass;
+
+    public function __construct(Reader $inner, $articleViewDocumentClass)
+    {
+        $this->inner = $inner;
+        $this->articleViewDocumentClass = $articleViewDocumentClass;
+    }
+
+    public function getClassAnnotations(\ReflectionClass $class)
+    {
+        return $this->inner->getClassAnnotations($class);
+    }
+
+    public function getClassAnnotation(\ReflectionClass $class, $annotationName)
+    {
+        $result = $this->inner->getClassAnnotation($class, $annotationName);
+        if (!$result && Document::class === $annotationName && $class->getName() === $this->articleViewDocumentClass) {
+            $annotation = new Document();
+            $annotation->type = 'article';
+
+            return $annotation;
+        }
+
+        return $result;
+    }
+
+    public function getMethodAnnotations(\ReflectionMethod $method)
+    {
+        return $this->inner->getMethodAnnotations($method);
+    }
+
+    public function getMethodAnnotation(\ReflectionMethod $method, $annotationName)
+    {
+        return $this->inner->getMethodAnnotation($method, $annotationName);
+    }
+
+    public function getPropertyAnnotations(\ReflectionProperty $property)
+    {
+        return $this->inner->getPropertyAnnotations($property);
+    }
+
+    public function getPropertyAnnotation(\ReflectionProperty $property, $annotationName)
+    {
+        return $this->inner->getPropertyAnnotation($property, $annotationName);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -395,7 +395,6 @@
             <tag name="massive_build.builder" />
         </service>
 
-
         <!-- webspace settings resolver -->
         <service id="sulu_bundle_article.webspace_settings_configuration_resolver"
                  class="Sulu\Bundle\ArticleBundle\DependencyInjection\WebspaceSettingsConfigurationResolver">
@@ -414,6 +413,14 @@
             <argument type="service" id="sulu_article.resolver.webspaces"/>
 
             <tag name="kernel.event_subscriber" />
+        </service>
+
+        <!-- annotation reader -->
+        <service id="sulu_article.annotations.cached_reader"
+                 decorates="es.annotations.cached_reader"
+                 class="Sulu\Bundle\ArticleBundle\Elasticsearch\AnnotationReader">
+            <argument type="service" id="sulu_article.annotations.cached_reader.inner"/>
+            <argument type="string">%sulu_article.view_document.article.class%</argument>
         </service>
     </services>
 </container>

--- a/Resources/doc/article-view-document.md
+++ b/Resources/doc/article-view-document.md
@@ -48,7 +48,7 @@ use ONGR\ElasticsearchBundle\Annotation\Property;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument as SuluArticleViewDocument;
 
 /**
- * @Document(type="app_article")
+ * @Document(type="article")
  */
 class ArticleViewDocument extends SuluArticleViewDocument
 {

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -652,7 +652,12 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertNotEquals($article['title'], $response['title']);
         $this->assertEquals($title, $response['title']);
         $this->assertEquals($extensions['seo'], $response['ext']['seo']);
-        $this->assertEquals($extensions['excerpt'], $response['ext']['excerpt']);
+
+        // segment is only returned for sulu versions >= 2.2
+        $responseExcerpt = $response['ext']['excerpt'];
+        unset($response['segment']);
+
+        $this->assertEquals($extensions['excerpt'], $responseExcerpt);
     }
 
     public function testPutDifferentTemplate($title = 'Sulu', $description = 'Sulu is awesome')
@@ -1696,7 +1701,10 @@ class ArticleControllerTest extends SuluTestCase
         /** @var Manager $manager */
         $manager = $this->getContainer()->get('es.manager.default');
 
-        return $manager->find(ArticleViewDocument::class, $this->getViewDocumentId($uuid, $locale));
+        return $manager->find(
+            $this->getContainer()->getParameter('sulu_article.view_document.article.class'),
+            $this->getViewDocumentId($uuid, $locale)
+        );
     }
 
     /**

--- a/Tests/Functional/Controller/ArticlePageControllerTest.php
+++ b/Tests/Functional/Controller/ArticlePageControllerTest.php
@@ -13,7 +13,6 @@ namespace Functional\Controller;
 
 use Ferrandini\Urlizer;
 use ONGR\ElasticsearchBundle\Service\Manager;
-use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
 use Sulu\Bundle\ArticleBundle\Document\Index\IndexerInterface;
 use Sulu\Bundle\ArticleBundle\Metadata\ArticleViewDocumentIdTrait;
@@ -405,7 +404,10 @@ class ArticlePageControllerTest extends SuluTestCase
         /** @var Manager $manager */
         $manager = $this->getContainer()->get('es.manager.default');
 
-        return $manager->find(ArticleViewDocument::class, $this->getViewDocumentId($uuid, $locale));
+        return $manager->find(
+            $this->getContainer()->getParameter('sulu_article.view_document.article.class'),
+            $this->getViewDocumentId($uuid, $locale)
+        );
     }
 
     private function getRoute($title, $page)

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -358,6 +358,9 @@ class ArticleIndexerTest extends SuluTestCase
      */
     private function findViewDocument($uuid, $locale = null)
     {
-        return $this->manager->find(ArticleViewDocument::class, $uuid . '-' . ($locale ? $locale : $this->locale));
+        return $this->manager->find(
+            $this->getContainer()->getParameter('sulu_article.view_document.article.class'),
+            $uuid . '-' . ($locale ? $locale : $this->locale)
+        );
     }
 }

--- a/Tests/TestExtendBundle/Document/ArticleViewDocument.php
+++ b/Tests/TestExtendBundle/Document/ArticleViewDocument.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document;
+
+use ONGR\ElasticsearchBundle\Annotation\Document;
+use ONGR\ElasticsearchBundle\Annotation\Property;
+use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument as SuluArticleViewDocument;
+
+/**
+ * @Document(type="article")
+ */
+class ArticleViewDocument extends SuluArticleViewDocument
+{
+    /**
+     * @var string
+     *
+     * @Property(type="text")
+     */
+    public $article;
+}

--- a/Tests/app/config/config_extend.yml
+++ b/Tests/app/config/config_extend.yml
@@ -19,3 +19,17 @@ sulu_route:
             options:
                 route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
                 parent: "{object.getParent().getRoutePath()}"
+
+ongr_elasticsearch:
+    managers:
+        default:
+            mappings:
+                - TestExtendBundle
+        live:
+            mappings:
+                - TestExtendBundle
+
+sulu_article:
+    documents:
+        article:
+            view: Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleViewDocument

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "sulu/sulu": "^1.6.8",
-        "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.2",
+        "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.3",
         "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
         "jackalope/jackalope": "^1.2.8 || >=1.3.3",
         "jms/serializer-bundle": "^1.1 || ^2.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "sulu/sulu": "^1.6.8",
-        "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.3",
+        "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.4",
         "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
         "jackalope/jackalope": "^1.2.8 || >=1.3.3",
         "jms/serializer-bundle": "^1.1 || ^2.0"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | requires https://github.com/handcraftedinthealps/ElasticsearchBundle/pull/12
| License | MIT

#### What's in this PR?

Add flag to enable/disable mapping prepend of the ongr bundle config.

#### Why?

When you add your own ViewDocument both "types" will be mapped and that ends up in an exception from elasticsearch.
