### PR TITLE
Adjust copy-locale action of ArticleController to use given source-locale

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -528,6 +528,7 @@ class ArticleController extends AbstractRestController implements ClassResourceI
 
                     break;
                 case 'copy-locale':
+                    $srcLocale = $this->getRequestParameter($request, 'src', false, $locale);
                     $destLocales = $this->getRequestParameter($request, 'dest', true);
                     $destLocales = explode(',', $destLocales);
 
@@ -538,7 +539,7 @@ class ArticleController extends AbstractRestController implements ClassResourceI
                         );
                     }
 
-                    $this->contentMapper->copyLanguage($id, $userId, null, $locale, $destLocales);
+                    $this->contentMapper->copyLanguage($id, $userId, null, $srcLocale, $destLocales);
 
                     $data = $this->documentManager->find($id, $locale);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/5573
| License | MIT

#### What's in this PR?

This PR adjusts the `ArticleController` to use the given `src` locale when invoking the `copy-locale` action. Sulu added a `src` locale in https://github.com/sulu/sulu/pull/5573
