### PR TITLE
Pass urls and localizations array to twig template

### DIFF
--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -64,12 +64,13 @@ class WebsiteArticleController extends AbstractController
 
         $content = $this->resolveArticle($object, $pageNumber);
 
-        $data = $this->get('sulu_website.resolver.parameter')->resolve(
-            array_merge($content, $attributes),
+        $parameters = $this->get('sulu_website.resolver.parameter')->resolve(
+            [],
             $this->get('sulu_core.webspace.request_analyzer'),
             null,
             $preview
         );
+        $data = array_merge($parameters, $content, $attributes);
 
         try {
             if ($partial) {

--- a/Document/Serializer/WebsiteArticleUrlsSubscriber.php
+++ b/Document/Serializer/WebsiteArticleUrlsSubscriber.php
@@ -85,16 +85,20 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
         }
 
         $urls = [];
+        $localizations = [];
         foreach ($webspace->getAllLocalizations() as $localization) {
             $locale = $localization->getLocale();
             $route = $this->routeRepository->findByEntity(get_class($article), $article->getUuid(), $locale);
+            $path = $route ? $route->getPath() : '/';
 
-            $urls[$locale] = '/';
-            if ($route) {
-                $urls[$locale] = $route->getPath();
-            }
+            $urls[$locale] = $path;
+            $localizations[$locale] = [
+                'locale' => $locale,
+                'url' => $path,
+            ];
         }
 
         $visitor->visitProperty(new StaticPropertyMetadata('', 'urls', $urls), $urls);
+        $visitor->visitProperty(new StaticPropertyMetadata('', 'localizations', $localizations), $localizations);
     }
 }

--- a/Document/Serializer/WebsiteArticleUrlsSubscriber.php
+++ b/Document/Serializer/WebsiteArticleUrlsSubscriber.php
@@ -19,6 +19,7 @@ use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -37,10 +38,19 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
      */
     private $routeRepository;
 
-    public function __construct(RequestStack $requestStack, RouteRepositoryInterface $routeRepository)
-    {
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    public function __construct(
+        RequestStack $requestStack,
+        RouteRepositoryInterface $routeRepository,
+        WebspaceManagerInterface $webspaceManager
+    ) {
         $this->requestStack = $requestStack;
         $this->routeRepository = $routeRepository;
+        $this->webspaceManager = $webspaceManager;
     }
 
     /**
@@ -94,7 +104,7 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
             $urls[$locale] = $path;
             $localizations[$locale] = [
                 'locale' => $locale,
-                'url' => $path,
+                'url' => $this->webspaceManager->findUrlByResourceLocator($path, null, $locale),
             ];
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -270,6 +270,7 @@
                  class="Sulu\Bundle\ArticleBundle\Document\Serializer\WebsiteArticleUrlsSubscriber">
             <argument type="service" id="request_stack"/>
             <argument type="service" id="sulu.repository.route"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
 
             <tag name="jms_serializer.event_subscriber"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #525
| License | MIT

#### What's in this PR?

The following change overwrites the `urls` that are set by the `WebsiteArticleUrlsSubscriber`:
https://github.com/sulu/SuluArticleBundle/pull/511/files#diff-db580230ef3c42850622b9d5b0a46103221a92c430883ee4e19427d4e2632c8eR67-R72

Because of this, the rendering of alternate links does not work at the moment. See #525.

Additionally, Sulu now uses a `localizations` array instead of the `urls` per default. Therefore we need to add the `localizations` to the serialization too.
