### PR TITLE
Adjust elasticsearch/elasticsearch version constraint in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Execute the following [composer](https://getcomposer.org/) commands to add the b
 project:
 
 ```bash
-composer require elasticsearch/elasticsearch:7.9.* # should match version of your elasticsearch installation
+composer require "elasticsearch/elasticsearch:7.9.*" # should match version of your elasticsearch installation
 composer require sulu/article-bundle
 ```
 
@@ -95,4 +95,3 @@ on the the [sulu/SuluArticleBundle](https://github.com/sulu/SuluArticleBundle) r
 ## 📘&nbsp; License
 
 The Sulu content management system is released under the under terms of the [MIT License](LICENSE).
-

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Execute the following [composer](https://getcomposer.org/) commands to add the b
 project:
 
 ```bash
-composer require elasticsearch/elasticsearch:^7.9 # should match version of your elasticsearch installation
+composer require elasticsearch/elasticsearch:7.9.* # should match version of your elasticsearch installation
 composer require sulu/article-bundle
 ```
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -7,7 +7,7 @@ The SuluArticleBundle requires a running elasticsearch `^5.0`, `^6.0` or `^7.0`.
 ## Install dependencies
 
 ```bash
-composer require elasticsearch/elasticsearch:7.9.* # should match version of your elasticsearch installation
+composer require "elasticsearch/elasticsearch:7.9.*" # should match version of your elasticsearch installation
 composer require sulu/article-bundle
 ```
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -7,7 +7,7 @@ The SuluArticleBundle requires a running elasticsearch `^5.0`, `^6.0` or `^7.0`.
 ## Install dependencies
 
 ```bash
-composer require elasticsearch/elasticsearch:^7.9 # should match version of your elasticsearch installation
+composer require elasticsearch/elasticsearch:7.9.* # should match version of your elasticsearch installation
 composer require sulu/article-bundle
 ```
 


### PR DESCRIPTION
When using `^7.9`, composer will install `7.10` when executing `composer update`