### PR TITLE
Add functionality to remove single locale from article

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 /auth.json
 /vendor
 
+# symfony
+.env.local
+.env.*.local
+
 # php-cs
 .php_cs
 .php_cs.cache

--- a/Admin/ArticleAdmin.php
+++ b/Admin/ArticleAdmin.php
@@ -185,7 +185,28 @@ class ArticleAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)
                 && $this->securityChecker->hasPermission(static::SECURITY_CONTEXT . '_' . $typeKey, PermissionTypes::DELETE)) {
-                $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.delete');
+                $formToolbarActionsWithType[] = new DropdownToolbarAction(
+                    'sulu_admin.delete',
+                    'su-trash-alt',
+                    [
+                        new ToolbarAction(
+                            'sulu_admin.delete',
+                            [
+                                'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                                'router_attributes_to_back_view' => ['webspace'],
+                            ]
+                        ),
+                        new ToolbarAction(
+                            'sulu_admin.delete',
+                            [
+                                'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                                'router_attributes_to_back_view' => ['webspace'],
+                                'delete_locale' => true,
+                            ]
+                        ),
+                    ]
+                );
+
                 $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
             }
 

--- a/Admin/ArticleAdmin.php
+++ b/Admin/ArticleAdmin.php
@@ -23,6 +23,7 @@ use Sulu\Bundle\AutomationBundle\Admin\View\AutomationViewBuilder;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -185,27 +186,32 @@ class ArticleAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)
                 && $this->securityChecker->hasPermission(static::SECURITY_CONTEXT . '_' . $typeKey, PermissionTypes::DELETE)) {
-                $formToolbarActionsWithType[] = new DropdownToolbarAction(
-                    'sulu_admin.delete',
-                    'su-trash-alt',
-                    [
-                        new ToolbarAction(
-                            'sulu_admin.delete',
-                            [
-                                'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
-                                'router_attributes_to_back_view' => ['webspace'],
-                            ]
-                        ),
-                        new ToolbarAction(
-                            'sulu_admin.delete',
-                            [
-                                'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
-                                'router_attributes_to_back_view' => ['webspace'],
-                                'delete_locale' => true,
-                            ]
-                        ),
-                    ]
-                );
+                // TODO remove when ArticleBundle requires Sulu ^2.3
+                if ((new \ReflectionClass(DocumentManagerInterface::class))->hasMethod('removeLocale')) {
+                    $formToolbarActionsWithType[] = new DropdownToolbarAction(
+                        'sulu_admin.delete',
+                        'su-trash-alt',
+                        [
+                            new ToolbarAction(
+                                'sulu_admin.delete',
+                                [
+                                    'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                                    'router_attributes_to_back_view' => ['webspace'],
+                                ]
+                            ),
+                            new ToolbarAction(
+                                'sulu_admin.delete',
+                                [
+                                    'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                                    'router_attributes_to_back_view' => ['webspace'],
+                                    'delete_locale' => true,
+                                ]
+                            ),
+                        ]
+                    );
+                } else {
+                    $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.delete');
+                }
 
                 $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
             }

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -484,12 +484,18 @@ class ArticleController extends AbstractRestController implements ClassResourceI
     /**
      * Deletes multiple documents.
      */
-    public function deleteAction(string $id): Response
+    public function deleteAction(Request $request, string $id): Response
     {
-        $documentManager = $this->documentManager;
-        $document = $documentManager->find($id);
-        $documentManager->remove($document);
-        $documentManager->flush();
+        $locale = $this->getLocale($request);
+        $deleteLocale = $this->getBooleanRequestParameter($request, 'deleteLocale', false, false);
+
+        $document = $this->documentManager->find($id);
+        if ($deleteLocale) {
+            $this->documentManager->removeLocale($document, $locale);
+        } else {
+            $this->documentManager->remove($document);
+        }
+        $this->documentManager->flush();
 
         return $this->handleView($this->view(null));
     }

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -167,7 +167,7 @@ class ArticleIndexer implements IndexerInterface
         ArticleDocument $document,
         string $locale,
         string $localizationState = LocalizationState::LOCALIZED
-    ): ArticleViewDocumentInterface {
+    ): ?ArticleViewDocumentInterface {
         $article = $this->findOrCreateViewDocument($document, $locale, $localizationState);
         if (!$article) {
             return null;
@@ -257,7 +257,7 @@ class ArticleIndexer implements IndexerInterface
         ArticleDocument $document,
         string $locale,
         string $localizationState
-    ): ArticleViewDocumentInterface {
+    ): ?ArticleViewDocumentInterface {
         $articleId = $this->getViewDocumentId($document->getUuid(), $locale);
         /** @var ArticleViewDocumentInterface $article */
         $article = $this->manager->find($this->documentFactory->getClass('article'), $articleId);
@@ -348,6 +348,15 @@ class ArticleIndexer implements IndexerInterface
         }
     }
 
+    public function removeLocale(ArticleDocument $document, string $locale): void
+    {
+        // overwrite removed locale with properties from original locale
+        $article = $this->createOrUpdateArticle($document, $locale);
+        $article->setLocalizationState(new LocalizationStateViewObject(LocalizationState::GHOST, $document->getOriginalLocale()));
+
+        $this->manager->persist($article);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -383,7 +392,7 @@ class ArticleIndexer implements IndexerInterface
     /**
      * {@inheritdoc}
      */
-    public function setUnpublished(string $uuid, string $locale): ArticleViewDocumentInterface
+    public function setUnpublished(string $uuid, string $locale): ?ArticleViewDocumentInterface
     {
         $articleId = $this->getViewDocumentId($uuid, $locale);
         /** @var ArticleViewDocumentInterface|null $article */

--- a/Document/Index/IndexerInterface.php
+++ b/Document/Index/IndexerInterface.php
@@ -28,7 +28,7 @@ interface IndexerInterface
      * Sets state of document to unpublished.
      * Clear published and sets published state to false.
      */
-    public function setUnpublished(string $uuid, string $locale): ArticleViewDocumentInterface;
+    public function setUnpublished(string $uuid, string $locale): ?ArticleViewDocumentInterface;
 
     /**
      * Indexes given document.
@@ -39,6 +39,11 @@ interface IndexerInterface
      * Removes document from index.
      */
     public function remove(ArticleDocument $document): void;
+
+    /**
+     * Removes specific document locale from the index.
+     */
+    public function removeLocale(ArticleDocument $document, string $locale): void;
 
     /**
      * Flushes index.

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -103,7 +103,7 @@ class ArticleSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return [
+        $subscribedEvents = [
             Events::HYDRATE => [
                 ['hydratePageData', -2000],
             ],
@@ -116,10 +116,6 @@ class ArticleSubscriber implements EventSubscriberInterface
                 ['handleRemove', -500],
                 ['handleRemoveLive', -500],
                 ['handleRemovePage', -500],
-            ],
-            EVENTS::REMOVE_LOCALE => [
-                ['handleRemoveLocale', -500],
-                ['handleRemoveLocaleLive', -500],
             ],
             Events::PUBLISH => [
                 ['handleScheduleIndexLive', 0],
@@ -135,6 +131,15 @@ class ArticleSubscriber implements EventSubscriberInterface
             Events::COPY => ['handleCopy'],
             Events::METADATA_LOAD => ['handleMetadataLoad'],
         ];
+
+        if (defined(Events::class . '::REMOVE_LOCALE')) {
+            $subscribedEvents[EVENTS::REMOVE_LOCALE] = [
+                ['handleRemoveLocale', -500],
+                ['handleRemoveLocaleLive', -500],
+            ];
+        }
+
+        return $subscribedEvents;
     }
 
     /**

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -30,6 +30,7 @@ use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\RemoveLocaleEvent;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
 use Sulu\Component\DocumentManager\Event\UnpublishEvent;
 use Sulu\Component\DocumentManager\Events;
@@ -115,6 +116,10 @@ class ArticleSubscriber implements EventSubscriberInterface
                 ['handleRemove', -500],
                 ['handleRemoveLive', -500],
                 ['handleRemovePage', -500],
+            ],
+            EVENTS::REMOVE_LOCALE => [
+                ['handleRemoveLocale', -500],
+                ['handleRemoveLocaleLive', -500],
             ],
             Events::PUBLISH => [
                 ['handleScheduleIndexLive', 0],
@@ -457,6 +462,20 @@ class ArticleSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * Removes localized article-document.
+     */
+    public function handleRemoveLocale(RemoveLocaleEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof ArticleDocument) {
+            return;
+        }
+
+        $this->indexer->removeLocale($document, $event->getLocale());
+        $this->indexer->flush();
+    }
+
+    /**
      * Removes article-document.
      *
      * @param RemoveEvent|UnpublishEvent $event
@@ -469,6 +488,20 @@ class ArticleSubscriber implements EventSubscriberInterface
         }
 
         $this->liveIndexer->remove($document);
+        $this->liveIndexer->flush();
+    }
+
+    /**
+     * Removes localized article-document from live index.
+     */
+    public function handleRemoveLocaleLive(RemoveLocaleEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof ArticleDocument) {
+            return;
+        }
+
+        $this->liveIndexer->removeLocale($document, $event->getLocale());
         $this->liveIndexer->flush();
     }
 

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -67,6 +67,12 @@ class ArticleIndexerTest extends SuluTestCase
 
     public function testDeleteLocale()
     {
+        if ((new \ReflectionClass(DocumentManagerInterface::class))->hasMethod('deleteLocale')) {
+            $this->markTestSkipped('Test is only viable on Sulu ^2.3');
+
+            return;
+        }
+
         $article = $this->createArticle(
             [
                 'article' => 'Test content',

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ArticleBundle\Tests\Functional\Document\Index;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
 use Ramsey\Uuid\Uuid;
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument;
 use Sulu\Bundle\ArticleBundle\Document\Index\ArticleIndexer;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
@@ -62,6 +63,45 @@ class ArticleIndexerTest extends SuluTestCase
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->indexer = $this->getContainer()->get('sulu_article.elastic_search.article_live_indexer');
         $this->indexer->clear();
+    }
+
+    public function testDeleteLocale()
+    {
+        $article = $this->createArticle(
+            [
+                'article' => 'Test content',
+            ],
+            'Test Article',
+            'default_with_route'
+        );
+
+        $secondLocale = 'de';
+
+        // now add second locale
+        $this->updateArticle(
+            $article['id'],
+            $secondLocale,
+            [
+                'id' => $article['id'],
+                'article' => 'Test Inhalt',
+            ],
+            'Test Artikel Deutsch',
+            'default_with_route'
+        );
+
+        /** @var ArticleDocument $articleDocument */
+        $articleDocument = $this->documentManager->find($article['id']);
+        $this->indexer->removeLocale($articleDocument, 'de');
+        $this->indexer->flush();
+
+        $documentDE = $this->findViewDocument($articleDocument->getUuid(), 'de');
+        $documentEN = $this->findViewDocument($articleDocument->getUuid(), 'en');
+
+        $this->assertSame('Test Article', $documentDE->getTitle());
+        $this->assertSame('ghost', $documentDE->getLocalizationState()->state);
+        $this->assertSame('en', $documentDE->getLocalizationState()->locale);
+
+        $this->assertSame('Test Article', $documentEN->getTitle());
     }
 
     public function testIndexDefaultWithRoute()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Adds the possibility to remove a single locale from an article, similar to https://github.com/sulu/sulu/pull/5686

#### Why?

Because it is already possible for pages