### PR TITLE
Fix php version for php-cs-fixer

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -19,6 +19,11 @@ jobs:
             - name: Create downloads directory
               run: mkdir downloads
 
+            - name: Install and configure PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+
             - name: Get downloads path
               id: php-cs-fixer-dir
               run: echo "::set-output name=dir::downloads"

--- a/Document/ArticleDocument.php
+++ b/Document/ArticleDocument.php
@@ -39,8 +39,7 @@ use Sulu\Component\DocumentManager\Version;
 /**
  * Represents an article in phpcr.
  */
-class ArticleDocument implements
-    UuidBehavior,
+class ArticleDocument implements UuidBehavior,
     NodeNameBehavior,
     AutoNameBehavior,
     PathBehavior,

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -28,8 +28,7 @@ use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
 /**
  * Represents an article-page in phpcr.
  */
-class ArticlePageDocument implements
-    UuidBehavior,
+class ArticlePageDocument implements UuidBehavior,
     LocalizedTitleBehavior,
     ParentBehavior,
     AutoNameBehavior,

--- a/Tests/Unit/Twig/ArticleViewDocumentTwigExtensionTest.php
+++ b/Tests/Unit/Twig/ArticleViewDocumentTwigExtensionTest.php
@@ -187,7 +187,7 @@ class ArticleViewDocumentTwigExtensionTest extends TestCase
      */
     private function getArticleViewDocuments(array $articleDocuments)
     {
-        return  array_map(
+        return array_map(
             function($articleDocument) {
                 $articleViewDocument = new ArticleViewDocument($articleDocument->getUuid());
                 $articleViewDocument->setLocale($articleDocument->getLocale());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Github Actions use PHP 8 and `php-cs-fixer` is not yet compatibel with php 8