### PR TITLE
Turn off normalization of type keys

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -101,6 +101,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('types')
                     ->useAttributeAsKey('name')
+                    ->normalizeKeys(false)
                     ->prototype('array')
                         ->children()
                             ->scalarNode('translation_key')->end()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Turn off normalization of type keys in the Symfony config loader.

#### Why?

The type keys of the configuration must match the tag type of tags by the name sulu_article.type from article XML files.
See here about the Symfony feature:
https://symfony.com/doc/current/components/config/definition.html#normalization

#### Example Usage

See press-release in the following config file. It must not be normalized to press_release.
~~~yaml
sulu_article:
    index_name: '%env(resolve:ELASTICSEARCH_INDEX)%'
    hosts:
        - '%env(resolve:ELASTICSEARCH_HOST)%'
    types:
        press-release:
            translation_key: "app.article_types.press-release"
~~~