### PR TITLE
Add experimental article admin with article content dimension entity

### DIFF
--- a/Article/Domain/Model/Article.php
+++ b/Article/Domain/Model/Article.php
@@ -12,6 +12,8 @@
 namespace Sulu\Bundle\ArticleBundle\Article\Domain\Model;
 
 use Ramsey\Uuid\Uuid;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityTrait;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Component\Persistence\Model\AuditableTrait;
 
 /**
@@ -19,12 +21,13 @@ use Sulu\Component\Persistence\Model\AuditableTrait;
  */
 class Article implements ArticleInterface
 {
+    use ContentRichEntityTrait;
     use AuditableTrait;
 
     /**
      * @var string
      */
-    private $id;
+    protected $id;
 
     public function __construct(
         ?string $id = null
@@ -35,5 +38,13 @@ class Article implements ArticleInterface
     public function getId(): string
     {
         return $this->id;
+    }
+
+    /**
+     * @return ArticleDimensionContentInterface
+     */
+    public function createDimensionContent(): DimensionContentInterface
+    {
+        return new ArticleDimensionContent($this);
     }
 }

--- a/Article/Domain/Model/ArticleDimensionContent.php
+++ b/Article/Domain/Model/ArticleDimensionContent.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Article\Domain\Model;
+
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentTrait;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptTrait;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\RoutableTrait;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoTrait;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateTrait;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowTrait;
+
+/**
+ * @experimental
+ */
+class ArticleDimensionContent implements ArticleDimensionContentInterface
+{
+    use DimensionContentTrait;
+    use ExcerptTrait;
+    use RoutableTrait;
+    use SeoTrait;
+    use TemplateTrait {
+        getTemplateData as parentGetTemplateData;
+        setTemplateData as parentSetTemplateData;
+    }
+    use WorkflowTrait;
+
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var ArticleInterface
+     */
+    protected $article;
+
+    /**
+     * @var string|null
+     */
+    protected $title;
+
+    public function __construct(ArticleInterface $article)
+    {
+        $this->article = $article;
+    }
+
+    /**
+     * @return ArticleInterface
+     */
+    public function getResource(): ContentRichEntityInterface
+    {
+        return $this->article;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTemplateData(): array
+    {
+        $data = $this->parentGetTemplateData();
+        $data['title'] = $this->getTitle();
+
+        return $data;
+    }
+
+    public function setTemplateData(array $templateData): void
+    {
+        $this->setTitle($templateData['title']);
+        unset($templateData['title']);
+        $this->parentSetTemplateData($templateData);
+    }
+
+    public static function getTemplateType(): string
+    {
+        return ArticleInterface::TEMPLATE_TYPE;
+    }
+
+    public static function getResourceKey(): string
+    {
+        return ArticleInterface::RESOURCE_KEY;
+    }
+}

--- a/Article/Domain/Model/ArticleDimensionContentInterface.php
+++ b/Article/Domain/Model/ArticleDimensionContentInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Article\Domain\Model;
+
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ExcerptInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\RoutableInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\SeoInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\TemplateInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\WorkflowInterface;
+
+/**
+ * @experimental
+ */
+interface ArticleDimensionContentInterface extends DimensionContentInterface, ExcerptInterface, SeoInterface, TemplateInterface, RoutableInterface, WorkflowInterface
+{
+    public function getTitle(): ?string;
+
+    public function setTitle(?string $title);
+}

--- a/Article/Domain/Model/ArticleInterface.php
+++ b/Article/Domain/Model/ArticleInterface.php
@@ -11,12 +11,13 @@
 
 namespace Sulu\Bundle\ArticleBundle\Article\Domain\Model;
 
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * @experimental
  */
-interface ArticleInterface extends AuditableInterface
+interface ArticleInterface extends AuditableInterface, ContentRichEntityInterface
 {
     public const TEMPLATE_TYPE = 'article';
     public const RESOURCE_KEY = 'article';

--- a/Article/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/Article/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Article\Infrastructure\Sulu\Admin;
+
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleInterface;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
+use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+
+/**
+ * @internal This class is internal and should not be extended or overwritten.
+ *           Create an own admin class to extend the view or navigation
+ *           by getting the the instance from the collection.
+ *
+ * @experimental
+ */
+class ArticleAdmin extends Admin
+{
+    const SECURITY_CONTEXT = 'sulu.article.articles';
+
+    const LIST_VIEW = 'sulu_article.article.list';
+
+    const ADD_TABS_VIEW = 'sulu_article.article.add_tabs';
+
+    const EDIT_TABS_VIEW = 'sulu_article.article.edit_tabs';
+
+    /**
+     * @var ViewBuilderFactoryInterface
+     */
+    private $viewBuilderFactory;
+
+    /**
+     * @var ContentViewBuilderFactoryInterface
+     */
+    private $contentViewBuilderFactory;
+
+    /**
+     * @var SecurityCheckerInterface
+     */
+    private $securityChecker;
+
+    /**
+     * @var LocalizationManagerInterface
+     */
+    private $localizationManager;
+
+    public function __construct(
+        ViewBuilderFactoryInterface $viewBuilderFactory,
+        ContentViewBuilderFactoryInterface $contentViewBuilderFactory,
+        SecurityCheckerInterface $securityChecker,
+        LocalizationManagerInterface $localizationManager
+    ) {
+        $this->viewBuilderFactory = $viewBuilderFactory;
+        $this->contentViewBuilderFactory = $contentViewBuilderFactory;
+        $this->securityChecker = $securityChecker;
+        $this->localizationManager = $localizationManager;
+    }
+
+    public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
+    {
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $navigationItem = new NavigationItem('sulu_article.articles');
+            $navigationItem->setPosition(20);
+            $navigationItem->setIcon('su-newspaper');
+            $navigationItem->setView(static::LIST_VIEW);
+
+            $navigationItemCollection->add($navigationItem);
+        }
+    }
+
+    public function configureViews(ViewCollection $viewCollection): void
+    {
+        $bundlePrefix = 'sulu_article.';
+        $locales = $this->localizationManager->getLocales();
+        $resourceKey = ArticleInterface::RESOURCE_KEY;
+
+        $listToolbarActions = [];
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+        }
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+        }
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+        }
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $viewCollection->add(
+                $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/' . $resourceKey . '/:locale')
+                    ->setResourceKey($resourceKey)
+                    ->setListKey($resourceKey)
+                    ->setTitle($bundlePrefix . $resourceKey)
+                    ->addListAdapters(['table'])
+                    ->addLocales($locales)
+                    ->setDefaultLocale($locales[0])
+                    ->setAddView(static::ADD_TABS_VIEW)
+                    ->setEditView(static::EDIT_TABS_VIEW)
+                    ->addToolbarActions($listToolbarActions)
+            );
+            $viewCollection->add(
+                $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_TABS_VIEW, '/' . $resourceKey . '/:locale/add')
+                    ->setResourceKey($resourceKey)
+                    ->addLocales($locales)
+                    ->setBackView(static::LIST_VIEW)
+            );
+            $viewCollection->add(
+                $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_TABS_VIEW, '/' . $resourceKey . '/:locale/:id')
+                    ->setResourceKey($resourceKey)
+                    ->addLocales($locales)
+                    ->setBackView(static::LIST_VIEW)
+                    ->setTitleProperty('name')
+            );
+
+            $viewBuilders = $this->contentViewBuilderFactory->createViews(
+                ArticleInterface::class,
+                static::EDIT_TABS_VIEW,
+                static::ADD_TABS_VIEW,
+                static::SECURITY_CONTEXT
+            );
+
+            foreach ($viewBuilders as $viewBuilder) {
+                $viewCollection->add($viewBuilder);
+            }
+        }
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getSecurityContexts()
+    {
+        return [
+            'Sulu' => [
+                'Global' => [
+                    static::SECURITY_CONTEXT => [
+                        PermissionTypes::VIEW,
+                        PermissionTypes::ADD,
+                        PermissionTypes::EDIT,
+                        PermissionTypes::DELETE,
+                        PermissionTypes::LIVE,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/Article/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/Article/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -25,8 +25,8 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
 /**
  * @internal This class is internal and should not be extended or overwritten.
- *           Create an own admin class to extend the view or navigation
- *           by getting the the instance from the collection.
+ *           You can create a separate admin class in your project and get the 
+ *           respective object from the collection to extend a navigation item or a view
  *
  * @experimental
  */

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle\DependencyInjection;
 
 use Sulu\Bundle\ArticleBundle\Article\Domain\Model\Article;
+use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleDimensionContent;
 use Sulu\Bundle\ArticleBundle\Document\ArticlePageViewObject;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -49,6 +50,12 @@ class Configuration implements ConfigurationInterface
                                     ->addDefaultsIfNotSet()
                                     ->children()
                                         ->scalarNode('model')->defaultValue(Article::class)->end()
+                                    ->end()
+                                ->end()
+                                ->arrayNode('article_content')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(ArticleDimensionContent::class)->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -418,6 +418,8 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
     private function loadExperimentalStorage(array $config, ContainerBuilder $container, Loader\XmlFileLoader $loader): void
     {
         $this->configurePersistence($config['article']['objects'], $container);
+
+        $loader->load('experimental.xml');
     }
 
     /**

--- a/Resources/config/doctrine/Article/Article.orm.xml
+++ b/Resources/config/doctrine/Article/Article.orm.xml
@@ -10,5 +10,11 @@
         <id name="id" type="string" column="id">
             <generator strategy="NONE"/>
         </id>
+
+        <one-to-many field="dimensionContents" target-entity="Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleDimensionContentInterface" mapped-by="article">
+            <cascade>
+                <cascade-persist/>
+            </cascade>
+        </one-to-many>
     </mapped-superclass>
 </doctrine-mapping>

--- a/Resources/config/doctrine/Article/ArticleDimensionContent.orm.xml
+++ b/Resources/config/doctrine/Article/ArticleDimensionContent.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleDimensionContent"
+            table="ar_articles_dimension_contents">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="title" type="string" column="title" length="64" nullable="true"/>
+
+        <many-to-one field="article" target-entity="Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleInterface" inversed-by="dimensionContents">
+            <join-columns>
+                <join-column name="articleId" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
+            </join-columns>
+        </many-to-one>
+    </entity>
+</doctrine-mapping>

--- a/Resources/config/experimental.xml
+++ b/Resources/config/experimental.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <!--
+        @internal this file should not be referenced inside your project
+
+        NOTE: this are the service definitions when using the "experimental" storage
+        The service definitions when using the "phpcr" storage can
+        be found in the "services.xml" file in this directory.
+    -->
+
+    <services>
+        <service id="sulu_article.article_admin" class="Sulu\Bundle\ArticleBundle\Article\Infrastructure\Sulu\Admin\ArticleAdmin">
+            <!-- @internal this service is internal and should not be used by your project -->
+
+            <argument type="service" id="sulu_admin.view_builder_factory" />
+            <argument type="service" id="sulu_content.content_view_builder_factory" />
+            <argument type="service" id="sulu_security.security_checker" />
+            <argument type="service" id="sulu.core.localization_manager" />
+
+            <tag name="sulu.context" context="admin"/>
+            <tag name="sulu.admin" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -3,9 +3,11 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <!--
+        @internal this file should not be referenced inside your project
+
         NOTE: this are the service definitions when using the "phpcr" storage
-        The service definitions when using the "content_bundle" storage can
-        be found in the other xml files in this directory.
+        The service definitions when using the "experimental" storage can
+        be found in the "experimental.xml" file in this directory.
     -->
 
     <parameters>

--- a/SuluArticleBundle.php
+++ b/SuluArticleBundle.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle;
 
+use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\ArticleBundle\DependencyInjection\Configuration;
 use Sulu\Bundle\ArticleBundle\DependencyInjection\ConverterCompilerPass;
@@ -64,6 +65,7 @@ class SuluArticleBundle extends Bundle implements CompilerPassInterface
         return [
             new ResolveTargetEntitiesPass([
                 ArticleInterface::class => 'sulu.model.article.class',
+                ArticleDimensionContentInterface::class => 'sulu.model.article_content.class',
             ]),
         ];
     }

--- a/Tests/Application/Kernel.php
+++ b/Tests/Application/Kernel.php
@@ -15,6 +15,7 @@ use ONGR\ElasticsearchBundle\ONGRElasticsearchBundle;
 use Sulu\Bundle\ArticleBundle\SuluArticleBundle;
 use Sulu\Bundle\ArticleBundle\Tests\Application\Testing\ArticleBundleKernelBrowser;
 use Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\TestExtendBundle;
+use Sulu\Bundle\ContentBundle\SuluContentBundle;
 use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -50,6 +51,10 @@ class Kernel extends SuluTestKernel implements CompilerPassInterface
 
         if ('phpcr_storage' === $this->config) {
             $bundles[] = new ONGRElasticsearchBundle();
+        }
+
+        if ('experimental_storage' === $this->config) {
+            $bundles[] = new SuluContentBundle();
         }
 
         if ('extend' === getenv('ARTICLE_TEST_CASE')) {

--- a/Tests/Application/config/config_experimental_storage.yml
+++ b/Tests/Application/config/config_experimental_storage.yml
@@ -1,4 +1,3 @@
 sulu_article:
     article:
         storage: 'experimental'
-    default_main_webspace: 'sulu_io'

--- a/Tests/Unit/Article/Domain/Model/ArticleDimensionContentTest.php
+++ b/Tests/Unit/Article/Domain/Model/ArticleDimensionContentTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Article\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleDimensionContent;
+use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleDimensionContentInterface;
+use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleInterface;
+
+class ArticleDimensionContentTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy<ArticleInterface>
+     */
+    private $article;
+
+    protected function setUp(): void
+    {
+        $this->article = $this->prophesize(ArticleInterface::class);
+    }
+
+    public function testGetResource(): void
+    {
+        $articleDimensionContent = $this->createArticlDimensionContent();
+        $this->assertSame($this->article->reveal(), $articleDimensionContent->getResource());
+    }
+
+    public function testTitle(): void
+    {
+        $articleDimensionContent = $this->createArticlDimensionContent();
+        $articleDimensionContent->setTitle('My Title');
+        $this->assertSame('My Title', $articleDimensionContent->getTitle());
+    }
+
+    public function testTitleNull(): void
+    {
+        $articleDimensionContent = $this->createArticlDimensionContent();
+        $this->assertNull($articleDimensionContent->getTitle());
+    }
+
+    public function testTitleTemplateData(): void
+    {
+        $articleDimensionContent = $this->createArticlDimensionContent();
+        $articleDimensionContent->setTemplateData(['title' => 'My Title']);
+        $this->assertSame('My Title', $articleDimensionContent->getTitle());
+    }
+
+    public function testTemplateData(): void
+    {
+        $articleDimensionContent = $this->createArticlDimensionContent();
+        $articleDimensionContent->setTemplateData(['title' => 'My Title', 'description' => 'My Description']);
+        $this->assertSame(
+            [
+                'description' => 'My Description',
+                'title' => 'My Title',
+            ],
+            $articleDimensionContent->getTemplateData()
+        );
+    }
+
+    public function testGetTemplateType(): void
+    {
+        $this->assertSame(
+            // use string instead of constant to test regression which maybe need migrations
+            'article',
+            ArticleDimensionContent::getTemplateType()
+        );
+    }
+
+    public function testGetResourceKey(): void
+    {
+        $this->assertSame(
+            // use string instead of constant to test regression which maybe need migrations
+            'article',
+            ArticleDimensionContent::getResourceKey()
+        );
+    }
+
+    private function createArticlDimensionContent(): ArticleDimensionContentInterface
+    {
+        return new ArticleDimensionContent(
+            $this->article->reveal()
+        );
+    }
+}

--- a/Tests/Unit/Article/Infrastructure/Sulu/Admin/ArticleAdminTest.php
+++ b/Tests/Unit/Article/Infrastructure/Sulu/Admin/ArticleAdminTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Article\Infrastructure\Sulu\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\ArticleBundle\Article\Domain\Model\ArticleInterface;
+use Sulu\Bundle\ArticleBundle\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
+use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
+use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+
+class ArticleAdminTest extends TestCase
+{
+    /**
+     * @var ViewBuilderFactoryInterface
+     */
+    private $viewBuilderFactory;
+
+    /**
+     * @var ObjectProphecy<ContentViewBuilderFactoryInterface>
+     */
+    private $contentViewBuilderFactory;
+
+    /**
+     * @var ObjectProphecy<SecurityCheckerInterface>
+     */
+    private $securityChecker;
+
+    /**
+     * @var ObjectProphecy<LocalizationManagerInterface>
+     */
+    private $localizationManager;
+
+    /**
+     * @var ArticleAdmin
+     */
+    private $articleAdmin;
+
+    protected function setUp(): void
+    {
+        $this->viewBuilderFactory = new ViewBuilderFactory();
+        $this->contentViewBuilderFactory = $this->prophesize(ContentViewBuilderFactoryInterface::class);
+        $this->securityChecker = $this->prophesize(SecurityCheckerInterface::class);
+        $this->localizationManager = $this->prophesize(LocalizationManagerInterface::class);
+
+        $this->articleAdmin = new ArticleAdmin(
+            $this->viewBuilderFactory,
+            $this->contentViewBuilderFactory->reveal(),
+            $this->securityChecker->reveal(),
+            $this->localizationManager->reveal()
+        );
+    }
+
+    public function testConfigureViews(): void
+    {
+        $viewCollection = $this->prophesize(ViewCollection::class);
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, Argument::any())
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $this->localizationManager->getLocales()
+            ->shouldBeCalled()
+            ->willReturn(['de', 'en']);
+
+        $contentView = $this->prophesize(ViewBuilderInterface::class);
+
+        $this->contentViewBuilderFactory->createViews(
+            ArticleInterface::class,
+            ArticleAdmin::EDIT_TABS_VIEW,
+            ArticleAdmin::ADD_TABS_VIEW,
+            ArticleAdmin::SECURITY_CONTEXT
+        )
+            ->shouldBeCalled()
+            ->willReturn([$contentView->reveal()]);
+
+        $viewCollection->add(Argument::any())
+            ->shouldBeCalled(4);
+
+        $this->articleAdmin->configureViews($viewCollection->reveal());
+    }
+
+    public function testConfigureNavigationItems(): void
+    {
+        $navigationItemCollection = $this->prophesize(NavigationItemCollection::class);
+        $navigationItemCollection->add(Argument::any())
+            ->shouldBeCalledOnce();
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection->reveal());
+    }
+
+    public function testConfigureNavigationItemsNoPermissions(): void
+    {
+        $navigationItemCollection = $this->prophesize(NavigationItemCollection::class);
+        $navigationItemCollection->add(Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection->reveal());
+    }
+
+    public function testGetSecurityContexts(): void
+    {
+        $this->assertSame(
+            [
+                'Sulu' => [
+                    'Global' => [
+                        // using not the ArticleAdmin constant here to test regression which would need a migration
+                        'sulu.article.articles' => [
+                            PermissionTypes::VIEW,
+                            PermissionTypes::ADD,
+                            PermissionTypes::EDIT,
+                            PermissionTypes::DELETE,
+                            PermissionTypes::LIVE,
+                        ],
+                    ],
+                ],
+            ],
+            $this->articleAdmin->getSecurityContexts()
+        );
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #430, #553 previous PR
| License | MIT

#### What's in this PR?

Add article admin with article content dimension entity.

#### Why?

For the experimental article storage.

#### Example Usage

```yaml
sulu_article:
     article:
           storage: 'experimental'
```

