### PR TITLE
Fixed route provider regarding published state and ghost content

### DIFF
--- a/Routing/ArticleRouteDefaultProvider.php
+++ b/Routing/ArticleRouteDefaultProvider.php
@@ -118,7 +118,13 @@ class ArticleRouteDefaultProvider implements RouteDefaultsProviderInterface
      */
     public function isPublished($entityClass, $id, $locale)
     {
-        $object = $this->documentManager->find($id, $locale);
+        $object = $this->documentManager->find(
+            $id,
+            $locale,
+            [
+                'load_ghost_content' => false,
+            ]
+        );
 
         if (!$object instanceof ArticleInterface || WorkflowStage::PUBLISHED !== $object->getWorkflowStage()) {
             return false;

--- a/Tests/Unit/Routing/ArticleRouteDefaultProviderTest.php
+++ b/Tests/Unit/Routing/ArticleRouteDefaultProviderTest.php
@@ -100,9 +100,11 @@ class ArticleRouteDefaultProviderTest extends \PHPUnit_Framework_TestCase
     public function publishedDataProvider()
     {
         $articleDocument = new ArticleDocument();
+	$articleDocument->setLocale($this->locale);
         $articleDocument->setWorkflowStage(WorkflowStage::TEST);
 
         $articleDocumentPublished = new ArticleDocument();
+	$articleDocumentPublished->setLocale($this->locale);
         $articleDocumentPublished->setWorkflowStage(WorkflowStage::PUBLISHED);
 
         $unknownDocument = new UnknownDocument();

--- a/Tests/Unit/Routing/ArticleRouteDefaultProviderTest.php
+++ b/Tests/Unit/Routing/ArticleRouteDefaultProviderTest.php
@@ -100,11 +100,11 @@ class ArticleRouteDefaultProviderTest extends \PHPUnit_Framework_TestCase
     public function publishedDataProvider()
     {
         $articleDocument = new ArticleDocument();
-	$articleDocument->setLocale($this->locale);
+        $articleDocument->setLocale($this->locale);
         $articleDocument->setWorkflowStage(WorkflowStage::TEST);
 
         $articleDocumentPublished = new ArticleDocument();
-	$articleDocumentPublished->setLocale($this->locale);
+        $articleDocumentPublished->setLocale($this->locale);
         $articleDocumentPublished->setWorkflowStage(WorkflowStage::PUBLISHED);
 
         $unknownDocument = new UnknownDocument();

--- a/Tests/Unit/Routing/ArticleRouteDefaultProviderTest.php
+++ b/Tests/Unit/Routing/ArticleRouteDefaultProviderTest.php
@@ -100,11 +100,9 @@ class ArticleRouteDefaultProviderTest extends \PHPUnit_Framework_TestCase
     public function publishedDataProvider()
     {
         $articleDocument = new ArticleDocument();
-        $articleDocument->setLocale($this->locale);
         $articleDocument->setWorkflowStage(WorkflowStage::TEST);
 
         $articleDocumentPublished = new ArticleDocument();
-        $articleDocumentPublished->setLocale($this->locale);
         $articleDocumentPublished->setWorkflowStage(WorkflowStage::PUBLISHED);
 
         $unknownDocument = new UnknownDocument();
@@ -132,7 +130,13 @@ class ArticleRouteDefaultProviderTest extends \PHPUnit_Framework_TestCase
             $this->webspaceResolver->resolveAdditionalWebspaces($document)->willReturn($documentAdditionalWebspaces);
         }
 
-        $this->documentManager->find($this->entityId, $this->locale)->willReturn($document);
+        $this->documentManager->find(
+            $this->entityId,
+            $this->locale,
+            [
+                'load_ghost_content' => false,
+            ]
+        )->willReturn($document);
 
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn($webspaceKey);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixes the `ArticleRouteDefaultProvider` as the ghost content was loaded although the article in the requested locale was unpublished.

#### Why?

To show the article on the website only if it's published in the requested locale.
