### PR TITLE
Add content fields to ArticleViewDocument

### DIFF
--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -887,7 +887,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     /**
      * {@inheritdoc}
      */
-    public function setContentFields(array $contentFields): ArticleViewDocumentInterface
+    public function setContentFields(array $contentFields)
     {
         $this->contentFields = $contentFields;
 

--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -290,6 +290,13 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     protected $targetWebspace;
 
     /**
+     * @var string[]
+     *
+     * @Property(type="text")
+     */
+    protected $contentFields;
+
+    /**
      * @param string $uuid
      */
     public function __construct($uuid = null)
@@ -865,6 +872,24 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     public function setTargetWebspace($targetWebspace)
     {
         $this->targetWebspace = $targetWebspace;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentFields(): array
+    {
+        return $this->contentFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContentFields(array $contentFields): ArticleViewDocumentInterface
+    {
+        $this->contentFields = $contentFields;
 
         return $this;
     }

--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -879,7 +879,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
     /**
      * {@inheritdoc}
      */
-    public function getContentFields(): array
+    public function getContentFields()
     {
         return $this->contentFields;
     }

--- a/Document/ArticleViewDocumentInterface.php
+++ b/Document/ArticleViewDocumentInterface.php
@@ -516,6 +516,8 @@ interface ArticleViewDocumentInterface
 
     /**
      * @param string[] $searchableContent
+     *
+     * @return $this
      */
-    public function setContentFields(array $contentFields): self;
+    public function setContentFields(array $contentFields);
 }

--- a/Document/ArticleViewDocumentInterface.php
+++ b/Document/ArticleViewDocumentInterface.php
@@ -508,4 +508,14 @@ interface ArticleViewDocumentInterface
      * @return $this
      */
     public function setTargetWebspace($targetWebspace);
+
+    /**
+     * @return string[]
+     */
+    public function getContentFields(): array;
+
+    /**
+     * @param string[] $searchableContent
+     */
+    public function setContentFields(array $contentFields): self;
 }

--- a/Document/ArticleViewDocumentInterface.php
+++ b/Document/ArticleViewDocumentInterface.php
@@ -512,7 +512,7 @@ interface ArticleViewDocumentInterface
     /**
      * @return string[]
      */
-    public function getContentFields(): array;
+    public function getContentFields();
 
     /**
      * @param string[] $searchableContent

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -281,7 +281,6 @@ class ArticleIndexer implements IndexerInterface
         return $contentFields;
     }
 
-
     private function getBlockContentFieldsRecursive(array $blocks, ArticleDocument $document, $blockMetaData, string $tag): array
     {
         $contentFields = [];

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ArticleBundle\Document\Index;
 
+use Metadata\PropertyMetadata;
 use ONGR\ElasticsearchBundle\Collection\Collection;
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
@@ -34,6 +35,7 @@ use Sulu\Bundle\SecurityBundle\UserManager\UserManager;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -246,6 +248,7 @@ class ArticleIndexer implements IndexerInterface
             }
         }
 
+        $article->setContentFields($this->getContentFields($structureMetadata, $document));
         $article->setContentData(json_encode($document->getStructure()->toArray()));
 
         $article->setMainWebspace($this->webspaceResolver->resolveMainWebspace($document));
@@ -254,6 +257,74 @@ class ArticleIndexer implements IndexerInterface
         $this->mapPages($document, $article);
 
         return $article;
+    }
+
+    protected function getContentFields(StructureMetadata $structure, ArticleDocument $document)
+    {
+        $tag = 'sulu.search.field';
+        $contentFields = [];
+        foreach ($structure->getProperties() as $property) {
+            if (method_exists($property, 'getComponents') && \count($property->getComponents()) > 0) {
+                $blocks = $document->getStructure()->getProperty($property->getName())->getValue();
+                if (isset($blocks['hotspots'])) {
+                    $blocks = $blocks['hotspots'];
+                }
+                $contentFields = array_merge($contentFields, $this->getBlockContentFieldsRecursive($blocks, $document, $property, $tag));
+            } elseif ($property->hasTag($tag)) {
+                $value = $document->getStructure()->getProperty($property->getName())->getValue();
+                if (is_string($value) && '' !== $value) {
+                    $contentFields[] = strip_tags($value);
+                }
+            }
+        }
+
+        return $contentFields;
+    }
+
+
+    private function getBlockContentFieldsRecursive(array $blocks, ArticleDocument $document, $blockMetaData, string $tag): array
+    {
+        $contentFields = [];
+        foreach ($blockMetaData->getComponents() as $component) {
+            /** @var PropertyMetadata $componentProperty */
+            foreach ($component->getChildren() as $componentProperty) {
+                if (method_exists($componentProperty, 'getComponents') && \count($componentProperty->getComponents()) > 0) {
+                    $filteredBlocks = array_filter($blocks, function($block) use ($component) {
+                        return $block['type'] === $component->getName();
+                    });
+
+                    foreach ($filteredBlocks as $filteredBlock) {
+                        if (isset($filteredBlock['hotspots'])) {
+                            $filteredBlock = $filteredBlock['hotspots'];
+                        }
+                        $contentFields = array_merge(
+                            $contentFields,
+                            $this->getBlockContentFieldsRecursive(
+                                $filteredBlock[$componentProperty->getName()],
+                                $document,
+                                $componentProperty,
+                                $tag
+                            )
+                        );
+                    }
+                }
+
+                if (false === $componentProperty->hasTag($tag)) {
+                    continue;
+                }
+
+                foreach ($blocks as $block) {
+                    if ($block['type'] === $component->getName()) {
+                        $blockValue = $block[$componentProperty->getName()];
+                        if (\is_string($blockValue) && '' !== $blockValue) {
+                            $contentFields[] = strip_tags($blockValue);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $contentFields;
     }
 
     /**

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -281,7 +281,10 @@ class ArticleIndexer implements IndexerInterface
         return $contentFields;
     }
 
-    private function getBlockContentFieldsRecursive(array $blocks, ArticleDocument $document, $blockMetaData, string $tag): array
+    /**
+     * @return string[]
+     */
+    private function getBlockContentFieldsRecursive(array $blocks, ArticleDocument $document, $blockMetaData, $tag)
     {
         $contentFields = [];
         foreach ($blockMetaData->getComponents() as $component) {

--- a/Resources/doc/article-view-document.md
+++ b/Resources/doc/article-view-document.md
@@ -28,8 +28,27 @@ is requested (content-types, smart-content, ...).
 | targetWebspace | string | Recommended webspace key |
 | mainWebspace | string | Configured main webspace |
 | additionalWebspaces | string[] | Configured additional webspaces |
+| contentFields | string[] | Contains content properties tagged with `sulu.search.field` |
 
 The `content` and `view` property is represented by a proxy to avoid resolving data where it is not needed.
+
+### ContentFields
+
+The content of the property `contentFields` can be customized. All properties which are tagged with
+`sulu.search.field` in the xml configuration, are automatically added to this field. The main purpose of this field
+is to give the developer enough data and flexibility to implement search functionality via e.g. a `SearchController`.
+
+Example:
+```xml
+    <property name="text" type="text_editor" mandatory="true">
+        <meta>
+            <title lang="en">Text</title>
+            <title lang="de">Text</title>
+        </meta>
+    
+        <tag name="sulu.search.field"/>
+    </property>
+```
 
 ## How to extend?
 

--- a/Tests/Functional/Controller/TemplateControllerTest.php
+++ b/Tests/Functional/Controller/TemplateControllerTest.php
@@ -23,8 +23,8 @@ class TemplateControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(2, $response['total']);
-        $this->assertCount(2, $response['_embedded']);
+        $this->assertEquals(3, $response['total']);
+        $this->assertCount(3, $response['_embedded']);
         $this->assertContains(
             [
                 'internal' => false,

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -192,8 +192,8 @@ class ArticleIndexerTest extends SuluTestCase
                     'type' => 'title-with-article',
                     'title' => 'Test Title in Block',
                     'article' => '<p>Test Article in Block</p>',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $article = $this->createArticle($data, $data['title'], 'default_with_search_tags');

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -180,7 +180,7 @@ class ArticleIndexerTest extends SuluTestCase
         $this->assertFalse($viewDocument->getPublishedState());
     }
 
-    public function testIndexTaggedProperties(): void
+    public function testIndexTaggedProperties()
     {
         $data = [
             'title' => 'Test Article Title',

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -180,6 +180,43 @@ class ArticleIndexerTest extends SuluTestCase
         $this->assertFalse($viewDocument->getPublishedState());
     }
 
+    public function testIndexTaggedProperties(): void
+    {
+        $data = [
+            'title' => 'Test Article Title',
+            'pageTitle' => 'Test Page Title',
+            'article' => '<p>Test Article</p>',
+            'article_2' => '<p>should not be indexed</p>',
+            'blocks' => [
+                [
+                    'type' => 'title-with-article',
+                    'title' => 'Test Title in Block',
+                    'article' => '<p>Test Article in Block</p>',
+                ]
+            ]
+        ];
+
+        $article = $this->createArticle($data, $data['title'], 'default_with_search_tags');
+        $this->documentManager->clear();
+
+        $document = $this->documentManager->find($article['id'], $this->locale);
+        $this->indexer->index($document);
+        $this->indexer->flush();
+
+        $viewDocument = $this->findViewDocument($article['id']);
+        $contentFields = $viewDocument->getContentFields();
+
+        $this->assertSame($article['id'], $viewDocument->getUuid());
+        $this->assertSame($data, json_decode($viewDocument->getContentData(), true));
+
+        $this->assertCount(5, $contentFields);
+        $this->assertContains('Test Article Title', $contentFields);
+        $this->assertContains('Test Page Title', $contentFields);
+        $this->assertContains('Test Article', $contentFields);
+        $this->assertContains('Test Title in Block', $contentFields);
+        $this->assertContains('Test Article in Block', $contentFields);
+    }
+
     public function testIndexContentData()
     {
         $data = [

--- a/Tests/app/Resources/articles/default_with_search_tags.xml
+++ b/Tests/app/Resources/articles/default_with_search_tags.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default_with_search_tags</key>
+
+    <view>::default</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <tag name="sulu_article.type" type="blog"/>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <tag name="sulu.search.field"/>
+        </property>
+
+        <property name="pageTitle" type="text_line">
+            <tag name="sulu.search.field"/>
+        </property>
+
+        <property name="article" type="text_editor">
+            <tag name="sulu.search.field"/>
+        </property>
+
+        <property name="article_2" type="text_editor"/>
+
+        <block name="blocks" default-type="title-with-article">
+            <types>
+                <type name="title-with-article">
+                    <properties>
+                        <property name="title" type="text_line">
+                            <tag name="sulu.search.field"/>
+                        </property>
+
+                        <property name="article" type="text_editor">
+                            <tag name="sulu.search.field"/>
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Adds an additional `contentField` to the `ArticleViewDocument`. 
The `contentField` holds all properties, which are tagged with `sulu.search.field` in the xml configuration.

Thus the developer can easily index custom fields and use them e.g. in a `SearchController`.

#### Why?

Some projects need more data in the index to create a desired search behaviour.

#### Example Usage

~~~xml
        <property name="text" type="text_editor" mandatory="true">
            <meta>
                <title lang="en">Text</title>
                <title lang="de">Text</title>
            </meta>

            <tag name="sulu.search.field"/>
        </property>
~~~

#### To Do

- [x] Add tests
- [ ] Add documentation page
