### PR TITLE
Add activity view and restore domain event

### DIFF
--- a/Domain/Event/ArticleVersionRestoredEvent.php
+++ b/Domain/Event/ArticleVersionRestoredEvent.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
+
+class ArticleVersionRestoredEvent extends DomainEvent
+{
+    /**
+     * @var ArticleDocument
+     */
+    private $articleDocument;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var string
+     */
+    private $version;
+
+    public function __construct(
+        ArticleDocument $articleDocument,
+        string $locale,
+        string $version
+    ) {
+        parent::__construct();
+
+        $this->articleDocument = $articleDocument;
+        $this->locale = $locale;
+        $this->version = $version;
+    }
+
+    public function getArticleDocument(): ArticleDocument
+    {
+        return $this->articleDocument;
+    }
+
+    public function getEventType(): string
+    {
+        return 'version_restored';
+    }
+
+    public function getEventContext(): array
+    {
+        return [
+            'version' => $this->version,
+        ];
+    }
+
+    public function getResourceKey(): string
+    {
+        return ArticleDocument::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return $this->articleDocument->getUuid();
+    }
+
+    public function getResourceLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        return $this->articleDocument->getTitle();
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->articleDocument->getLocale();
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return ArticleAdmin::SECURITY_CONTEXT;
+    }
+
+    public function getResourceSecurityObjectType(): ?string
+    {
+        return SecurityBehavior::class;
+    }
+}

--- a/Domain/Event/ArticleVersionRestoredEvent.php
+++ b/Domain/Event/ArticleVersionRestoredEvent.php
@@ -16,8 +16,6 @@ namespace Sulu\Bundle\ArticleBundle\Domain\Event;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
-use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 
 class ArticleVersionRestoredEvent extends DomainEvent

--- a/EventListener/DomainEventSubscriber.php
+++ b/EventListener/DomainEventSubscriber.php
@@ -23,6 +23,7 @@ use Sulu\Bundle\ArticleBundle\Domain\Event\ArticleTranslationAddedEvent;
 use Sulu\Bundle\ArticleBundle\Domain\Event\ArticleTranslationCopiedEvent;
 use Sulu\Bundle\ArticleBundle\Domain\Event\ArticleTranslationRemovedEvent;
 use Sulu\Bundle\ArticleBundle\Domain\Event\ArticleUnpublishedEvent;
+use Sulu\Bundle\ArticleBundle\Domain\Event\ArticleVersionRestoredEvent;
 use Sulu\Bundle\DocumentManagerBundle\Collector\DocumentDomainEventCollectorInterface;
 use Sulu\Component\Content\Document\Extension\ExtensionContainer;
 use Sulu\Component\Content\Document\Subscriber\SecuritySubscriber;
@@ -36,6 +37,7 @@ use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\Event\RemoveLocaleEvent;
+use Sulu\Component\DocumentManager\Event\RestoreEvent;
 use Sulu\Component\DocumentManager\Event\UnpublishEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\PropertyEncoder;
@@ -105,6 +107,7 @@ class DomainEventSubscriber implements EventSubscriberInterface
             Events::PUBLISH => ['handlePublish', -10000],
             Events::UNPUBLISH => ['handleUnpublish', -10000],
             Events::REMOVE_DRAFT => ['handleRemoveDraft', -10000],
+            Events::RESTORE => ['handleRestore', -10000],
         ];
     }
 
@@ -350,6 +353,25 @@ class DomainEventSubscriber implements EventSubscriberInterface
             new ArticleDraftRemovedEvent(
                 $document,
                 $locale
+            )
+        );
+    }
+
+    public function handleRestore(RestoreEvent $event): void
+    {
+        $document = $event->getDocument();
+        $locale = $event->getLocale();
+        $version = $event->getVersion();
+
+        if (!$document instanceof ArticleDocument) {
+            return;
+        }
+
+        $this->domainEventCollector->collect(
+            new ArticleVersionRestoredEvent(
+                $document,
+                $locale,
+                $version
             )
         );
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,6 +26,7 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument>%kernel.bundles%</argument>
             <argument>%sulu_article.types%</argument>
+            <argument>%sulu_document_manager.versioning.enabled%</argument>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/Resources/translations/admin.de.json
+++ b/Resources/translations/admin.de.json
@@ -10,5 +10,17 @@
     "sulu_article.main_webspace": "Haupt Webspace",
     "sulu_article.additional_webspace": "Zusätzliche Webspaces",
     "sulu_article.shadow_article": "Shadow Artikel",
-    "sulu_article.enable_shadow_article": "Shadow Artikel aktivieren"
+    "sulu_article.enable_shadow_article": "Shadow Artikel aktivieren",
+    "sulu_activity.resource.articles": "Artikel",
+    "sulu_activity.text.articles.created": "{userFullName} hat den Artikel \"{resourceTitle}\" erstellt",
+    "sulu_activity.text.articles.modified": "{userFullName} hat den Artikel \"{resourceTitle}\" geändert",
+    "sulu_activity.text.articles.removed": "{userFullName} hat den Artikel \"{resourceTitle}\" gelöscht",
+    "sulu_activity.text.articles.published": "{userFullName} hat den Artikel \"{resourceTitle}\" veröffentlicht",
+    "sulu_activity.text.articles.unpublished": "{userFullName} hat den Artikel \"{resourceTitle}\" nicht mehr veröffentlicht",
+    "sulu_activity.text.articles.draft_removed": "{userFullName} hat den Entwurf des Artikels \"{resourceTitle}\" verworfen",
+    "sulu_activity.text.articles.copied": "{userFullName} hat den Artikel \"{resourceTitle}\" kopiert",
+    "sulu_activity.text.articles.translation_added": "{userFullName} hat eine neue Sprachvariante für \"{resourceLocale}\" zum Artikel \"{resourceTitle}\" hinzugefügt",
+    "sulu_activity.text.articles.translation_copied": "{userFullName} hat die Sprachvariante für \"{context_sourceLocale}\" des Artikels \"{resourceTitle}\" nach \"{resourceLocale}\" kopiert",
+    "sulu_activity.text.articles.translation_removed": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" gelöscht",
+    "sulu_activity.text.articles.version_restored": "{userFullName} hat die Version \"{context_version}\" des Artikels \"{resourceTitle}\" wiederhergestellt"
 }

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -10,5 +10,17 @@
     "sulu_article.main_webspace": "Main webspace",
     "sulu_article.additional_webspace": "Additional webspaces",
     "sulu_article.shadow_article": "Shadow Article",
-    "sulu_article.enable_shadow_article": "Enable Shadow Article"
+    "sulu_article.enable_shadow_article": "Enable Shadow Article",
+    "sulu_activity.resource.articles": "Article",
+    "sulu_activity.text.articles.created": "{userFullName} has created the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.modified": "{userFullName} has changed the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.removed": "{userFullName} has removed the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.published": "{userFullName} has published the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.unpublished": "{userFullName} has unpublished the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.draft_removed": "{userFullName} has discarded the draft of the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.copied": "{userFullName} has copied the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.translation_added": "{userFullName} has added a new translation \"{resourceLocale}\" to the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.translation_copied": "{userFullName} has copied the \"{context_sourceLocale}\" translation of the article \"{resourceTitle}\" into \"{resourceLocale}\"",
+    "sulu_activity.text.articles.translation_removed": "{userFullName} has removed the \"{resourceLocale}\" translation of the article \"{resourceTitle}\"",
+    "sulu_activity.text.articles.version_restored": "{userFullName} has restored the version \"{context_version}\" of the article \"{resourceTitle}\""
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add `Activity` view for articles.
Add `restored_version` domain event.