### PR TITLE
Fix alternate article urls meta tags

### DIFF
--- a/Document/Serializer/WebsiteArticleUrlsSubscriber.php
+++ b/Document/Serializer/WebsiteArticleUrlsSubscriber.php
@@ -100,11 +100,13 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
             $locale = $localization->getLocale();
             $route = $this->routeRepository->findByEntity(get_class($article), $article->getUuid(), $locale);
             $path = $route ? $route->getPath() : '/';
+            $alternate = (bool) $route;
 
             $urls[$locale] = $path;
             $localizations[$locale] = [
                 'locale' => $locale,
                 'url' => $this->webspaceManager->findUrlByResourceLocator($path, null, $locale),
+                'alternate' => $alternate,
             ];
         }
 

--- a/Tests/Unit/Document/Serializer/WebsiteArticleUrlsSubscriberTest.php
+++ b/Tests/Unit/Document/Serializer/WebsiteArticleUrlsSubscriberTest.php
@@ -104,19 +104,67 @@ class WebsiteArticleUrlsSubscriberTest extends TestCase
         $this->webspaceManager->findUrlByResourceLocator('/page', null, 'en')->willReturn('http://sulu.io/page');
 
         $visitor->visitProperty(
-            Argument::that(function (StaticPropertyMetadata $metadata) {
+            Argument::that(function(StaticPropertyMetadata $metadata) {
                 return 'urls' === $metadata->name;
             }),
             ['de' => '/seite', 'en' => '/page']
         )->shouldBeCalled();
 
         $visitor->visitProperty(
-            Argument::that(function (StaticPropertyMetadata $metadata) {
+            Argument::that(function(StaticPropertyMetadata $metadata) {
                 return 'localizations' === $metadata->name;
             }),
             [
-                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite'],
-                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/page'],
+                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'alternate' => true],
+                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/page', 'alternate' => true],
+            ]
+        )->shouldBeCalled();
+
+        $this->urlsSubscriber->addUrlsOnPostSerialize($event->reveal());
+    }
+
+    public function testAddUrlsOnPostSerializeNonExistLocale()
+    {
+        $article = $this->prophesize(ArticleDocument::class);
+        $visitor = $this->prophesize(SerializationVisitorInterface::class);
+
+        $context = $this->prophesize(SerializationContext::class);
+        $context->hasAttribute('urls')->willReturn(true);
+
+        $entityId = '123-123-123';
+        $article->getUuid()->willReturn($entityId);
+
+        $event = $this->prophesize(ObjectEvent::class);
+        $event->getObject()->willReturn($article->reveal());
+        $event->getVisitor()->willReturn($visitor->reveal());
+        $event->getContext()->willReturn($context->reveal());
+
+        $entityClass = get_class($article->reveal());
+
+        $deRoute = $this->prophesize(RouteInterface::class);
+        $deRoute->getPath()->willReturn('/seite');
+        $this->routeRepository->findByEntity($entityClass, $entityId, 'de')->willReturn($deRoute->reveal());
+        $this->webspaceManager->findUrlByResourceLocator('/seite', null, 'de')->willReturn('http://sulu.io/de/seite');
+
+        $enRoute = $this->prophesize(RouteInterface::class);
+        $enRoute->getPath()->willReturn('/page');
+        $this->routeRepository->findByEntity($entityClass, $entityId, 'en')->willReturn(null);
+        $this->webspaceManager->findUrlByResourceLocator('/', null, 'en')->willReturn('http://sulu.io/');
+
+        $visitor->visitProperty(
+            Argument::that(function(StaticPropertyMetadata $metadata) {
+                return 'urls' === $metadata->name;
+            }),
+            ['de' => '/seite', 'en' => '/']
+        )->shouldBeCalled();
+
+        $visitor->visitProperty(
+            Argument::that(function(StaticPropertyMetadata $metadata) {
+                return 'localizations' === $metadata->name;
+            }),
+            [
+                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'alternate' => true],
+                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/', 'alternate' => false],
             ]
         )->shouldBeCalled();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes part of https://github.com/sulu/sulu/issues/6027
| Related issues/PRs | https://github.com/sulu/sulu/pull/6073
| License | MIT

#### What's in this PR?

Fix alternate article urls meta tags.

#### Why?

Should tell the frontend if a url is alternate or not.