### PR TITLE
Adjust documentation to configure live-generation of URL

### DIFF
--- a/Resources/doc/article-types.md
+++ b/Resources/doc/article-types.md
@@ -41,19 +41,3 @@ The type can also be used to predefine a filter for the smart-content provider f
 ```
 
 This will filter the smart-content for the given two types of articles.
-
-## Route Schema
-
-The bundle provides also a way to define a `route_schema` foreach article-type.
-
-```yml
-sulu_route:
-    mappings:
-        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            generator: type
-            options:
-                my_custom_type: "/custom/{object.getTitle()}"
-                my_second_custom_type: "/custom2/{object.getTitle()}"
-```
-
-See more information in [Routing](routing.md#route-schema).

--- a/Resources/doc/default.xml
+++ b/Resources/doc/default.xml
@@ -27,6 +27,8 @@
             <params>
                 <param name="headline" value="true"/>
             </params>
+
+            <tag name="sulu.rlp.part"/>
         </property>
 
         <property name="routePath" type="route">

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -29,12 +29,7 @@ sulu_route:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
             generator: schema
             options:
-                route_schema: '/articles/{object.getTitle()}'
-        Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
-            generator: article_page
-            options:
-                route_schema: '{translator.trans("page")}-{object.getPageNumber()}'
-                parent: '{object.getParent().getRoutePath()}'
+                route_schema: '/articles/{implode("-", object)}'
 
 ongr_elasticsearch:
 # If you expect more than 10000 articles, you need to set the `max_result_window` to an appropriate number  

--- a/Resources/doc/routing.md
+++ b/Resources/doc/routing.md
@@ -36,6 +36,26 @@ sulu_route:
 This schema will be used for all articles which will be created in the future. Older articles
 will not be touched.
 
+### Overwrite route schema in template
+
+You can use a different `route_schema` for articles with a specific template by setting the 
+`route_schema` param of the `routePath` property in the template:
+
+```xml
+<property name="routePath" type="route">
+    <meta>
+        <title lang="en">Resourcelocator</title>
+        <title lang="de">Adresse</title>
+    </meta>
+
+    <params>
+        <param name="route_schema" value="/template-specific-prefix/{implode('-', object)}"/>
+    </params>
+
+    <tag name="sulu_article.article_route"/>
+</property>
+```
+
 ## Route Generation
 
 For the route generation this bundle provides two different ways and two different approaches.

--- a/Resources/doc/routing.md
+++ b/Resources/doc/routing.md
@@ -30,29 +30,11 @@ sulu_route:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
             generator: schema
             options:
-                route_schema: /articles/{object.getTitle()}
-        Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument:
-            generator: "article_page"
-            options:
-                route_schema: "/{translator.trans(\"page\")}-{object.getPageNumber()}"
-                parent: "{object.getParent().getRoutePath()}"
+                route_schema: '/articles/{implode("-", object)}'
 ```
 
 This schema will be used for all articles which will be created in the future. Older articles
 will not be touched.
-
-If you want to define the schema based on the template or type you can use the related generator
-(`type` or `template`).
-
-```yml
-sulu_route:
-    mappings:
-        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
-            generator: <template|type>
-            options:
-                custom_template_or_type1: /test1/{object.getTitle()}
-                custom_template_or_type2: /test2/{object.getTitle()}
-```
 
 ## Route Generation
 
@@ -66,8 +48,8 @@ already configured in the installation process (see [installation](installation.
 To use this approach you have to do nothing (if you followed the installation description). For
 the completeness you have to be aware that following steps are done:
  
-* The content-type `route` for the property `routePath`
-* The `route_schema` was configured for the appropriate template or type.
+* The `routePath` property uses the `route` content type
+* The `sulu_route` configuration includes a `route_schema` for the `ArticleDocument`
 
 ### Page tree integration
 


### PR DESCRIPTION
#### What's in this PR?

This PR adjust the documentation in the repository to allow for liver-generation of the URL inside of the article template.

#### Why?

Because the current behaviour provides a bad UX and is inconsistent to page. See #514 and #580

