### PR TITLE
Fix sorting of articles in admin list

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -82,12 +82,12 @@ class ArticleController extends RestController implements ClassResourceInterface
                 ->setSortField('authorFullName.raw')
                 ->build(),
             'created' => ElasticSearchFieldDescriptor::create('created', 'public.created')
-                ->setSortField('authored')
+                ->setSortField('created')
                 ->setType('datetime')
                 ->setDisabled(true)
                 ->build(),
             'changed' => ElasticSearchFieldDescriptor::create('changed', 'public.changed')
-                ->setSortField('authored')
+                ->setSortField('changed')
                 ->setType('datetime')
                 ->setDisabled(true)
                 ->build(),
@@ -211,6 +211,10 @@ class ArticleController extends RestController implements ClassResourceInterface
         ) {
             $search->addSort(
                 new FieldSort($sortField, $restHelper->getSortOrder())
+            );
+        } else {
+            $search->addSort(
+                new FieldSort('created', 'ASC')
             );
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

- Add default sort by `created` to article list, because without sorting, the last modified article is returned as last element by elasticsearch, so after editing an article, the sorting is always changed
- Fix sorting by `created` and `changed`, because previosly it sorted by `authored` instead
