### PR TITLE
Fix sorting by created and changed timestamp

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -171,12 +171,12 @@ class ArticleController extends AbstractRestController implements ClassResourceI
                 ->setSortField('authorFullName.raw')
                 ->build(),
             'created' => ElasticSearchFieldDescriptor::create('created', 'public.created')
-                ->setSortField('authored')
+                ->setSortField('created')
                 ->setType('datetime')
                 ->setVisibility(FieldDescriptorInterface::VISIBILITY_NO)
                 ->build(),
             'changed' => ElasticSearchFieldDescriptor::create('changed', 'public.changed')
-                ->setSortField('authored')
+                ->setSortField('changed')
                 ->setType('datetime')
                 ->setVisibility(FieldDescriptorInterface::VISIBILITY_NO)
                 ->build(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes
| License | MIT

#### What's in this PR?

Fix sorting by created and changed timestamp

#### Why?

Currently sorting by created and changed is not possible.