### PR TITLE
Fix ArticleTeaserProvider

### DIFF
--- a/Teaser/ArticleTeaserProvider.php
+++ b/Teaser/ArticleTeaserProvider.php
@@ -166,6 +166,7 @@ class ArticleTeaserProvider implements TeaserProviderInterface
         $repository = $this->searchManager->getRepository($this->articleDocumentClass);
         $search = $repository->createSearch();
         $search->addQuery(new IdsQuery($articleIds));
+        $search->setSize(\count($articleIds));
 
         $result = [];
         foreach ($repository->findDocuments($search) as $item) {

--- a/Teaser/ArticleTeaserProvider.php
+++ b/Teaser/ArticleTeaserProvider.php
@@ -184,6 +184,11 @@ class ArticleTeaserProvider implements TeaserProviderInterface
             );
         }
 
+        $idPositions = array_flip($ids);
+        usort($result, function(Teaser $a, Teaser $b) use ($idPositions) {
+            return $idPositions[$a->getId()] - $idPositions[$b->getId()];
+        });
+
         return $result;
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix ArticleTeaserProvider to load more than 10 teasers and to sort them correctly.

#### Why?

By default, if not limit is given, elasticsearch returns no more than 10 documents. Also, elasticsearch doesn't respect the order of the ids in the ids query.
