### PR TITLE
Prevent full deindexing on unpublish

### DIFF
--- a/Document/Index/IndexerInterface.php
+++ b/Document/Index/IndexerInterface.php
@@ -16,6 +16,8 @@ use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
 
 /**
  * Interface for article-indexer.
+ *
+ * @method void remove(ArticleDocument $document, ?string $locale)
  */
 interface IndexerInterface
 {
@@ -38,12 +40,18 @@ interface IndexerInterface
     /**
      * Removes document from index.
      */
-    public function remove(ArticleDocument $document): void;
+    public function remove(ArticleDocument $document/*, ?string $locale = null*/): void;
 
     /**
-     * Removes specific document locale from the index.
+     * @deprecated
+     * @see IndexerInterface::replaceWithGhostData
      */
     public function removeLocale(ArticleDocument $document, string $locale): void;
+
+    /**
+     * Reindexes the document in given locale with the data of the originalLocale.
+     */
+    public function replaceWithGhostData(ArticleDocument $document, string $locale): void;
 
     /**
      * Flushes index.

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -420,7 +420,8 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->liveIndexer->remove($document);
+        /** @phpstan-ignore-next-line See https://github.com/phpstan/phpstan/issues/3779 */
+        $this->liveIndexer->remove($document, $event->getLocale());
         $this->liveIndexer->flush();
 
         $this->indexer->setUnpublished($document->getUuid(), $event->getLocale());
@@ -468,7 +469,7 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->indexer->removeLocale($document, $event->getLocale());
+        $this->indexer->replaceWithGhostData($document, $event->getLocale());
         $this->indexer->flush();
     }
 
@@ -498,7 +499,7 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->liveIndexer->removeLocale($document, $event->getLocale());
+        $this->liveIndexer->replaceWithGhostData($document, $event->getLocale());
         $this->liveIndexer->flush();
     }
 

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -67,7 +67,7 @@ class ArticleIndexerTest extends SuluTestCase
         $this->indexer->clear();
     }
 
-    public function testDeleteLocale()
+    public function testRemove()
     {
         $article = $this->createArticle(
             [
@@ -93,7 +93,73 @@ class ArticleIndexerTest extends SuluTestCase
 
         /** @var ArticleDocument $articleDocument */
         $articleDocument = $this->documentManager->find($article['id']);
-        $this->indexer->removeLocale($articleDocument, 'de');
+        $this->indexer->remove($articleDocument);
+        $this->indexer->flush();
+
+        self::assertNull($this->findViewDocument($articleDocument->getUuid(), 'de'));
+        self::assertNull($this->findViewDocument($articleDocument->getUuid(), 'en'));
+    }
+
+    public function testRemoveLocale()
+    {
+        $article = $this->createArticle(
+            [
+                'article' => 'Test content',
+            ],
+            'Test Article',
+            'default_with_route'
+        );
+
+        $secondLocale = 'de';
+
+        // now add second locale
+        $this->updateArticle(
+            $article['id'],
+            $secondLocale,
+            [
+                'id' => $article['id'],
+                'article' => 'Test Inhalt',
+            ],
+            'Test Artikel Deutsch',
+            'default_with_route'
+        );
+
+        /** @var ArticleDocument $articleDocument */
+        $articleDocument = $this->documentManager->find($article['id']);
+        $this->indexer->remove($articleDocument, 'en');
+        $this->indexer->flush();
+
+        self::assertNotNull($this->findViewDocument($articleDocument->getUuid(), 'de'));
+        self::assertNull($this->findViewDocument($articleDocument->getUuid(), 'en'));
+    }
+
+    public function testReplaceWithGhostData()
+    {
+        $article = $this->createArticle(
+            [
+                'article' => 'Test content',
+            ],
+            'Test Article',
+            'default_with_route'
+        );
+
+        $secondLocale = 'de';
+
+        // now add second locale
+        $this->updateArticle(
+            $article['id'],
+            $secondLocale,
+            [
+                'id' => $article['id'],
+                'article' => 'Test Inhalt',
+            ],
+            'Test Artikel Deutsch',
+            'default_with_route'
+        );
+
+        /** @var ArticleDocument $articleDocument */
+        $articleDocument = $this->documentManager->find($article['id']);
+        $this->indexer->replaceWithGhostData($articleDocument, 'de');
         $this->indexer->flush();
 
         $documentDE = $this->findViewDocument($articleDocument->getUuid(), 'de');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Prevent full deindexing on unpublish

#### Why?

When a locale was unpublished, all locales of the document have been deindex previously
