### PR TITLE
Add BC layer for track-total-hits

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -326,6 +326,10 @@ class ArticleController extends AbstractRestController implements ClassResourceI
             $search->setScroll('1m');
         }
 
+        if (method_exists($search, 'setTrackTotalHits')) {
+            $search->setTrackTotalHits(true);
+        }
+
         $searchResult = $repository->findRaw($search);
         $result = [];
         foreach ($searchResult as $document) {

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -37,6 +37,17 @@ sulu_route:
                 parent: '{object.getParent().getRoutePath()}'
 
 ongr_elasticsearch:
+# If you expect more than 10000 articles, you need to set the `max_result_window` to an appropriate number  
+#    managers:
+#        default:
+#            index:
+#                settings:
+#                    max_result_window: 20000
+#        live:
+#            index:
+#                settings:
+#                    max_result_window: 20000
+    
     analysis:
         tokenizer:
             pathTokenizer:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #599 
| Related issues/PRs | https://github.com/symfony/recipes-contrib/pull/1314
| License | MIT

#### What's in this PR?

This PR set the parameter `track_total_hits` to allow pagination in the admin which Elasticsearch ^7.0

#### Why?

If not set until 7.0 elasticsearch limits the total in the response to 10000 because of the change of the default value.

#### To Do

- [x] Document the configuration for amount of articles > 10000
