### PR TITLE
Fixes sitemap limit for ElasticSearch 7.x

### DIFF
--- a/Sitemap/ArticleSitemapProvider.php
+++ b/Sitemap/ArticleSitemapProvider.php
@@ -172,7 +172,9 @@ class ArticleSitemapProvider implements SitemapProviderInterface
         }
 
         $search->addQuery($webspaceQuery);
-        $search->setTrackTotalHits(true);
+        if (method_exists($search, 'setTrackTotalHits')) {
+            $search->setTrackTotalHits(true);
+        }
 
         return $repository->findDocuments($search);
     }

--- a/Sitemap/ArticleSitemapProvider.php
+++ b/Sitemap/ArticleSitemapProvider.php
@@ -172,6 +172,7 @@ class ArticleSitemapProvider implements SitemapProviderInterface
         }
 
         $search->addQuery($webspaceQuery);
+        $search->setTrackTotalHits(true);
 
         return $repository->findDocuments($search);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #599
| Related issues/PRs | #600
| License | MIT

#### What's in this PR?

Fixes 10k limit issues for the sitemap

#### Why?

In ES 7.x, the `track_total_hits` parameter must be added to the query, to fetch all search result.
