### PR TITLE
Allow installation of jms bundle 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.4",
         "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
         "jms/serializer": "^3.3",
-        "jms/serializer-bundle": "^3.3",
+        "jms/serializer-bundle": "^3.3 || ^4.0",
         "sulu/sulu": "^2.3 || ^2.3@dev",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Allow installation of jms bundle 4.

#### Why?

Avoid an error when trying to install SuluArticleBundle on latest sulu version which installs jms bundle 4.

Currently the following was required:

```bash
composer require sulu/article-bundle --no-update
composer update # downgrades jms
```