### PR TITLE
Fix `PageTreeArticleDataProvider` data-source prefix query

### DIFF
--- a/Content/PageTreeArticleDataProvider.php
+++ b/Content/PageTreeArticleDataProvider.php
@@ -64,7 +64,7 @@ class PageTreeArticleDataProvider extends ArticleDataProvider
 
         if ($document instanceof BasePageDocument && $document->getResourceSegment()) {
             // the selected data-source could be removed
-            $search->addQuery(new PrefixQuery('route_path.raw', $document->getResourceSegment()));
+            $search->addQuery(new PrefixQuery('route_path.raw', $document->getResourceSegment() . '/'));
         }
 
         return $search;

--- a/Tests/Functional/Content/PageTreeArticleDataProviderTest.php
+++ b/Tests/Functional/Content/PageTreeArticleDataProviderTest.php
@@ -51,7 +51,9 @@ class PageTreeArticleDataProviderTest extends SuluTestCase
     public function testFilterByDataSource()
     {
         $page1 = $this->createPage('Test Page', '/page-1');
-        $page2 = $this->createPage('Test Page', '/page-2');
+
+        // Tests additionally that the trailing slash in the prefix query is there
+        $page2 = $this->createPage('Test Page', '/page-1-1');
 
         $articles = [
             $this->createArticle($page1, 'Test 1'),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT

#### What's in this PR?

Add trailing slash for the prefix query to exclude mismatches.

#### Why?

Because the query potionaly matches too many articles.
