### PR TITLE
Add support for elasticsearch 8

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -58,6 +58,18 @@ jobs:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           ELASTICSEARCH_HOST: '127.0.0.1:9200'
 
+                    - php-version: '8.1'
+                      elasticsearch-version: '8.0.1'
+                      elasticsearch-package-constraint: '^8.0'
+                      phpcr-transport: jackrabbit
+                      dependency-versions: 'highest'
+                      php-extensions: 'ctype, iconv, mysql, imagick'
+                      tools: 'composer:v2'
+                      lint: false
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                          ELASTICSEARCH_HOST: '127.0.0.1:9200'
+
         services:
             mysql:
                 image: mysql:5.7

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -6,7 +6,6 @@ on:
         branches:
             - '[0-9]+.x'
             - '[0-9]+.[0-9]+'
-
 jobs:
     test:
         name: "PHP ${{ matrix.php-version }} (elasticsearch ${{ matrix.elasticsearch-version }}, ${{ matrix.phpcr-transport }}, ${{ matrix.dependency-versions }})"
@@ -15,6 +14,7 @@ jobs:
         env:
             DATABASE_URL: mysql://root:root@127.0.0.1:3306/sulu_test?serverVersion=5.7
             PHPCR_TRANSPORT: ${{ matrix.phpcr-transport }}
+            COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         strategy:
             fail-fast: false

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "elasticsearch/elasticsearch": "^5.0 || ^6.0 || ^7.0",
         "friendsofphp/php-cs-fixer": "^2.17",
         "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.4",
-        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
+        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1 || ^8.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3.4",
         "jackalope/jackalope-jackrabbit": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,12 @@
             "homepage": "https://github.com/sulu/SuluArticleBundle/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/alexander-schranz/ElasticsearchBundle.git"
+        }
+    ],
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
@@ -39,7 +45,7 @@
         "doctrine/data-fixtures": "^1.3.3",
         "elasticsearch/elasticsearch": "^5.0 || ^6.0 || ^7.0",
         "friendsofphp/php-cs-fixer": "^2.17",
-        "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.4",
+        "handcraftedinthealps/elasticsearch-bundle": "dev-feature/elasticsearch-8-support as 5.2.6.5",
         "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1 || ^8.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3.4",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/alexander-schranz/ElasticsearchBundle.git"
+            "url": "git@github.com:alexander-schranz/ElasticsearchBundle.git"
         }
     ],
     "require": {
@@ -43,10 +43,10 @@
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3.3",
-        "elasticsearch/elasticsearch": "^5.0 || ^6.0 || ^7.0",
+        "elasticsearch/elasticsearch": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "friendsofphp/php-cs-fixer": "^2.17",
         "handcraftedinthealps/elasticsearch-bundle": "dev-feature/elasticsearch-8-support as 5.2.6.5",
-        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1 || ^8.0",
+        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1 || ^8.0@RC",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3.4",
         "jackalope/jackalope-jackrabbit": "^1.3",
@@ -66,9 +66,9 @@
     },
     "conflict": {
         "doctrine/doctrine-bundle": "2.3.0",
-        "elasticsearch/elasticsearch": "<5.0 || >=8.0",
+        "elasticsearch/elasticsearch": "<5.0 || >=9.0",
         "handcraftedinthealps/elasticsearch-bundle": "<5.2.6.4 || >=6.0",
-        "handcraftedinthealps/elasticsearch-dsl": "<5.0.7.1 || 6.0 - 6.2.0 || 7.0 - 7.2.0 || >=8.0"
+        "handcraftedinthealps/elasticsearch-dsl": "<5.0.7.1 || 6.0 - 6.2.0 || 7.0 - 7.2.0 || >=9.0"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "Required for the default article phpcr storage.",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Add support for elasticsearch 8

#### Why?

Released support for Elasticsearch 8:

 - https://github.com/handcraftedinthealps/ElasticsearchDSL/pull/18
 - https://github.com/handcraftedinthealps/ElasticsearchBundle/pull/27