### PR TITLE
Add toolbar action to copy article

### DIFF
--- a/Admin/ArticleAdmin.php
+++ b/Admin/ArticleAdmin.php
@@ -228,13 +228,21 @@ class ArticleAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::LIVE)
                 && $this->securityChecker->hasPermission(static::getArticleSecurityContext($typeKey), PermissionTypes::LIVE)) {
+
+                $editDropdownToolbarActions = [
+                    new ToolbarAction('sulu_admin.delete_draft'),
+                    new ToolbarAction('sulu_admin.set_unpublished'),
+                    new ToolbarAction('sulu_admin.copy'),
+                ];
+
+                if (\count($locales) > 1) {
+                    $editDropdownToolbarActions[] = new ToolbarAction('sulu_admin.copy_locale');
+                }
+
                 $formToolbarActionsWithType[] = new DropdownToolbarAction(
                     'sulu_admin.edit',
                     'su-pen',
-                    [
-                        new ToolbarAction('sulu_admin.delete_draft'),
-                        new ToolbarAction('sulu_admin.set_unpublished'),
-                    ]
+                    $editDropdownToolbarActions
                 );
             }
 

--- a/Admin/ArticleAdmin.php
+++ b/Admin/ArticleAdmin.php
@@ -228,7 +228,6 @@ class ArticleAdmin extends Admin
 
             if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::LIVE)
                 && $this->securityChecker->hasPermission(static::getArticleSecurityContext($typeKey), PermissionTypes::LIVE)) {
-
                 $editDropdownToolbarActions = [
                     new ToolbarAction('sulu_admin.delete_draft'),
                     new ToolbarAction('sulu_admin.set_unpublished'),

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -528,7 +528,7 @@ class ArticleController extends AbstractRestController implements ClassResourceI
     {
         // extract parameter
         $action = $this->getRequestParameter($request, 'action', true);
-        $locale = $this->getRequestParameter($request, 'locale', true);
+        $locale = $this->getRequestParameter($request, 'locale', false);
 
         // prepare vars
         $view = null;

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -417,7 +417,6 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /* @phpstan-ignore-next-line See https://github.com/phpstan/phpstan/issues/3779 */
         $this->liveIndexer->remove($document, $event->getLocale());
         $this->liveIndexer->flush();
 
@@ -451,6 +450,7 @@ class ArticleSubscriber implements EventSubscriberInterface
         if (!$document instanceof ArticleDocument) {
             return;
         }
+
 
         $this->indexer->remove($document);
         $this->indexer->flush();

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -451,7 +451,6 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-
         $this->indexer->remove($document);
         $this->indexer->flush();
     }

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -1193,6 +1193,28 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertNull($this->findViewDocument($article2['id'], 'de'));
     }
 
+    public function testCopy()
+    {
+        // create article
+        $sourceArticle = $this->testPost('Sulu ist toll - Artikel 1');
+        $this->publish($sourceArticle['id']);
+        $this->flush();
+
+        // trigger copy action
+        $this->client->jsonRequest('POST',
+            \sprintf('/api/articles/%s?action=copy', $sourceArticle['id'])
+        );
+        $response = $this->client->getResponse();
+
+        $result = \json_decode($response->getContent(), true);
+        $this->assertHttpStatusCode(200, $response);
+
+        $this->assertNotEquals($sourceArticle['id'], $result['id']);
+        $this->assertEquals($sourceArticle['title'], $result['title']);
+        $this->assertEquals($sourceArticle['articleType'], $result['articleType']);
+        $this->assertEquals(false, $result['publishedState']);
+    }
+
     public function testCopyLocaleWithoutSource()
     {
         // prepare vars

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
         "jms/serializer": "^3.3",
         "jms/serializer-bundle": "^3.3 || ^4.0",
-        "sulu/sulu": "~2.4.11 || ^2.5.7",
+        "sulu/sulu": "~2.4.13 || ^2.5.9@dev",
         "symfony/config": "^4.3 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.3 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
         "jms/serializer": "^3.3",
         "jms/serializer-bundle": "^3.3 || ^4.0",
-        "sulu/sulu": "^2.3 || ^2.3@dev",
+        "sulu/sulu": "~2.4.11 || ^2.5.7",
         "symfony/config": "^4.3 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.3 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,9 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1696,6 +1696,11 @@ parameters:
 			path: Document/Subscriber/ArticleSubscriber.php
 
 		-
+			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Index\\\\IndexerInterface\\:\\:remove\\(\\) invoked with 1 parameter, 2 required\\.$#"
+			count: 2
+			path: Document/Subscriber/ArticleSubscriber.php
+
+		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:getChildren\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: Document/Subscriber/ArticleSubscriber.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #538 
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

This adds the possibility to copy an existing article. It's similar to the "Copy Form" (https://github.com/sulu/SuluFormBundle/pull/316) and "Copy Snippet" (https://github.com/sulu/sulu/pull/6859) features.

Needs this change in `sulu/sulu`: https://github.com/sulu/sulu/pull/6859/files#diff-579b061b25841f1a028b4adc7b447e987e298306a441dd13346d08de3ec2d5ba, which is currently only in 2.6 - maybe it can be backported to allow the feature to work with Sulu >=2.4.

Please see also #538 for related discussion.


