### PR TITLE
Add support for symfony 6

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -55,7 +55,7 @@ jobs:
                       php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'
                       phpstan: false
-                      lint: true
+                      lint: false
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           ELASTICSEARCH_HOST: '127.0.0.1:9200'
@@ -68,7 +68,7 @@ jobs:
                       php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'
                       phpstan: false
-                      lint: false
+                      lint: true
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           ELASTICSEARCH_HOST: '127.0.0.1:9200'

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -60,6 +60,19 @@ jobs:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           ELASTICSEARCH_HOST: '127.0.0.1:9200'
 
+                    - php-version: '8.1'
+                      elasticsearch-version: '7.11.1'
+                      elasticsearch-package-constraint: '~7.11.0'
+                      phpcr-transport: jackrabbit
+                      dependency-versions: 'highest'
+                      php-extensions: 'ctype, iconv, mysql, imagick'
+                      tools: 'composer:v2'
+                      phpstan: false
+                      lint: false
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                          ELASTICSEARCH_HOST: '127.0.0.1:9200'
+
         services:
             mysql:
                 image: mysql:5.7

--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -205,7 +205,7 @@ class WebsiteArticleController extends AbstractController
         return $this->container->get('sulu_article.article_content_resolver');
     }
 
-    public static function getSubscribedServices()
+    public static function getSubscribedServices(): array
     {
         $subscribedServices = parent::getSubscribedServices();
 

--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -64,9 +64,9 @@ class WebsiteArticleController extends AbstractController
 
         $content = $this->resolveArticle($object, $pageNumber);
 
-        $parameters = $this->get('sulu_website.resolver.parameter')->resolve(
+        $parameters = $this->container->get('sulu_website.resolver.parameter')->resolve(
             [],
-            $this->get('sulu_core.webspace.request_analyzer'),
+            $this->container->get('sulu_core.webspace.request_analyzer'),
             null,
             $preview
         );

--- a/Routing/ArticleRouteEnhancer.php
+++ b/Routing/ArticleRouteEnhancer.php
@@ -49,7 +49,7 @@ class ArticleRouteEnhancer implements RouteEnhancerInterface
         $this->environment = $environment;
     }
 
-    public function enhance(array $defaults, Request $request)
+    public function enhance(array $defaults, Request $request): array
     {
         if (!$this->shouldAddCanonicalTag($defaults, $request)) {
             return $defaults;

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^5.0 || ^6.0 || ^7.0",
-        "handcraftedinthealps/elasticsearch-bundle": "dev-enhancement/symfony-6-support",
-        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1 || 7.x-dev",
+        "handcraftedinthealps/elasticsearch-bundle": "^5.2.6.4 || ^5.3@dev",
+        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1 || ^7.3@dev",
         "jms/serializer": "^3.3",
         "jms/serializer-bundle": "^3.3 || ^4.0",
         "sulu/sulu": "^2.3 || ^2.3@dev",
@@ -56,12 +56,6 @@
         "symfony/security-bundle": "^4.3 || ^5.0 || ^6.0",
         "symfony/stopwatch": "^4.3 || ^5.0 || ^6.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/niklasnatter/ElasticsearchBundle"
-        }
-    ],
     "suggest": {
         "sulu/automation-bundle": "Allows to outsource long-running route update processes."
     },

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^5.0 || ^6.0 || ^7.0",
         "handcraftedinthealps/elasticsearch-bundle": "dev-enhancement/symfony-6-support",
-        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1",
+        "handcraftedinthealps/elasticsearch-dsl": "^5.0.7.1 || ^6.2.0.1 || ^7.2.0.1 || 7.x-dev",
         "jms/serializer": "^3.3",
         "jms/serializer-bundle": "^3.3 || ^4.0",
         "sulu/sulu": "^2.3 || ^2.3@dev",
-        "symfony/config": "^4.3 || ^5.0",
-        "symfony/dependency-injection": "^4.3 || ^5.0",
-        "symfony/http-foundation": "^4.3 || ^5.0",
-        "symfony/http-kernel": "^4.3 || ^5.0",
+        "symfony/config": "^4.3 || ^5.0 || ^6.0",
+        "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
+        "symfony/http-foundation": "^4.3 || ^5.0 || ^6.0",
+        "symfony/http-kernel": "^4.3 || ^5.0 || ^6.0",
         "symfony-cmf/slugifier-api": "^1.0 || ^2.0",
         "twig/twig": "^1.41 || ^2.0 || ^3.0"
     },
@@ -49,12 +49,12 @@
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^8.2",
         "sulu/automation-bundle": "^2.0@dev",
-        "symfony/browser-kit": "^4.3 || ^5.0",
-        "symfony/dotenv": "^4.3 || ^5.0",
-        "symfony/framework-bundle": "^4.3 || ^5.0",
+        "symfony/browser-kit": "^4.3 || ^5.0 || ^6.0",
+        "symfony/dotenv": "^4.3 || ^5.0 || ^6.0",
+        "symfony/framework-bundle": "^4.3 || ^5.0 || ^6.0",
         "symfony/monolog-bundle": "^3.1",
-        "symfony/security-bundle": "^4.3 || ^5.0",
-        "symfony/stopwatch": "^4.3 || ^5.0"
+        "symfony/security-bundle": "^4.3 || ^5.0 || ^6.0",
+        "symfony/stopwatch": "^4.3 || ^5.0 || ^6.0"
     },
     "repositories": [
         {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2411,12 +2411,12 @@ parameters:
 			path: Routing/ArticleRouteEnhancer.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Routing\\\\ArticleRouteEnhancer\\:\\:enhance\\(\\) has parameter \\$defaults with no value type specified in iterable type array\\.$#"
+			message: "#^Cannot call method getLocale\\(\\) on mixed\\.$#"
 			count: 1
 			path: Routing/ArticleRouteEnhancer.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Routing\\\\ArticleRouteEnhancer\\:\\:enhance\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Cannot call method getRoutePath\\(\\) on mixed\\.$#"
 			count: 1
 			path: Routing/ArticleRouteEnhancer.php
 
@@ -2427,6 +2427,11 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: Routing/ArticleRouteEnhancer.php
+
+		-
+			message: "#^Parameter \\#1 \\$document of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Resolver\\\\WebspaceResolver\\:\\:resolveMainWebspace\\(\\) expects Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Behavior\\\\WebspaceBehavior, mixed given\\.$#"
 			count: 1
 			path: Routing/ArticleRouteEnhancer.php
 


### PR DESCRIPTION
#### What's in this PR?

This PR updates the bundle to be compatible with Symfony 6.

Builds upon: https://github.com/sulu/SuluArticleBundle/pull/617
Requires: https://github.com/handcraftedinthealps/ElasticsearchBundle/pull/29