### PR TITLE
Implement CacheLifetimeBehaviourInterface in ArticleBridge

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,6 +31,9 @@ $config->setRiskyAllowed(true)
         'phpdoc_types_order' => false,
         'single_line_throw' => false,
         'single_line_comment_spacing' => false,
+        'phpdoc_to_comment' => [
+            'ignored_tags' => ['todo', 'var', 'see', 'phpstan-ignore-next-line'],
+        ],
     ])
     ->setFinder($finder);
 

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -30,14 +30,26 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
 
     public function getView(): string
     {
-        return $this->structure->getView();
+        /** @var string $view */
+        $view = $this->structure->getView();
+
+        return $view;
     }
 
+    /**
+     * @return string
+     */
     public function getController()
     {
-        return $this->structure->getController();
+        /** @var string $controller */
+        $controller = $this->structure->getController();
+
+        return $controller;
     }
 
+    /**
+     * @return array{type: string, value: string}
+     */
     public function getCacheLifeTime()
     {
         /** @var array{type: string, value: string} $cacheLifetime */

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -36,10 +36,7 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
         return $view;
     }
 
-    /**
-     * @return string
-     */
-    public function getController()
+    public function getController(): string
     {
         /** @var string $controller */
         $controller = $this->structure->getController();
@@ -50,7 +47,7 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
     /**
      * @return array{type: string, value: string}
      */
-    public function getCacheLifeTime()
+    public function getCacheLifeTime(): array
     {
         /** @var array{type: string, value: string} $cacheLifetime */
         $cacheLifetime = $this->structure->getCacheLifetime();

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -16,7 +16,7 @@ use Sulu\Component\Content\Compat\Structure\StructureBridge;
 /**
  * Own structure bridge for articles.
  */
-class ArticleBridge extends StructureBridge implements CacheLifetimeBehaviourInterface
+class ArticleBridge extends StructureBridge implements RoutableStructureInterface
 {
     /**
      * @var string
@@ -31,6 +31,19 @@ class ArticleBridge extends StructureBridge implements CacheLifetimeBehaviourInt
     public function getView(): string
     {
         return $this->structure->getView();
+    }
+
+    public function getController()
+    {
+        return $this->structure->getController();
+    }
+
+    public function getCacheLifeTime()
+    {
+        /** @var array{type: string, value: string} $cacheLifetime */
+        $cacheLifetime = $this->structure->getCacheLifetime();
+
+        return $cacheLifetime;
     }
 
     public function getUuid()
@@ -90,13 +103,5 @@ class ArticleBridge extends StructureBridge implements CacheLifetimeBehaviourInt
     public function setWebspaceKey($webspace)
     {
         $this->webspaceKey = $webspace;
-    }
-
-    public function getCacheLifeTime()
-    {
-        /** @var array{type: string, value: string} $cacheLifetime */
-        $cacheLifetime = $this->structure->getCacheLifetime();
-
-        return $cacheLifetime;
     }
 }

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -30,18 +30,14 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
 
     public function getView(): string
     {
-        /** @var string $view */
-        $view = $this->structure->getView();
-
-        return $view;
+        /** @var string */
+        return $this->structure->getView();;
     }
 
     public function getController(): string
     {
-        /** @var string $controller */
-        $controller = $this->structure->getController();
-
-        return $controller;
+        /** @var string */
+        return $this->structure->getController();
     }
 
     /**
@@ -49,10 +45,8 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
      */
     public function getCacheLifeTime(): array
     {
-        /** @var array{type: string, value: string} $cacheLifetime */
-        $cacheLifetime = $this->structure->getCacheLifetime();
-
-        return $cacheLifetime;
+        /** @var array{type: string, value: string} */
+        return $this->structure->getCacheLifetime();
     }
 
     public function getUuid()

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -31,7 +31,7 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
     public function getView(): string
     {
         /** @var string */
-        return $this->structure->getView();;
+        return $this->structure->getView();
     }
 
     public function getController(): string

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -16,7 +16,7 @@ use Sulu\Component\Content\Compat\Structure\StructureBridge;
 /**
  * Own structure bridge for articles.
  */
-class ArticleBridge extends StructureBridge
+class ArticleBridge extends StructureBridge implements CacheLifetimeBehaviourInterface
 {
     /**
      * @var string
@@ -90,5 +90,10 @@ class ArticleBridge extends StructureBridge
     public function setWebspaceKey($webspace)
     {
         $this->webspaceKey = $webspace;
+    }
+
+    public function getCacheLifeTime()
+    {
+        return $this->structure->getCacheLifetime();
     }
 }

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -94,6 +94,9 @@ class ArticleBridge extends StructureBridge implements CacheLifetimeBehaviourInt
 
     public function getCacheLifeTime()
     {
-        return $this->structure->getCacheLifetime();
+        /** @var array{type: string, value: string} $cacheLifetime */
+        $cacheLifetime = $this->structure->getCacheLifetime();
+
+        return $cacheLifetime;
     }
 }

--- a/Document/Structure/CacheLifetimeBehaviourInterface.php
+++ b/Document/Structure/CacheLifetimeBehaviourInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Structure;
+
+use Sulu\Component\Content\Compat\CacheLifetimeBehaviourInterface as SuluCacheLifetimeBehaviourInterface;
+
+if (\interface_exists(SuluCacheLifetimeBehaviourInterface::class)) {
+    /**
+     * @deprecated will be removed, as soon as the ArticleBundle rises the minimum requirement of sulu to a version,
+     * where this interface exists
+     *
+     * @internal
+     */
+    interface CacheLifetimeBehaviourInterface extends SuluCacheLifetimeBehaviourInterface
+    {
+        /**
+         * cacheLifeTime of template definition.
+         *
+         * @return array{
+         *     type: string,
+         *     value: string,
+         * }
+         */
+        public function getCacheLifeTime();
+    }
+} else {
+    /**
+     * @deprecated will be removed, as soon as the ArticleBundle rises the minimum requirement of sulu to a version,
+     * where this interface exists
+     *
+     * @internal
+     */
+    interface CacheLifetimeBehaviourInterface
+    {
+        /**
+         * cacheLifeTime of template definition.
+         *
+         * @return array{
+         *     type: string,
+         *     value: string,
+         * }
+         */
+        public function getCacheLifeTime();
+    }
+}

--- a/Document/Structure/RoutableStructureInterface.php
+++ b/Document/Structure/RoutableStructureInterface.php
@@ -13,17 +13,31 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\ArticleBundle\Document\Structure;
 
-use Sulu\Component\Content\Compat\CacheLifetimeBehaviourInterface as SuluCacheLifetimeBehaviourInterface;
+use Sulu\Component\Content\Compat\RoutableStructureInterface as SuluRoutableStructureInterface;
 
-if (\interface_exists(SuluCacheLifetimeBehaviourInterface::class)) {
+if (\interface_exists(SuluRoutableStructureInterface::class)) {
     /**
      * @deprecated will be removed, as soon as the ArticleBundle rises the minimum requirement of sulu to a version,
      * where this interface exists
      *
      * @internal
      */
-    interface CacheLifetimeBehaviourInterface extends SuluCacheLifetimeBehaviourInterface
+    interface RoutableStructureInterface extends SuluRoutableStructureInterface
     {
+        /**
+         * twig template of template definition.
+         *
+         * @return string
+         */
+        public function getView();
+
+        /**
+         * controller which renders the twig template.
+         *
+         * @return string
+         */
+        public function getController();
+
         /**
          * cacheLifeTime of template definition.
          *
@@ -41,8 +55,22 @@ if (\interface_exists(SuluCacheLifetimeBehaviourInterface::class)) {
      *
      * @internal
      */
-    interface CacheLifetimeBehaviourInterface
+    interface RoutableStructureInterface
     {
+        /**
+         * twig template of template definition.
+         *
+         * @return string
+         */
+        public function getView();
+
+        /**
+         * controller which renders the twig template.
+         *
+         * @return string
+         */
+        public function getController();
+
         /**
          * cacheLifeTime of template definition.
          *

--- a/Document/Structure/RoutableStructureInterface.php
+++ b/Document/Structure/RoutableStructureInterface.php
@@ -24,29 +24,6 @@ if (\interface_exists(SuluRoutableStructureInterface::class)) {
      */
     interface RoutableStructureInterface extends SuluRoutableStructureInterface
     {
-        /**
-         * twig template of template definition.
-         *
-         * @return string
-         */
-        public function getView();
-
-        /**
-         * controller which renders the twig template.
-         *
-         * @return string
-         */
-        public function getController();
-
-        /**
-         * cacheLifeTime of template definition.
-         *
-         * @return array{
-         *     type: string,
-         *     value: string,
-         * }
-         */
-        public function getCacheLifeTime();
     }
 } else {
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1526,11 +1526,6 @@ parameters:
 			path: Document/Structure/ArticleBridge.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Structure\\\\ArticleBridge\\:\\:getView\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: Document/Structure/ArticleBridge.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Structure\\\\ArticleBridge\\:\\:setUuid\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: Document/Structure/ArticleBridge.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | sulu/sulu#6814
| License | MIT

#### What's in this PR?

Implement CacheLifetimeBehaviourInterface in ArticleBridge

#### Why?

This allows Sulu's `CacheLifetimeEnhancer` service to work with `ArticleBridge` objects. The reason for this is, that the `HeadlessWebsiteController` can then be used to render articles.
