### PR TITLE
Fix types filter with website user

### DIFF
--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -362,8 +362,10 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
         $filterTypes = [];
 
         if (\array_key_exists('types', $propertyParameter)
-            && !empty($value = $propertyParameter['types']->getValue())) {
-            $types = \is_array($value) ? $value : \explode(',', $value);
+            && !empty($value = $propertyParameter['types']->getValue())
+            && \is_string($value)) {
+            $types = \explode(',', $value);
+
             foreach ($types as $type) {
                 $filterTypes[] = $type;
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/tommysonsylverstone/sulu-elasticsearch-user-bug
| License | MIT

#### What's in this PR?

This PR fixes the problem described in https://github.com/tommysonsylverstone/sulu-elasticsearch-user-bug

#### Why?

The `ArticleDataProvider::getTypes()` method is used to call `ConfigurationBuilder::enableTypes()` (see https://github.com/sulu/SuluArticleBundle/blob/2.x/Content/ArticleDataProvider.php#L499). This method only returns types, if there is a `TokenStorage` with a user, to use the user's locale to return the title of the templates in the correct locale. This works fine, because in most cases, this just returns the types in the admin context and not in the website context. But as soon as there is a website user, this method also returns types, and the `ArticleDataProvider` doesn't expect that, because those types are used in the `ContentType::getDefaultParams()`. Because that logic is in sulu itself, we should not touch it and instead work around that here in the article bundle.
