### PR TITLE
Add update of locale in previews PageObjectProvider

### DIFF
--- a/Preview/ArticleObjectProvider.php
+++ b/Preview/ArticleObjectProvider.php
@@ -91,6 +91,9 @@ class ArticleObjectProvider implements PreviewObjectProviderInterface
             ->enableMagicCall()
             ->getPropertyAccessor();
 
+        $object->setLocale($locale);
+        $object->setOriginalLocale($locale);
+
         $structure = $object->getStructure();
         foreach ($data as $property => $value) {
             try {

--- a/Tests/Unit/Preview/ArticleObjectProviderTest.php
+++ b/Tests/Unit/Preview/ArticleObjectProviderTest.php
@@ -86,6 +86,9 @@ class ArticleObjectProviderTest extends TestCase
         $object = $this->prophesize(ArticleDocument::class);
         $object->getStructure()->willReturn($structure);
 
+        $object->setLocale($locale)->shouldBeCalled();
+        $object->setOriginalLocale($locale)->shouldBeCalled();
+
         $this->provider->setValues($object->reveal(), $locale, $data);
 
         $this->assertEquals('SULU', $structure->getProperty('title')->getValue());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #6831
| Related issues/PRs | linked with https://github.com/sulu/sulu/pull/6866
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add an update of locale and original locale on the preview document. To allow loading the data (e.g. teaser_selection) in the correct locale.