### PR TITLE
Fix snippet selection

### DIFF
--- a/Document/Structure/ContentProxyFactory.php
+++ b/Document/Structure/ContentProxyFactory.php
@@ -150,6 +150,6 @@ class ContentProxyFactory
             return null;
         }
 
-        return $attributes->getAttribute('webspaceKey');
+        return $attributes->getAttribute('webspaceKey') ?? $attributes->getAttribute('webspace')->getKey();
     }
 }


### PR DESCRIPTION
The webspaceKey attribute is null in the previewer, but the key is available in the webspace attribute.

This fixes #190/#51.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #190/#51
| Related issues/PRs | #190/#51 
| License | MIT

#### What's in this PR?

This PR contains a bugfix for the problem described in ticket #190/#51.
