### PR TITLE
Fix use of the correct localizations with multiple portals

### DIFF
--- a/Document/Serializer/WebsiteArticleUrlsSubscriber.php
+++ b/Document/Serializer/WebsiteArticleUrlsSubscriber.php
@@ -138,11 +138,18 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
             return;
         }
 
+        if (null !== ($portal = $attributes->getAttribute('portal'))) {
+            $allLocalizations = $portal->getLocalizations();
+        } else {
+            $allLocalizations = $webspace->getAllLocalizations();
+        }
+
         $urls = [];
         $localizations = [];
         $publishedLocales = $this->getPublishedLocales($article, $webspace);
 
-        foreach ($this->getWebspaceLocales($webspace) as $locale) {
+        foreach ($allLocalizations as $localization) {
+            $locale = $localization->getLocale();
             $published = \in_array($locale, $publishedLocales, true);
             $path = '/';
             $alternate = false;
@@ -160,6 +167,7 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
             $localizations[$locale] = [
                 'locale' => $locale,
                 'url' => $this->webspaceManager->findUrlByResourceLocator($path, null, $locale),
+                'country' => $localization->getCountry(),
                 'alternate' => $alternate,
             ];
         }

--- a/Tests/Unit/Document/Serializer/WebsiteArticleUrlsSubscriberTest.php
+++ b/Tests/Unit/Document/Serializer/WebsiteArticleUrlsSubscriberTest.php
@@ -140,8 +140,8 @@ class WebsiteArticleUrlsSubscriberTest extends TestCase
                 return 'localizations' === $metadata->name;
             }),
             [
-                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'alternate' => true],
-                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/page', 'alternate' => true],
+                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'country' => '', 'alternate' => true],
+                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/page', 'country' => '', 'alternate' => true],
             ]
         )->shouldBeCalled();
 
@@ -197,8 +197,8 @@ class WebsiteArticleUrlsSubscriberTest extends TestCase
                 return 'localizations' === $metadata->name;
             }),
             [
-                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'alternate' => true],
-                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/page', 'alternate' => true],
+                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'country' => '', 'alternate' => true],
+                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/page', 'country' => '', 'alternate' => true],
             ]
         )->shouldBeCalled();
 
@@ -248,8 +248,8 @@ class WebsiteArticleUrlsSubscriberTest extends TestCase
                 return 'localizations' === $metadata->name;
             }),
             [
-                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'alternate' => true],
-                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/', 'alternate' => false],
+                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'country' => '', 'alternate' => true],
+                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/', 'country' => '', 'alternate' => false],
             ]
         )->shouldBeCalled();
 
@@ -297,8 +297,8 @@ class WebsiteArticleUrlsSubscriberTest extends TestCase
                 return 'localizations' === $metadata->name;
             }),
             [
-                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'alternate' => true],
-                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/', 'alternate' => false],
+                'de' => ['locale' => 'de', 'url' => 'http://sulu.io/de/seite', 'country' => '', 'alternate' => true],
+                'en' => ['locale' => 'en', 'url' => 'http://sulu.io/', 'country' => '', 'alternate' => false],
             ]
         )->shouldBeCalled();
 


### PR DESCRIPTION
Use the correct localizations of the portal if multiple portals are configured and ´country´ key to the localizations array to match it with the other implementations in sulu.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

This fixes an issue with localizations when you split them in multiple portals.

#### Why?

Before this change all localizations of a webspace were returned even if you had separated them in multiple portals.

<img width="841" alt="image" src="https://user-images.githubusercontent.com/14167832/227655952-7a39981a-9746-4909-9d64-14704393878c.png">

After this change, only localizations of the active portal are returned if you have multiple portals.

<img width="744" alt="image" src="https://user-images.githubusercontent.com/14167832/227656201-5325fad7-13b0-40b0-8fed-0c542bdd636b.png">

Also, the `country` key was added to match the output of pages.