### PR TITLE
Respect webspaces when calculating the maximum number of sitemap pages

### DIFF
--- a/Sitemap/ArticleSitemapProvider.php
+++ b/Sitemap/ArticleSitemapProvider.php
@@ -195,6 +195,8 @@ class ArticleSitemapProvider implements SitemapProviderInterface
             $webspaceQuery->add(new TermQuery('additional_webspaces', $webspaceKey), BoolQuery::SHOULD);
         }
 
+        $search->addQuery($webspaceQuery);
+
         return \ceil($repository->count($search) / static::PAGE_SIZE);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,19 +41,9 @@ parameters:
 			path: Builder/ArticleIndexBuilder.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Command\\\\ArticleExportCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Command/ArticleExportCommand.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between 0 and bool will always evaluate to false\\.$#"
 			count: 1
 			path: Command/ArticleExportCommand.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Command\\\\ArticleImportCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Command/ArticleImportCommand.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Command\\\\ArticleImportCommand\\:\\:printExceptions\\(\\) has no return type specified\\.$#"
@@ -69,11 +59,6 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between 0 and bool will always evaluate to false\\.$#"
 			count: 1
 			path: Command/ArticleImportCommand.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Command\\\\ReindexCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Command/ReindexCommand.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Command\\\\ReindexCommand\\:\\:getDocuments\\(\\) should return Sulu\\\\Component\\\\DocumentManager\\\\Collection\\\\QueryResultCollection but returns mixed\\.$#"
@@ -536,21 +521,6 @@ parameters:
 			path: Controller/WebsiteArticleController.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\DependencyInjection\\\\ConverterCompilerPass\\:\\:process\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: DependencyInjection/ConverterCompilerPass.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\DependencyInjection\\\\RouteEnhancerCompilerPass\\:\\:process\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: DependencyInjection/RouteEnhancerCompilerPass.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\DependencyInjection\\\\StructureValidatorCompilerPass\\:\\:process\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: DependencyInjection/StructureValidatorCompilerPass.php
-
-		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
 			path: DependencyInjection/StructureValidatorCompilerPass.php
@@ -587,11 +557,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\DependencyInjection\\\\SuluArticleExtension\\:\\:load\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: DependencyInjection/SuluArticleExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\DependencyInjection\\\\SuluArticleExtension\\:\\:prepend\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: DependencyInjection/SuluArticleExtension.php
 
@@ -961,17 +926,7 @@ parameters:
 			path: Document/Form/ArticleDocumentType.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Form\\\\ArticleDocumentType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/Form/ArticleDocumentType.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Form\\\\ArticlePageDocumentType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/Form/ArticlePageDocumentType.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Form\\\\ArticlePageDocumentType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: Document/Form/ArticlePageDocumentType.php
 
@@ -994,11 +949,6 @@ parameters:
 			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#"
 			count: 1
 			path: Document/Form/Listener/DataNormalizer.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Form\\\\UnstructuredType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/Form/UnstructuredType.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Index\\\\ArticleGhostIndexer\\:\\:__construct\\(\\) has parameter \\$typeConfiguration with no value type specified in iterable type array\\.$#"
@@ -1687,6 +1637,11 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'routePath' on mixed\\.$#"
+			count: 1
+			path: Document/Subscriber/ArticleSubscriber.php
+
+		-
+			message: "#^Cannot access offset int\\<0, max\\> on mixed\\.$#"
 			count: 1
 			path: Document/Subscriber/ArticleSubscriber.php
 
@@ -2509,11 +2464,6 @@ parameters:
 			message: "#^Parameter \\#3 \\$defaultLocale of class Sulu\\\\Bundle\\\\WebsiteBundle\\\\Sitemap\\\\SitemapUrl constructor expects string\\|null, DateTime given\\.$#"
 			count: 1
 			path: Sitemap/ArticleSitemapProvider.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\SuluArticleBundle\\:\\:build\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: SuluArticleBundle.php
 
 		-
 			message: "#^Cannot call method getExcerpt\\(\\) on mixed\\.$#"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs |
| License | MIT

#### What's in this PR?

When articles are collected for the sitemap, the provider restricts them to the articles that are associated with the webspaces of the current host. However, this restriction is not applied when the number of pages is being calculated.

#### Why?



#### Example Usage

#### BC Breaks/Deprecations

#### To Do