### PR TITLE
fix article-bridge language-code

### DIFF
--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -107,4 +107,19 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
     {
         $this->webspaceKey = $webspace;
     }
+
+
+    public function getLanguageCode()
+    {
+        if (!$this->document) {
+            return $this->locale;
+        }
+
+        // return original locale for shadow or ghost pages
+        if ($this->getIsShadow() || ($this->getType() && 'ghost' === $this->getType()->getName())) {
+            return $this->inspector->getOriginalLocale($this->getDocument());
+        }
+
+        return parent::getLanguageCode();
+    }
 }

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -108,7 +108,6 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
         $this->webspaceKey = $webspace;
     }
 
-
     public function getLanguageCode()
     {
         if (!$this->document) {

--- a/SuluArticleBundle.php
+++ b/SuluArticleBundle.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SuluArticleBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConverterCompilerPass());
         $container->addCompilerPass(new StructureValidatorCompilerPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -386,11 +386,6 @@ parameters:
 			path: Controller/ArticleController.php
 
 		-
-			message: "#^Parameter \\#1 \\$type of method Symfony\\\\Component\\\\Form\\\\FormFactoryInterface\\:\\:create\\(\\) expects class\\-string\\<Symfony\\\\Component\\\\Form\\\\FormTypeInterface\\<object\\>\\>, string given\\.$#"
-			count: 1
-			path: Controller/ArticleController.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|null given\\.$#"
 			count: 1
 			path: Controller/ArticleController.php
@@ -458,11 +453,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$actionParameter of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Controller\\\\ArticlePageController\\:\\:handleActionParameter\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 2
-			path: Controller/ArticlePageController.php
-
-		-
-			message: "#^Parameter \\#1 \\$type of method Symfony\\\\Component\\\\Form\\\\FormFactoryInterface\\:\\:create\\(\\) expects class\\-string\\<Symfony\\\\Component\\\\Form\\\\FormTypeInterface\\<object\\>\\>, string given\\.$#"
-			count: 1
 			path: Controller/ArticlePageController.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -386,6 +386,11 @@ parameters:
 			path: Controller/ArticleController.php
 
 		-
+			message: "#^Parameter \\#1 \\$type of method Symfony\\\\Component\\\\Form\\\\FormFactoryInterface\\:\\:create\\(\\) expects class\\-string\\<Symfony\\\\Component\\\\Form\\\\FormTypeInterface\\<object\\>\\>, string given\\.$#"
+			count: 1
+			path: Controller/ArticleController.php
+
+		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|null given\\.$#"
 			count: 1
 			path: Controller/ArticleController.php
@@ -453,6 +458,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$actionParameter of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Controller\\\\ArticlePageController\\:\\:handleActionParameter\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 2
+			path: Controller/ArticlePageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$type of method Symfony\\\\Component\\\\Form\\\\FormFactoryInterface\\:\\:create\\(\\) expects class\\-string\\<Symfony\\\\Component\\\\Form\\\\FormTypeInterface\\<object\\>\\>, string given\\.$#"
+			count: 1
 			path: Controller/ArticlePageController.php
 
 		-
@@ -1456,6 +1466,11 @@ parameters:
 			path: Document/Structure/ArticleBridge.php
 
 		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: Document/Structure/ArticleBridge.php
+
+		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Structure\\\\ArticleBridge\\:\\:getConcreteLanguages\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Document/Structure/ArticleBridge.php
@@ -1482,6 +1497,11 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Structure\\\\ArticleBridge\\:\\:setWebspaceKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: Document/Structure/ArticleBridge.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: Document/Structure/ArticleBridge.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR adds a missing pice of code from the PageBridge (https://github.com/sulu/sulu/blob/2.5/src/Sulu/Component/Content/Compat/Structure/PageBridge.php#L33-L44) which adapts the structure locale for shadow and ghost articles.

#### Why?

This leads into that the links in text_editor properties uses the wrong locale to resolve the URL.