### PR TITLE
Fix indexing of unpublished documents

### DIFF
--- a/Document/Index/ArticleGhostIndexer.php
+++ b/Document/Index/ArticleGhostIndexer.php
@@ -87,7 +87,7 @@ class ArticleGhostIndexer extends ArticleIndexer
         }
 
         $article = $this->createOrUpdateArticle($document, $document->getLocale());
-        $this->createOrUpdateShadows($document);
+        $this->updateShadows($document);
         $this->createOrUpdateGhosts($document);
         $this->dispatchIndexEvent($document, $article);
         $this->manager->persist($article);

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -429,9 +429,15 @@ class ArticleIndexer implements IndexerInterface
         }
     }
 
+    /**
+     * @deprecated
+     * @see ArticleIndexer::replaceWithGhostData
+     */
     public function removeLocale(ArticleDocument $document, string $locale): void
     {
-        $this->remove($document, $locale);
+        @\trigger_error('Calling ArticleIndexer::removeLocale() is deprecated and will be removed in future. Use ArticleIndexer::replaceWithGhostData() instead.', \E_USER_DEPRECATED);
+
+        $this->replaceWithGhostData($document, $locale);
     }
 
     public function replaceWithGhostData(ArticleDocument $document, string $locale): void
@@ -524,7 +530,7 @@ class ArticleIndexer implements IndexerInterface
             return;
         }
 
-        foreach (\array_keys($this->inspector->getShadowLocales($document, true)) as $shadowLocale) {
+        foreach (\array_keys($this->inspector->getPublishedShadowLocales($document)) as $shadowLocale) {
             try {
                 /** @var ArticleDocument $shadowDocument */
                 $shadowDocument = $this->documentManager->find($document->getUuid(), $shadowLocale);

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -18,7 +18,6 @@ use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticlePageDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticlePageViewObject;
-use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
 use Sulu\Bundle\ArticleBundle\Document\Index\Factory\ExcerptFactory;
 use Sulu\Bundle\ArticleBundle\Document\Index\Factory\SeoFactory;

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -429,15 +429,9 @@ class ArticleIndexer implements IndexerInterface
         }
     }
 
-    /**
-     * @deprecated
-     * @see ArticleIndexer::replaceWithGhostData
-     */
     public function removeLocale(ArticleDocument $document, string $locale): void
     {
-        @\trigger_error('Calling ArticleIndexer::removeLocale() is deprecated and will be removed in future. Use ArticleIndexer::replaceWithGhostData() instead.', \E_USER_DEPRECATED);
-
-        $this->replaceWithGhostData($document, $locale);
+        $this->remove($document, $locale);
     }
 
     public function replaceWithGhostData(ArticleDocument $document, string $locale): void
@@ -530,7 +524,7 @@ class ArticleIndexer implements IndexerInterface
             return;
         }
 
-        foreach (\array_keys($this->inspector->getShadowLocales($document)) as $shadowLocale) {
+        foreach (\array_keys($this->inspector->getShadowLocales($document, true)) as $shadowLocale) {
             try {
                 /** @var ArticleDocument $shadowDocument */
                 $shadowDocument = $this->documentManager->find($document->getUuid(), $shadowLocale);

--- a/Document/Index/IndexerInterface.php
+++ b/Document/Index/IndexerInterface.php
@@ -43,7 +43,8 @@ interface IndexerInterface
     public function remove(ArticleDocument $document/*, ?string $locale = null*/): void;
 
     /**
-     * Removes a locale for the given document from the index.
+     * @deprecated
+     * @see IndexerInterface::replaceWithGhostData
      */
     public function removeLocale(ArticleDocument $document, string $locale): void;
 

--- a/Document/Index/IndexerInterface.php
+++ b/Document/Index/IndexerInterface.php
@@ -43,8 +43,7 @@ interface IndexerInterface
     public function remove(ArticleDocument $document/*, ?string $locale = null*/): void;
 
     /**
-     * @deprecated
-     * @see IndexerInterface::replaceWithGhostData
+     * Removes a locale for the given document from the index.
      */
     public function removeLocale(ArticleDocument $document, string $locale): void;
 

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -495,7 +495,7 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->liveIndexer->removeLocale($document, $event->getLocale());
+        $this->liveIndexer->remove($document, $event->getLocale());
         $this->liveIndexer->flush();
     }
 

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -495,7 +495,7 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->liveIndexer->replaceWithGhostData($document, $event->getLocale());
+        $this->liveIndexer->removeLocale($document, $event->getLocale());
         $this->liveIndexer->flush();
     }
 

--- a/Resources/translations/admin.de.json
+++ b/Resources/translations/admin.de.json
@@ -28,5 +28,6 @@
     "sulu_activity.description.articles.translation_copied": "{userFullName} hat die Sprachvariante für \"{context_sourceLocale}\" des Artikels \"{resourceTitle}\" nach \"{resourceLocale}\" kopiert",
     "sulu_activity.description.articles.translation_removed": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" gelöscht",
     "sulu_activity.description.articles.translation_restored": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
-    "sulu_activity.description.articles.version_restored": "{userFullName} hat die Version \"{context_version}\" des Artikels \"{resourceTitle}\" wiederhergestellt"
+    "sulu_activity.description.articles.version_restored": "{userFullName} hat die Version \"{context_version}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
+    "sulu_activity.description.articles.route_removed": "{userFullName} hat die Route \"{resourceTitle}\" gelöscht."
 }

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -28,5 +28,6 @@
     "sulu_activity.description.articles.translation_copied": "{userFullName} has copied the \"{context_sourceLocale}\" translation of the article \"{resourceTitle}\" into \"{resourceLocale}\"",
     "sulu_activity.description.articles.translation_removed": "{userFullName} has removed the \"{resourceLocale}\" translation of the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.translation_restored": "{userFullName} has restored the \"{resourceLocale}\" translation of the article \"{resourceTitle}\"",
-    "sulu_activity.description.articles.version_restored": "{userFullName} has restored the version \"{context_version}\" of the article \"{resourceTitle}\""
+    "sulu_activity.description.articles.version_restored": "{userFullName} has restored the version \"{context_version}\" of the article \"{resourceTitle}\"",
+    "sulu_activity.description.articles.route_removed": "{userFullName} has removed the route \"{resourceTitle}\"."
 }

--- a/Tests/Application/config/webspaces/sulu.io.xml
+++ b/Tests/Application/config/webspaces/sulu.io.xml
@@ -9,6 +9,7 @@
     <localizations>
         <localization language="de" default="true"/>
         <localization language="en"/>
+        <localization language="fr"/>
     </localizations>
 
     <theme>default</theme>

--- a/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
@@ -31,6 +31,7 @@ use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\RemoveLocaleEvent;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
 
 class ArticleSubscriberTest extends TestCase
@@ -653,5 +654,64 @@ class ArticleSubscriberTest extends TestCase
         $this->documentManager->persist($this->document->reveal(), 'de')->shouldBeCalled();
 
         $this->articleSubscriber->persistPageDataOnReorder($event->reveal());
+    }
+
+    public function testHandleRemoveLocaleWithInvalidDocument()
+    {
+        $event = $this->prophesize(RemoveLocaleEvent::class);
+        $document = $this->prophesize(\stdClass::class); // Not an ArticleDocument
+        $event->getDocument()->willReturn($document->reveal());
+
+        // Ensure the indexer methods are not called
+        $this->indexer->replaceWithGhostData()->shouldNotBeCalled();
+        $this->indexer->flush()->shouldNotBeCalled();
+
+        // Call the method and make sure it doesn't throw exceptions
+        $this->articleSubscriber->handleRemoveLocale($event->reveal());
+    }
+
+    public function testHandleRemoveLocale()
+    {
+        $event = $this->prophesize(RemoveLocaleEvent::class);
+        $document = $this->prophesize(ArticleDocument::class);
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getLocale()->willReturn('en');
+
+        // Ensure the indexer methods are called
+        $this->indexer->replaceWithGhostData($document->reveal(), 'en')->shouldBeCalled();
+        $this->indexer->flush()->shouldBeCalled();
+
+        // Call the method
+        $this->articleSubscriber->handleRemoveLocale($event->reveal());
+    }
+
+    public function testHandleRemoveLocaleLiveWithInvalidDocument()
+    {
+        $event = $this->prophesize(RemoveLocaleEvent::class);
+        $document = $this->prophesize(\stdClass::class); // Not an ArticleDocument
+        $event->getDocument()->willReturn($document->reveal());
+
+        // Ensure the liveIndexer methods are not called
+        $this->liveIndexer->remove()->shouldNotBeCalled();
+        $this->liveIndexer->flush()->shouldNotBeCalled();
+
+        // Call the method and make sure it doesn't throw exceptions
+        $this->articleSubscriber->handleRemoveLocaleLive($event->reveal());
+    }
+
+    public function testHandleRemoveLocaleLive()
+    {
+        // Create a mock RemoveLocaleEvent with an ArticleDocument
+        $event = $this->prophesize(RemoveLocaleEvent::class);
+        $document = $this->prophesize(ArticleDocument::class);
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getLocale()->willReturn('en');
+
+        // Ensure the liveIndexer methods are called
+        $this->liveIndexer->remove($document->reveal(), 'en')->shouldBeCalled();
+        $this->liveIndexer->flush()->shouldBeCalled();
+
+        // Call the method
+        $this->articleSubscriber->handleRemoveLocaleLive($event->reveal());
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -976,11 +976,6 @@ parameters:
 			path: Document/Index/ArticleIndexer.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: Document/Index/ArticleIndexer.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Index\\\\ArticleIndexer\\:\\:__construct\\(\\) has parameter \\$typeConfiguration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Document/Index/ArticleIndexer.php
@@ -1051,16 +1046,6 @@ parameters:
 			path: Document/Index/ArticleIndexer.php
 
 		-
-			message: "#^Parameter \\#1 \\$document of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Index\\\\ArticleIndexer\\:\\:createOrUpdateArticle\\(\\) expects Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument, object given\\.$#"
-			count: 1
-			path: Document/Index/ArticleIndexer.php
-
-		-
-			message: "#^Parameter \\#1 \\$document of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Index\\\\ArticleIndexer\\:\\:dispatchIndexEvent\\(\\) expects Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument, object given\\.$#"
-			count: 1
-			path: Document/Index/ArticleIndexer.php
-
-		-
 			message: "#^Parameter \\#1 \\$metadata of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Index\\\\ArticleIndexer\\:\\:getType\\(\\) expects Sulu\\\\Component\\\\Content\\\\Metadata\\\\StructureMetadata, Sulu\\\\Component\\\\Content\\\\Metadata\\\\StructureMetadata\\|null given\\.$#"
 			count: 2
 			path: Document/Index/ArticleIndexer.php
@@ -1127,11 +1112,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between null and object will always evaluate to false\\.$#"
-			count: 1
-			path: Document/Index/ArticleIndexer.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: Document/Index/ArticleIndexer.php
 
@@ -1246,11 +1226,6 @@ parameters:
 			path: Document/Initializer/ArticleInitializer.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticleNodeType\\:\\:getDeclaredSupertypeNames\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Document/Initializer/ArticleNodeType.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticleNodeType\\:\\:getPrimaryItemName\\(\\) should return string but empty return statement found\\.$#"
 			count: 1
 			path: Document/Initializer/ArticleNodeType.php
@@ -1271,12 +1246,7 @@ parameters:
 			path: Document/Initializer/ArticlePageNodeDefinition.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticlePageNodeDefinition\\:\\:getRequiredPrimaryTypeNames\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Document/Initializer/ArticlePageNodeDefinition.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticlePageNodeDefinition\\:\\:getRequiredPrimaryTypeNames\\(\\) should return array but returns null\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticlePageNodeDefinition\\:\\:getRequiredPrimaryTypeNames\\(\\) should return array\\<string\\> but returns null\\.$#"
 			count: 1
 			path: Document/Initializer/ArticlePageNodeDefinition.php
 
@@ -1284,11 +1254,6 @@ parameters:
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticlePageNodeDefinition\\:\\:getRequiredPrimaryTypes\\(\\) should return array\\<PHPCR\\\\NodeType\\\\NodeTypeInterface\\> but returns null\\.$#"
 			count: 1
 			path: Document/Initializer/ArticlePageNodeDefinition.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticlePageNodeType\\:\\:getDeclaredSupertypeNames\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Document/Initializer/ArticlePageNodeType.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticlePageNodeType\\:\\:getPrimaryItemName\\(\\) should return string but empty return statement found\\.$#"
@@ -1651,28 +1616,8 @@ parameters:
 			path: Document/Subscriber/ArticleSubscriber.php
 
 		-
-			message: "#^Cannot call method getIdentifier\\(\\) on mixed\\.$#"
-			count: 1
-			path: Document/Subscriber/ArticleSubscriber.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Index\\\\IndexerInterface\\:\\:remove\\(\\) invoked with 1 parameter, 2 required\\.$#"
 			count: 2
-			path: Document/Subscriber/ArticleSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:getChildren\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
-			count: 1
-			path: Document/Subscriber/ArticleSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:getChildren\\(\\) return type has no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
-			count: 1
-			path: Document/Subscriber/ArticleSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:getChildren\\(\\) should return array\\<PHPCR\\\\NodeInterface\\> but returns array\\<int\\|string, mixed\\>\\.$#"
-			count: 1
 			path: Document/Subscriber/ArticleSubscriber.php
 
 		-
@@ -1682,11 +1627,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:handleRemoveLocaleLive\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/Subscriber/ArticleSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:loadPageDataForShadow\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: Document/Subscriber/ArticleSubscriber.php
 
@@ -1707,11 +1647,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:removeDraftChildren\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/Subscriber/ArticleSubscriber.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:setPageData\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: Document/Subscriber/ArticleSubscriber.php
 
@@ -1798,16 +1733,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method object\\:\\:getChildren\\(\\)\\.$#"
 			count: 2
-			path: Document/Subscriber/PageSubscriber.php
-
-		-
-			message: "#^Cannot call method getIdentifier\\(\\) on mixed\\.$#"
-			count: 1
-			path: Document/Subscriber/PageSubscriber.php
-
-		-
-			message: "#^Cannot call method setProperty\\(\\) on mixed\\.$#"
-			count: 1
 			path: Document/Subscriber/PageSubscriber.php
 
 		-
@@ -2062,11 +1987,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Import\\\\ArticleImport\\:\\:importExtension\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Import/ArticleImport.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Import\\\\ArticleImport\\:\\:importExtension\\(\\) has parameter \\$node with no value type specified in iterable type PHPCR\\\\NodeInterface\\.$#"
 			count: 1
 			path: Import/ArticleImport.php
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes

#### What's in this PR?

* `removeLocaleEvent` removes the locale completely from the live index now 
* shadows are now only updated and not created anymore on updates
* add translations for new route domain events ( see https://github.com/sulu/sulu/pull/7157 )

#### Why?

* Removing locales didn't remove the locale as expected, but instead a ghostcopy was created and published in the live index.
* Unpublished shadows were indexed in the live index and were therefore wrongfully published
* Translations for new domain events are missing
