### PR TITLE
Index correct ghost content when deleting the locale of an article

### DIFF
--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -465,6 +465,17 @@ class ArticleSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $concreteLocales = $this->documentInspector->getConcreteLocales($document);
+        $ghostLocale = $document->getOriginalLocale();
+        if (!\in_array($ghostLocale, $concreteLocales, true)) {
+            $ghostLocale = $concreteLocales[0] ?? null;
+        }
+
+        if (null !== $ghostLocale) {
+            /** @var ArticleDocument $document */
+            $document = $this->documentManager->find($document->getUuid(), $ghostLocale);
+        }
+
         $this->indexer->replaceWithGhostData($document, $event->getLocale());
         $this->indexer->flush();
     }

--- a/Tests/Application/.env
+++ b/Tests/Application/.env
@@ -1,5 +1,5 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:@127.0.0.1:3306/su_article_test?serverVersion=5.7
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7
 DATABASE_CHARSET=utf8mb4
 DATABASE_COLLATE=utf8mb4_unicode_ci
 ELASTICSEARCH_HOST=127.0.0.1:9200

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\MediaBundle\Content\Types\ImageMapContentType;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
@@ -38,7 +39,17 @@ class ArticleIndexerTest extends SuluTestCase
     /**
      * @var Manager
      */
+    private $liveManager;
+
+    /**
+     * @var Manager
+     */
     private $manager;
+
+    /**
+     * @var ArticleIndexer
+     */
+    private $liveIndexer;
 
     /**
      * @var ArticleIndexer
@@ -58,9 +69,12 @@ class ArticleIndexerTest extends SuluTestCase
         $this->initPhpcr();
         $this->purgeDatabase();
 
-        $this->manager = $this->getContainer()->get('es.manager.live');
+        $this->liveManager = $this->getContainer()->get('es.manager.live');
+        $this->manager = $this->getContainer()->get('es.manager.default');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->indexer = $this->getContainer()->get('sulu_article.elastic_search.article_live_indexer');
+        $this->liveIndexer = $this->getContainer()->get('sulu_article.elastic_search.article_live_indexer');
+        $this->liveIndexer->clear();
+        $this->indexer = $this->getContainer()->get('sulu_article.elastic_search.article_indexer');
         $this->indexer->clear();
     }
 
@@ -90,44 +104,11 @@ class ArticleIndexerTest extends SuluTestCase
 
         /** @var ArticleDocument $articleDocument */
         $articleDocument = $this->documentManager->find($article['id']);
-        $this->indexer->remove($articleDocument);
-        $this->indexer->flush();
+        $this->liveIndexer->remove($articleDocument);
+        $this->liveIndexer->flush();
 
-        self::assertNull($this->findViewDocument($articleDocument->getUuid(), 'de'));
-        self::assertNull($this->findViewDocument($articleDocument->getUuid(), 'en'));
-    }
-
-    public function testRemoveLocale()
-    {
-        $article = $this->createArticle(
-            [
-                'article' => 'Test content',
-            ],
-            'Test Article',
-            'default_with_route'
-        );
-
-        $secondLocale = 'de';
-
-        // now add second locale
-        $this->updateArticle(
-            $article['id'],
-            $secondLocale,
-            [
-                'id' => $article['id'],
-                'article' => 'Test Inhalt',
-            ],
-            'Test Artikel Deutsch',
-            'default_with_route'
-        );
-
-        /** @var ArticleDocument $articleDocument */
-        $articleDocument = $this->documentManager->find($article['id']);
-        $this->indexer->remove($articleDocument, 'en');
-        $this->indexer->flush();
-
-        self::assertNotNull($this->findViewDocument($articleDocument->getUuid(), 'de'));
-        self::assertNull($this->findViewDocument($articleDocument->getUuid(), 'en'));
+        self::assertNull($this->findLiveViewDocument($articleDocument->getUuid(), 'de'));
+        self::assertNull($this->findLiveViewDocument($articleDocument->getUuid(), 'en'));
     }
 
     public function testReplaceWithGhostData()
@@ -169,6 +150,73 @@ class ArticleIndexerTest extends SuluTestCase
         $this->assertSame('Test Article', $documentEN->getTitle());
     }
 
+    public function testReplaceWithGhostDataUpdateExistingGhosts()
+    {
+        $article = $this->createArticle(
+            [
+                'article' => 'Test content',
+            ],
+            'Test Article English',
+            'default_with_route'
+        );
+
+        $this->updateArticle(
+            $article['id'],
+            'de',
+            [
+                'id' => $article['id'],
+                'article' => 'Test Inhalt',
+            ],
+            'Test Artikel Deutsch',
+            'default_with_route'
+        );
+
+        $this->updateArticle(
+            $article['id'],
+            'fr',
+            [
+                'id' => $article['id'],
+                'article' => 'Test Inhalt',
+            ],
+            'Test Artikel French',
+            'default_with_route'
+        );
+
+        $documentEN = $this->findViewDocument($article['id'], 'en');
+        $this->assertSame(LocalizationState::LOCALIZED, $documentEN->getLocalizationState()->state);
+        $documentDE = $this->findViewDocument($article['id'], 'de');
+        $this->assertSame(LocalizationState::LOCALIZED, $documentDE->getLocalizationState()->state);
+        $documentFR = $this->findViewDocument($article['id'], 'fr');
+        $this->assertSame(LocalizationState::LOCALIZED, $documentFR->getLocalizationState()->state);
+
+        /** @var ArticleDocument $articleDocument */
+        $articleDocument = $this->documentManager->find($article['id'], 'en');
+        $this->indexer->replaceWithGhostData($articleDocument, 'fr');
+        $this->indexer->flush();
+
+        $documentEN = $this->findViewDocument($article['id'], 'en');
+        $this->assertSame(LocalizationState::LOCALIZED, $documentEN->getLocalizationState()->state);
+        $documentDE = $this->findViewDocument($article['id'], 'de');
+        $this->assertSame(LocalizationState::LOCALIZED, $documentDE->getLocalizationState()->state);
+        $documentFR = $this->findViewDocument($article['id'], 'fr');
+        $this->assertSame(LocalizationState::GHOST, $documentFR->getLocalizationState()->state);
+        $this->assertSame('en', $documentFR->getLocalizationState()->locale);
+
+        /** @var ArticleDocument $articleDocument */
+        $articleDocument = $this->documentManager->find($article['id'], 'de');
+        $this->indexer->replaceWithGhostData($articleDocument, 'en');
+        $this->indexer->flush();
+
+        $documentEN = $this->findViewDocument($article['id'], 'en');
+        $this->assertSame(LocalizationState::GHOST, $documentEN->getLocalizationState()->state);
+        $this->assertSame('de', $documentEN->getLocalizationState()->locale);
+        $documentDE = $this->findViewDocument($article['id'], 'de');
+        $this->assertSame(LocalizationState::LOCALIZED, $documentDE->getLocalizationState()->state);
+        $documentFR = $this->findViewDocument($article['id'], 'fr');
+        $this->assertSame(LocalizationState::GHOST, $documentFR->getLocalizationState()->state);
+        $this->assertSame('de', $documentFR->getLocalizationState()->locale);
+    }
+
     public function testIndexDefaultWithRoute()
     {
         $article = $this->createArticle(
@@ -179,12 +227,12 @@ class ArticleIndexerTest extends SuluTestCase
             'default_with_route'
         );
 
-        $this->indexer = $this->getContainer()->get('sulu_article.elastic_search.article_live_indexer');
+        $this->liveIndexer = $this->getContainer()->get('sulu_article.elastic_search.article_live_indexer');
 
         $document = $this->documentManager->find($article['id'], $this->locale);
-        $this->indexer->index($document);
+        $this->liveIndexer->index($document);
 
-        $viewDocument = $this->findViewDocument($article['id']);
+        $viewDocument = $this->findLiveViewDocument($article['id']);
         $this->assertEquals($document->getUuid(), $viewDocument->getUuid());
         $this->assertEquals('/articles/test-article', $viewDocument->getRoutePath());
         $this->assertInstanceOf('\DateTime', $viewDocument->getPublished());
@@ -230,7 +278,7 @@ class ArticleIndexerTest extends SuluTestCase
             null
         );
 
-        $viewDocument = $this->findViewDocument($article['id'], $secondLocale);
+        $viewDocument = $this->findLiveViewDocument($article['id'], $secondLocale);
 
         $this->assertEquals($article['id'], $viewDocument->getUuid());
         $this->assertEquals('/articles/test-artikel-deutsch', $viewDocument->getRoutePath());
@@ -257,7 +305,7 @@ class ArticleIndexerTest extends SuluTestCase
             'default_with_route'
         );
 
-        $viewDocument = $this->findViewDocument($article['id'], $secondLocale);
+        $viewDocument = $this->findLiveViewDocument($article['id'], $secondLocale);
         $this->assertEquals('Test Article - CHANGED!', $viewDocument->getTitle());
 
         $contentData = \json_decode($viewDocument->getContentData(), true);
@@ -320,17 +368,17 @@ class ArticleIndexerTest extends SuluTestCase
             null
         );
 
-        self::assertNotNull($this->findViewDocument($article['id'], $this->locale));
-        self::assertNotNull($this->findViewDocument($article['id'], $secondLocale));
-        self::assertNotNull($this->findViewDocument($article['id'], $thirdLocale));
+        self::assertNotNull($this->findLiveViewDocument($article['id'], $this->locale));
+        self::assertNotNull($this->findLiveViewDocument($article['id'], $secondLocale));
+        self::assertNotNull($this->findLiveViewDocument($article['id'], $thirdLocale));
 
         $this->unpublishArticle($article['id'], $this->locale);
         $this->unpublishArticle($article['id'], $secondLocale);
         $this->unpublishArticle($article['id'], $thirdLocale);
 
-        self::assertNull($this->findViewDocument($article['id'], $this->locale));
-        self::assertNull($this->findViewDocument($article['id'], $secondLocale));
-        self::assertNull($this->findViewDocument($article['id'], $thirdLocale));
+        self::assertNull($this->findLiveViewDocument($article['id'], $this->locale));
+        self::assertNull($this->findLiveViewDocument($article['id'], $secondLocale));
+        self::assertNull($this->findLiveViewDocument($article['id'], $thirdLocale));
 
         // publish the shadow
         $this->updateArticle(
@@ -344,9 +392,9 @@ class ArticleIndexerTest extends SuluTestCase
         );
 
         // only the DE shadow should be published
-        self::assertNull($this->findViewDocument($article['id'], $this->locale));
-        self::assertNotNull($this->findViewDocument($article['id'], $secondLocale));
-        self::assertNull($this->findViewDocument($article['id'], $thirdLocale));
+        self::assertNull($this->findLiveViewDocument($article['id'], $this->locale));
+        self::assertNotNull($this->findLiveViewDocument($article['id'], $secondLocale));
+        self::assertNull($this->findLiveViewDocument($article['id'], $thirdLocale));
     }
 
     public function testIndexPageTreeRoute()
@@ -364,9 +412,9 @@ class ArticleIndexerTest extends SuluTestCase
         );
 
         $document = $this->documentManager->find($article['id'], $this->locale);
-        $this->indexer->index($document);
+        $this->liveIndexer->index($document);
 
-        $viewDocument = $this->findViewDocument($article['id']);
+        $viewDocument = $this->findLiveViewDocument($article['id']);
         $this->assertEquals($page->getUuid(), $viewDocument->getParentPageUuid());
     }
 
@@ -374,7 +422,7 @@ class ArticleIndexerTest extends SuluTestCase
     {
         $article = $this->createArticle();
 
-        $viewDocument = $this->indexer->setUnpublished($article['id'], $this->locale);
+        $viewDocument = $this->liveIndexer->setUnpublished($article['id'], $this->locale);
         $this->assertNull($viewDocument->getPublished());
         $this->assertFalse($viewDocument->getPublishedState());
     }
@@ -411,10 +459,10 @@ class ArticleIndexerTest extends SuluTestCase
         $this->documentManager->clear();
 
         $document = $this->documentManager->find($article['id'], $this->locale);
-        $this->indexer->index($document);
-        $this->indexer->flush();
+        $this->liveIndexer->index($document);
+        $this->liveIndexer->flush();
 
-        $viewDocument = $this->findViewDocument($article['id']);
+        $viewDocument = $this->findLiveViewDocument($article['id']);
         $contentFields = $viewDocument->getContentFields();
 
         $this->assertSame($article['id'], $viewDocument->getUuid());
@@ -496,10 +544,10 @@ class ArticleIndexerTest extends SuluTestCase
         $this->documentManager->clear();
 
         $document = $this->documentManager->find($article['id'], $this->locale);
-        $this->indexer->index($document);
-        $this->indexer->flush();
+        $this->liveIndexer->index($document);
+        $this->liveIndexer->flush();
 
-        $viewDocument = $this->findViewDocument($article['id']);
+        $viewDocument = $this->findLiveViewDocument($article['id']);
         $contentFields = $viewDocument->getContentFields();
 
         $this->assertEquals($article['id'], $viewDocument->getUuid());
@@ -532,10 +580,10 @@ class ArticleIndexerTest extends SuluTestCase
         $this->documentManager->clear();
 
         $document = $this->documentManager->find($article['id'], $this->locale);
-        $this->indexer->index($document);
-        $this->indexer->flush();
+        $this->liveIndexer->index($document);
+        $this->liveIndexer->flush();
 
-        $viewDocument = $this->findViewDocument($article['id']);
+        $viewDocument = $this->findLiveViewDocument($article['id']);
         $this->assertEquals($article['id'], $viewDocument->getUuid());
         $this->assertEquals($data, \json_decode($viewDocument->getContentData(), true));
 
@@ -694,7 +742,23 @@ class ArticleIndexerTest extends SuluTestCase
     }
 
     /**
-     * Find view-document.
+     * Find view-document in live index.
+     *
+     * @param string $uuid
+     * @param string $locale
+     *
+     * @return ArticleViewDocument
+     */
+    private function findLiveViewDocument($uuid, $locale = null)
+    {
+        return $this->liveManager->find(
+            $this->getContainer()->getParameter('sulu_article.view_document.article.class'),
+            $uuid . '-' . ($locale ? $locale : $this->locale)
+        );
+    }
+
+    /**
+     * Find view-document in live index.
      *
      * @param string $uuid
      * @param string $locale

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: Admin/ArticleAdmin.php
 
 		-
+			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Admin\\\\ArticleAdmin\\:\\:getSecurityContexts\\(\\) should return array\\<string, array\\<string, array\\<string, array\\<string\\>\\>\\>\\> but returns array\\<string, array\\<string, array\\<int\\|string, array\\<int, string\\>\\>\\>\\>\\.$#"
+			count: 1
+			path: Admin/ArticleAdmin.php
+
+		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Admin\\\\ArticleAdmin\\:\\:getTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Admin/ArticleAdmin.php
@@ -2147,7 +2152,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'pageNumber' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: Preview/ArticleObjectProvider.php
 
 		-


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

When deleting a locale of an article the behaviour was wrong which locale is the "ghosted" locale. This should be fixed with this PR.

This PR uses now an existing one. If the default one is available this one will be used else another one will be used.

Additionally this PR fixes the problem when a locale was remove which is the ghosted locale of another page.

#### Why?

Without this fix ALWAYS the default locale was the ghosted locale. Also if this locale was removed or another one but the default one was not created.

#### To Do

- [ ] Fix: When a locale was remove which is the ghosted locale of another page
- [ ] Tests
