### PR TITLE
Fix for the add new locale dialog

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -56,6 +56,7 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument>%sulu_article.display_tab_all%</argument>
             <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/Resources/doc/default.html.twig
+++ b/Resources/doc/default.html.twig
@@ -6,10 +6,4 @@
     <div>
         {{ content.article|default()|raw }}
     </div>
-
-    <ul>
-        {% for page in pages %}
-            <li><a href="{{ sulu_content_path(page.routePath) }}">{{ page.title|default('Page '~page.pageNumber) }}</a></li>
-        {% endfor %}
-    </ul>
 {% endblock %}

--- a/Tests/Application/.env
+++ b/Tests/Application/.env
@@ -1,5 +1,5 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7
+DATABASE_URL=mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=5.7
 DATABASE_CHARSET=utf8mb4
 DATABASE_COLLATE=utf8mb4_unicode_ci
 ELASTICSEARCH_HOST=127.0.0.1:9200

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -371,7 +371,6 @@ class ArticleControllerTest extends SuluTestCase
 
         // test that ghost do not serve default webspace settings
         $response = $this->get($article['id'], 'en');
-        $this->assertEquals($title, $response['title']);
         $this->assertEquals('sulu_io', $response['mainWebspace']);
         $this->assertEquals([], $response['additionalWebspaces']);
 
@@ -415,7 +414,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($additionalWebspaces ?? [], $viewDocument->getAdditionalWebspaces());
     }
 
-    public function testGetGhost()
+    public function testGetEmptyDocument()
     {
         $title = 'Sulu ist toll';
         $article = $this->testPut($title, 'de');
@@ -425,11 +424,10 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $response = \json_decode($this->client->getResponse()->getContent(), true);
-        $this->assertNotEquals($article['title'], $response['title']);
-        $this->assertEquals($title, $response['title']);
-        $this->assertEquals('2016-01-01', \date('Y-m-d', \strtotime($response['authored'])));
-        $this->assertEquals($this->getTestUser()->getContact()->getId(), $response['author']);
-        $this->assertEquals(['name' => 'ghost', 'value' => 'de'], $response['type']);
+        $this->assertEquals('', $response['title']);
+        $this->assertEquals(null, $response['authored']);
+        $this->assertEquals(null, $response['author']);
+        $this->assertEquals($article['template'], $response['template']);
     }
 
     public function testGetShadow()

--- a/Tests/Functional/Controller/ArticlePageControllerTest.php
+++ b/Tests/Functional/Controller/ArticlePageControllerTest.php
@@ -284,30 +284,6 @@ class ArticlePageControllerTest extends SuluTestCase
         $this->assertCount(0, $articleViewDocument->getPages());
     }
 
-    public function testHandleGhostArticlePageAndArticle($pageTitle = 'Sulu is awesome')
-    {
-        $article = $this->createArticle();
-        $page = $this->post($article);
-
-        $this->client->jsonRequest(
-            'PUT',
-            '/api/articles/' . $article['id'] . '/pages/' . $page['id'] . '?locale=en',
-            [
-                'pageTitle' => $pageTitle,
-            ]
-        );
-
-        $response = \json_decode($this->client->getResponse()->getContent(), true);
-        $this->assertHttpStatusCode(200, $this->client->getResponse());
-
-        $this->assertArrayNotHasKey('type', $response);
-        $this->assertEquals($pageTitle, $response['pageTitle']);
-
-        // article should stay ghost
-        $article = $this->getArticle($article['id'], 'en');
-        $this->assertEquals('ghost', $article['type']['name']);
-    }
-
     public function testHandleSecondLocale($title = 'Sulu ist toll')
     {
         $articleDE = $this->createArticle($title);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Before this PR the choice in the copy dialog did not make a difference. The article was always loaded with `ghost_locale: true` and therefore the content of the previous locale was always copied. This fix prevents that.