### PR TITLE
Update loadArticles function in example

### DIFF
--- a/Resources/doc/overview-page.md
+++ b/Resources/doc/overview-page.md
@@ -112,7 +112,8 @@ class ArticleOverviewController extends WebsiteController
         $search = $repository->createSearch()
             ->addSort(new FieldSort('authored', FieldSort::DESC))
             ->setFrom(($page - 1) * $pageSize)
-            ->setSize($pageSize);
+            ->setSize($pageSize)
+            ->addQuery(new TermQuery('locale', $locale));
 
         return $repository->findDocuments($search);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |
| License | MIT

#### What's in this PR?

One of the parameters of the example `loadArticles` function in the documentation is `$locale`, which is never used. Calling this function results in downloading all articles, regardless of the language passed to `$locale`.
