### PR TITLE
Fix routePath in ArticleTrashItemHandler

### DIFF
--- a/Tests/Functional/Trash/ArticleTrashItemHandlerTest.php
+++ b/Tests/Functional/Trash/ArticleTrashItemHandlerTest.php
@@ -205,7 +205,7 @@ class ArticleTrashItemHandlerTest extends SuluTestCase
         $restoredArticleEn = $this->documentManager->find($restoredArticle->getUuid(), 'en');
         static::assertSame('target-locale-title', $restoredArticleEn->getTitle());
         static::assertSame('de', $restoredArticleEn->getLocale());
-        static::assertSame('source-locale-route-path', $restoredArticleEn->getRoutePath());
+        static::assertSame('target-locale-route-path', $restoredArticleEn->getRoutePath());
         static::assertSame('target locale article content', $restoredArticleEn->getStructure()->toArray()['article']);
         static::assertSame('en', $restoredArticleEn->getOriginalLocale());
         static::assertSame('de', $restoredArticleEn->getShadowLocale());

--- a/Trash/ArticleTrashItemHandler.php
+++ b/Trash/ArticleTrashItemHandler.php
@@ -16,7 +16,6 @@ namespace Sulu\Bundle\ArticleBundle\Trash;
 use Sulu\Bundle\ArticleBundle\Admin\ArticleAdmin;
 use Sulu\Bundle\ArticleBundle\Controller\ArticleController;
 use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
-use Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber;
 use Sulu\Bundle\ArticleBundle\Domain\Event\ArticleRestoredEvent;
 use Sulu\Bundle\ArticleBundle\Domain\Event\ArticleTranslationRestoredEvent;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
@@ -97,7 +96,6 @@ final class ArticleTrashItemHandler implements
             // routePath property of structure contains route of target locale in case of a shadow page
             // we want to restore the path of the source locale, therefore we use the value of the document
             $structureData = $localizedArticle->getStructure()->toArray();
-            $structureData[RoutableSubscriber::ROUTE_FIELD] = $localizedArticle->getRoutePath();
 
             $articleTitles[$locale] = $localizedArticle->getTitle();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Changed the structureData in the ArticleTrashItemHandler, so that the routePath is set correctly.

#### Why?

When an article has an routePath property and you delete it and want to restore it you get an type error.

