### PR TITLE
Fix restore when parent page was deleted

### DIFF
--- a/Document/Subscriber/WebspaceSubscriber.php
+++ b/Document/Subscriber/WebspaceSubscriber.php
@@ -20,6 +20,7 @@ use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -103,10 +104,14 @@ class WebspaceSubscriber implements EventSubscriberInterface
         if ($parentPageUuid) {
             // we know now it's a `page_tree_route` route
             // so load the parent and find out the webspace
-            $parentDocument = $this->documentManager->find($parentPageUuid, $event->getLocale());
-            $mainWebspace = $this->documentInspector->getWebspace($parentDocument);
-            $document->setMainWebspace($mainWebspace);
-            $document->setAdditionalWebspaces([]);
+            try {
+                $parentDocument = $this->documentManager->find($parentPageUuid, $event->getLocale());
+                $mainWebspace = $this->documentInspector->getWebspace($parentDocument);
+                $document->setMainWebspace($mainWebspace);
+                $document->setAdditionalWebspaces([]);
+            } catch (DocumentNotFoundException $exception) {
+                // Do nothing, because when the parent page was deleted it should still work while restoring.
+            }
         }
 
         $mainWebspace = $document->getMainWebspace();

--- a/Tests/Application/config/templates/articles/default_with_page_tree_route.xml
+++ b/Tests/Application/config/templates/articles/default_with_page_tree_route.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default_with_page_tree_route</key>
+
+    <view>::default_with_page_tree_route</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <tag name="sulu_article.type" type="blog"/>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true"/>
+
+        <property name="routePath" type="page_tree_route">
+            <tag name="sulu_article.article_route"/>
+        </property>
+
+        <property name="article" type="text_area"/>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add try/catch if the parent page was removed.

#### Why?

Fix when an article with parent page ("page_tree_route") was deleted and then the page is deleted. There was an error when restoring the Article.

