### PR TITLE
Add audience targeting groups to data provider for smart contents

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -92,7 +92,7 @@ jobs:
                 options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
 
             jackrabbit:
-                image: sulu/jackrabbit:2.20-standalone
+                image: sulu/jackrabbit:2.20-tomcat-filesystem
                 env:
                     DATABASE_HOST: mysql
                     DATABASE_PORT: 3306

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -605,6 +605,7 @@ class ArticleController extends AbstractRestController implements ClassResourceI
                 case 'copy':
                     /** @var ArticleDocument $document */
                     $document = $this->documentManager->find($id, $locale);
+                    /** @var string $copiedPath */
                     $copiedPath = $this->documentManager->copy($document, \dirname($document->getPath()));
                     $this->documentManager->flush();
 

--- a/Document/ExcerptViewObject.php
+++ b/Document/ExcerptViewObject.php
@@ -90,6 +90,13 @@ class ExcerptViewObject
     public $segments;
 
     /**
+     * @var int[]
+     *
+     * @Property(type="integer")
+     */
+    public $audienceTargetingGroups;
+
+    /**
      * @var MediaViewObject[]|Collection
      *
      * @Embedded(class="Sulu\Bundle\ArticleBundle\Document\MediaViewObject", multiple=true)

--- a/Document/Index/Factory/ExcerptFactory.php
+++ b/Document/Index/Factory/ExcerptFactory.php
@@ -70,6 +70,7 @@ class ExcerptFactory
         $excerpt->tags = $this->tagCollectionFactory->create($data['tags']);
         $excerpt->categories = $this->categoryCollectionFactory->create($data['categories'], $locale);
         $excerpt->segments = $this->segmentCollectionFactory->create($data['segments'] ?? []);
+        $excerpt->audienceTargetingGroups = $data['audience_targeting_groups'] ?? [];
         $excerpt->icon = $this->mediaCollectionFactory->create($data['icon'] ?? [], $locale);
         $excerpt->images = $this->mediaCollectionFactory->create($data['images'] ?? [], $locale);
 

--- a/Document/Subscriber/ArticlePageSubscriber.php
+++ b/Document/Subscriber/ArticlePageSubscriber.php
@@ -158,10 +158,12 @@ class ArticlePageSubscriber implements EventSubscriberInterface
         }
 
         $document->getParent()->setWorkflowStage(WorkflowStage::TEST);
+        /** @var array<string, mixed> $options */
+        $options = $event instanceof PersistEvent ? $event->getOptions() : [];
         $this->documentManager->persist(
             $document->getParent(),
             $this->documentInspector->getLocale($document),
-            $event instanceof PersistEvent ? $event->getOptions() : []
+            $options
         );
     }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -341,6 +341,7 @@
             <argument type="string">%sulu_article.smart_content.default_limit%</argument>
             <argument type="service" id="sulu_admin.form_metadata_provider" on-invalid="null"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <argument type="expression">container.hasParameter('sulu_audience_targeting.enabled')</argument>
 
             <tag name="sulu.smart_content.data_provider" alias="articles"/>
         </service>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1581,11 +1581,6 @@ parameters:
 			path: Document/Subscriber/ArticlePageSubscriber.php
 
 		-
-			message: "#^Parameter \\#3 \\$options of method Sulu\\\\Component\\\\DocumentManager\\\\DocumentManagerInterface\\:\\:persist\\(\\) expects array, array\\|Symfony\\\\Component\\\\OptionsResolver\\\\OptionsResolver given\\.$#"
-			count: 1
-			path: Document/Subscriber/ArticlePageSubscriber.php
-
-		-
 			message: "#^Right side of \\|\\| is always true\\.$#"
 			count: 1
 			path: Document/Subscriber/ArticlePageSubscriber.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add the audience targeting group id to the article view document and also add it to the smart_content filters.

#### Why?

Do use the full functionality of the AudienceTargetingBundle for Articles.

