### PR TITLE
Add route_path as searchfield

### DIFF
--- a/ListBuilder/ElasticSearchFieldDescriptor.php
+++ b/ListBuilder/ElasticSearchFieldDescriptor.php
@@ -30,6 +30,11 @@ class ElasticSearchFieldDescriptor extends FieldDescriptor
      */
     private $sortField;
 
+    /**
+     * @var string
+     */
+    private $searchField;
+
     public function __construct(
         string $name,
         string $sortField = null,
@@ -37,9 +42,11 @@ class ElasticSearchFieldDescriptor extends FieldDescriptor
         string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',
-        bool $sortable = true
+        bool $sortable = true,
+        string $searchField = ''
     ) {
         $this->sortField = $sortField ? $sortField : $name;
+        $this->searchField = $searchField;
 
         parent::__construct(
             $name,
@@ -54,5 +61,10 @@ class ElasticSearchFieldDescriptor extends FieldDescriptor
     public function getSortField(): string
     {
         return $this->sortField;
+    }
+
+    public function getSearchField(): string
+    {
+        return $this->searchField;
     }
 }

--- a/ListBuilder/ElasticSearchFieldDescriptorBuilder.php
+++ b/ListBuilder/ElasticSearchFieldDescriptorBuilder.php
@@ -50,6 +50,11 @@ final class ElasticSearchFieldDescriptorBuilder
      */
     private $sortable = false;
 
+    /**
+     * @var string
+     */
+    private $searchField = '';
+
     public function __construct(string $name, string $translation = null)
     {
         $this->name = $name;
@@ -85,6 +90,13 @@ final class ElasticSearchFieldDescriptorBuilder
         return $this;
     }
 
+    public function setSearchField(string $searchField): self
+    {
+        $this->searchField = $searchField;
+
+        return $this;
+    }
+
     public function build(): ElasticSearchFieldDescriptor
     {
         return new ElasticSearchFieldDescriptor(
@@ -94,7 +106,8 @@ final class ElasticSearchFieldDescriptorBuilder
             $this->visibility,
             $this->searchability,
             $this->type,
-            $this->sortable
+            $this->sortable,
+            $this->searchField,
         );
     }
 }

--- a/Resources/config/lists/articles.xml
+++ b/Resources/config/lists/articles.xml
@@ -111,5 +111,10 @@
                 </params>
             </filter>
         </property>
+        <property
+            name="routePath"
+            visibility="no"
+            translation="sulu_article.route"
+        />
     </properties>
 </list>

--- a/Resources/translations/admin.de.json
+++ b/Resources/translations/admin.de.json
@@ -14,6 +14,7 @@
     "sulu_article.published_state": "Status der Veröffentlichung",
     "sulu_article.published": "Veröffentlicht",
     "sulu_article.not_published": "Nicht Veröffentlicht",
+    "sulu_article.route": "Route",
     "sulu_activity.resource.articles": "Artikel",
     "sulu_activity.resource.articles.translation": "Übersetzung",
     "sulu_activity.description.articles.created": "{userFullName} hat den Artikel \"{resourceTitle}\" erstellt",

--- a/Resources/translations/admin.en.json
+++ b/Resources/translations/admin.en.json
@@ -14,6 +14,7 @@
     "sulu_article.published_state": "Published State",
     "sulu_article.published": "Published",
     "sulu_article.not_published": "Not Published",
+    "sulu_article.route": "Route",
     "sulu_activity.resource.articles": "Article",
     "sulu_activity.resource.articles.translation": "Translation",
     "sulu_activity.description.articles.created": "{userFullName} has created the article \"{resourceTitle}\"",

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -880,6 +880,28 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals($articles[1]['title'], $response['_embedded']['articles'][1]['title']);
     }
 
+    public function testCGetSearchFieldRoutePath()
+    {
+        $routePathData = [
+            'suffix' => '/test-route',
+        ];
+        $article = $this->postPageTreeRoute($routePathData, 'Article Name');
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/articles?locale=de&page=1&limit=10&fields=id,title,creatorFullName,changerFullName,authorFullName,routePath&search=test-route&flat=true'
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(1, $response['total']);
+        $this->assertCount(1, $response['_embedded']['articles']);
+        $this->assertEquals($article['id'], $response['_embedded']['articles'][0]['id']);
+        $this->assertEquals($article['title'], $response['_embedded']['articles'][0]['title']);
+    }
+
     public function testCGetSearchCaseInsensitive()
     {
         $this->testPost('Sulu');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add routePath to searchfields and also to article list view.

#### Why?

So the routePath can be searched, for better usability.
