### PR TITLE
Run lint task under PHP 8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
                       sudo docker-php-ext-install pdo_mysql gd
                   parallel: true
             - run: echo -e "memory_limit=2G" | sudo tee /usr/local/etc/php/php.ini > /dev/null
+            - run: /usr/local/bin/composer remove php-cs-fixer/shim --dev --no-update
             - run: /usr/local/bin/composer require "elasticsearch/elasticsearch:~7.5.2" --no-update
             - restore_cache:
                   keys:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -155,7 +155,7 @@ jobs:
             - name: Install and configure PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 8.1
+                  php-version: 8.3
                   extensions: 'ctype, iconv, mysql, imagick'
                   tools: 'composer:v2'
                   coverage: none

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -82,6 +82,18 @@ jobs:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           ELASTICSEARCH_HOST: '127.0.0.1:9200'
 
+                    - php-version: '8.3'
+                      elasticsearch-version: '7.11.1'
+                      elasticsearch-package-constraint: '~7.11.0'
+                      phpcr-transport: jackrabbit
+                      dependency-versions: 'highest'
+                      php-extensions: 'ctype, iconv, mysql, imagick'
+                      tools: 'composer:v2'
+                      phpstan: false
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                          ELASTICSEARCH_HOST: '127.0.0.1:9200'
+
         services:
             mysql:
                 image: mysql:5.7

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -124,6 +124,9 @@ jobs:
                   tools: ${{ matrix.tools }}
                   coverage: none
 
+            - name: Remove not required tooling
+              run: composer remove php-cs-fixer/shim --dev --no-interaction --no-update
+
             - name: Require elasticsearch dependency
               run: composer require --dev elasticsearch/elasticsearch:"${{ matrix.elasticsearch-package-constraint }}" --no-interaction --no-update
 

--- a/Command/ArticleImportCommand.php
+++ b/Command/ArticleImportCommand.php
@@ -37,7 +37,7 @@ class ArticleImportCommand extends Command
      */
     private $logger;
 
-    public function __construct(ArticleImportInterface $articleImporter, LoggerInterface $logger = null)
+    public function __construct(ArticleImportInterface $articleImporter, ?LoggerInterface $logger = null)
     {
         parent::__construct();
 

--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -98,8 +98,8 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
         ArticleResourceItemFactory $articleResourceItemFactory,
         string $articleDocumentClass,
         int $defaultLimit,
-        MetadataProviderInterface $formMetadataProvider = null,
-        TokenStorageInterface $tokenStorage = null,
+        ?MetadataProviderInterface $formMetadataProvider = null,
+        ?TokenStorageInterface $tokenStorage = null,
         bool $hasAudienceTargeting = false
     ) {
         $this->searchManager = $searchManager;

--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -333,8 +333,8 @@ class ArticleController extends AbstractRestController implements ClassResourceI
             $search->addQuery(new MatchAllQuery());
         }
 
-        if (null !== $this->restHelper->getSortColumn() &&
-            $sortField = $this->getSortFieldName($this->restHelper->getSortColumn())
+        if (null !== $this->restHelper->getSortColumn()
+            && $sortField = $this->getSortFieldName($this->restHelper->getSortColumn())
         ) {
             $search->addSort(
                 new FieldSort($sortField, $this->restHelper->getSortOrder())

--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -295,6 +295,7 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
+        /** @var array<string, string> $bundles */
         $bundles = $container->getParameter('kernel.bundles');
         if (\array_key_exists('SuluAutomationBundle', $bundles)) {
             $loader->load('automation.xml');

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -145,8 +145,6 @@ class ArticlePageDocument implements UuidBehavior,
 
     /**
      * Returns pageTitle.
-     *
-     * @return string
      */
     public function getPageTitle(): ?string
     {

--- a/Document/ArticleViewDocument.php
+++ b/Document/ArticleViewDocument.php
@@ -489,7 +489,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
         return $this->authored;
     }
 
-    public function setAuthored(\DateTime $authored = null)
+    public function setAuthored(?\DateTime $authored = null)
     {
         $this->authored = $authored;
 
@@ -537,7 +537,7 @@ class ArticleViewDocument implements ArticleViewDocumentInterface
         return $this->published;
     }
 
-    public function setPublished(\DateTime $published = null)
+    public function setPublished(?\DateTime $published = null)
     {
         $this->published = $published;
 

--- a/Document/ArticleViewDocumentInterface.php
+++ b/Document/ArticleViewDocumentInterface.php
@@ -267,11 +267,9 @@ interface ArticleViewDocumentInterface
     /**
      * Set authored date.
      *
-     * @param \DateTime $authored
-     *
      * @return $this
      */
-    public function setAuthored(\DateTime $authored = null);
+    public function setAuthored(?\DateTime $authored = null);
 
     /**
      * Returns author full name.
@@ -331,11 +329,9 @@ interface ArticleViewDocumentInterface
     /**
      * Set published.
      *
-     * @param \DateTime $published
-     *
      * @return $this
      */
-    public function setPublished(\DateTime $published = null);
+    public function setPublished(?\DateTime $published = null);
 
     /**
      * Get published state.

--- a/Document/LocalizationStateViewObject.php
+++ b/Document/LocalizationStateViewObject.php
@@ -35,7 +35,7 @@ class LocalizationStateViewObject
      */
     public $locale;
 
-    public function __construct(string $state = null, string $locale = null)
+    public function __construct(?string $state = null, ?string $locale = null)
     {
         $this->state = $state;
         $this->locale = $locale;

--- a/Document/Repository/ArticleViewDocumentRepository.php
+++ b/Document/Repository/ArticleViewDocumentRepository.php
@@ -76,7 +76,7 @@ class ArticleViewDocumentRepository
     public function findRecent(
         ?string $excludeUuid = null,
         int $limit = self::DEFAULT_LIMIT,
-        array $types = null,
+        ?array $types = null,
         ?string $locale = null,
         ?string $webspaceKey = null
     ): DocumentIterator {
@@ -97,7 +97,7 @@ class ArticleViewDocumentRepository
     public function findSimilar(
         string $uuid,
         int $limit = self::DEFAULT_LIMIT,
-        array $types = null,
+        ?array $types = null,
         ?string $locale = null,
         ?string $webspaceKey = null
     ): DocumentIterator {

--- a/Document/Serializer/WebsiteArticleUrlsSubscriber.php
+++ b/Document/Serializer/WebsiteArticleUrlsSubscriber.php
@@ -67,9 +67,9 @@ class WebsiteArticleUrlsSubscriber implements EventSubscriberInterface
         RequestStack $requestStack,
         RouteRepositoryInterface $routeRepository,
         WebspaceManagerInterface $webspaceManager,
-        DocumentInspector $documentInspector = null,
-        DocumentRegistry $documentRegistry = null,
-        NodeManager $nodeManager = null
+        ?DocumentInspector $documentInspector = null,
+        ?DocumentRegistry $documentRegistry = null,
+        ?NodeManager $nodeManager = null
     ) {
         $this->requestStack = $requestStack;
         $this->routeRepository = $routeRepository;

--- a/Document/Structure/ArticleBridge.php
+++ b/Document/Structure/ArticleBridge.php
@@ -21,7 +21,7 @@ class ArticleBridge extends StructureBridge implements RoutableStructureInterfac
     /**
      * @var string
      */
-    private $webspaceKey = null;
+    private $webspaceKey;
 
     /**
      * @var string

--- a/Document/Subscriber/ArticleSubscriber.php
+++ b/Document/Subscriber/ArticleSubscriber.php
@@ -127,7 +127,7 @@ class ArticleSubscriber implements EventSubscriberInterface
             Events::FLUSH => [['handleFlush', -2048], ['handleFlushLive', -2048]],
             Events::COPY => ['handleCopy'],
             Events::METADATA_LOAD => ['handleMetadataLoad'],
-            EVENTS::REMOVE_LOCALE => [['handleRemoveLocale', -500], ['handleRemoveLocaleLive', -500]],
+            Events::REMOVE_LOCALE => [['handleRemoveLocale', -500], ['handleRemoveLocaleLive', -500]],
         ];
     }
 

--- a/Export/ExportFormatNotFoundException.php
+++ b/Export/ExportFormatNotFoundException.php
@@ -18,7 +18,7 @@ class ExportFormatNotFoundException extends \Exception
      */
     private $format;
 
-    public function __construct(string $format, int $code = 0, \Throwable $previous = null)
+    public function __construct(string $format, int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct(\sprintf('No format "%s" configured for Snippet export', $format), $code, $previous);
 

--- a/Import/ArticleImport.php
+++ b/Import/ArticleImport.php
@@ -93,7 +93,7 @@ class ArticleImport extends Import implements ArticleImportInterface
         ExtensionManagerInterface $extensionManager,
         ImportManagerInterface $importManager,
         FormatImportInterface $xliff12,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         parent::__construct($importManager, $legacyPropertyFactory, ['1.2.xliff' => $xliff12]);
 
@@ -108,7 +108,7 @@ class ArticleImport extends Import implements ArticleImportInterface
     public function import(
         string $locale,
         string $filePath,
-        OutputInterface $output = null,
+        ?OutputInterface $output = null,
         string $format = '1.2.xliff',
         bool $overrideSettings = false
     ): ImportResult {

--- a/Import/ArticleImportInterface.php
+++ b/Import/ArticleImportInterface.php
@@ -18,7 +18,7 @@ interface ArticleImportInterface
     public function import(
         string $locale,
         string $filePath,
-        OutputInterface $output = null,
+        ?OutputInterface $output = null,
         string $format = '1.2.xliff',
         bool $overrideSettings = false
     ): ImportResult;

--- a/ListBuilder/ElasticSearchFieldDescriptor.php
+++ b/ListBuilder/ElasticSearchFieldDescriptor.php
@@ -20,7 +20,7 @@ use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
  */
 class ElasticSearchFieldDescriptor extends FieldDescriptor
 {
-    public static function create(string $name, string $translation = null): ElasticSearchFieldDescriptorBuilder
+    public static function create(string $name, ?string $translation = null): ElasticSearchFieldDescriptorBuilder
     {
         return new ElasticSearchFieldDescriptorBuilder($name, $translation);
     }
@@ -37,8 +37,8 @@ class ElasticSearchFieldDescriptor extends FieldDescriptor
 
     public function __construct(
         string $name,
-        string $sortField = null,
-        string $translation = null,
+        ?string $sortField = null,
+        ?string $translation = null,
         string $visibility = FieldDescriptorInterface::VISIBILITY_YES,
         string $searchability = FieldDescriptorInterface::SEARCHABILITY_NEVER,
         string $type = '',

--- a/ListBuilder/ElasticSearchFieldDescriptorBuilder.php
+++ b/ListBuilder/ElasticSearchFieldDescriptorBuilder.php
@@ -28,7 +28,7 @@ final class ElasticSearchFieldDescriptorBuilder
     /**
      * @var string
      */
-    private $sortField = null;
+    private $sortField;
 
     /**
      * @var string
@@ -55,7 +55,7 @@ final class ElasticSearchFieldDescriptorBuilder
      */
     private $searchField = '';
 
-    public function __construct(string $name, string $translation = null)
+    public function __construct(string $name, ?string $translation = null)
     {
         $this->name = $name;
         $this->translation = $translation;

--- a/Routing/ArticleRouteDefaultProvider.php
+++ b/Routing/ArticleRouteDefaultProvider.php
@@ -151,8 +151,8 @@ class ArticleRouteDefaultProvider implements RouteDefaultsProviderInterface
         }
 
         $webspace = $this->requestAnalyzer->getWebspace();
-        if (!$webspace ||
-            (
+        if (!$webspace
+            || (
                 $this->webspaceResolver->resolveMainWebspace($object) !== $webspace->getKey()
                 && !\in_array($webspace->getKey(), $this->webspaceResolver->resolveAdditionalWebspaces($object))
             )

--- a/Tests/Application/bin/console.php
+++ b/Tests/Application/bin/console.php
@@ -33,7 +33,7 @@ if ($debug) {
     if (\class_exists(Debug::class)) {
         Debug::enable();
     } else {
-        \Symfony\Component\Debug\Debug::enable();
+        Symfony\Component\Debug\Debug::enable();
     }
 }
 

--- a/Tests/Functional/Controller/ArticlePageControllerTest.php
+++ b/Tests/Functional/Controller/ArticlePageControllerTest.php
@@ -370,9 +370,6 @@ class ArticlePageControllerTest extends SuluTestCase
     }
 
     /**
-     * @param $uuid
-     * @param $locale
-     *
      * @return ArticleViewDocumentInterface
      */
     private function findViewDocument($uuid, $locale)

--- a/Tests/Unit/Content/ArticleSelectionContentTypeTest.php
+++ b/Tests/Unit/Content/ArticleSelectionContentTypeTest.php
@@ -55,15 +55,15 @@ class ArticleSelectionContentTypeTest extends TestCase
             Argument::that(
                 function(IdsQuery $query) use ($ids) {
                     return $query->toArray() === [
-                            'ids' => [
-                                'values' => \array_map(
-                                    function($id) {
-                                        return $id . '-de';
-                                    },
-                                    $ids
-                                ),
-                            ],
-                        ];
+                        'ids' => [
+                            'values' => \array_map(
+                                function($id) {
+                                    return $id . '-de';
+                                },
+                                $ids
+                            ),
+                        ],
+                    ];
                 }
             )
         )->shouldBeCalled();

--- a/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
+++ b/Tests/Unit/Document/Subscriber/ArticleSubscriberTest.php
@@ -508,7 +508,7 @@ class ArticleSubscriberTest extends TestCase
             $this->document->reveal()
         )->willReturn(LocalizationState::SHADOW);
 
-        $propertyNameEN = 'i18n:' . 'en' . '-' . ArticleSubscriber::PAGES_PROPERTY;
+        $propertyNameEN = 'i18n:en-' . ArticleSubscriber::PAGES_PROPERTY;
         $this->propertyEncoder->localizedSystemName(ArticleSubscriber::PAGES_PROPERTY, 'en')
             ->willReturn($propertyNameEN);
 

--- a/Twig/ArticleViewDocumentTwigExtension.php
+++ b/Twig/ArticleViewDocumentTwigExtension.php
@@ -93,7 +93,7 @@ class ArticleViewDocumentTwigExtension extends AbstractExtension
      */
     public function loadRecent(
         int $limit = ArticleViewDocumentRepository::DEFAULT_LIMIT,
-        array $types = null,
+        ?array $types = null,
         ?string $locale = null,
         bool $ignoreWebspaces = false
     ): array {
@@ -131,13 +131,13 @@ class ArticleViewDocumentTwigExtension extends AbstractExtension
     /**
      * Loads similar articles with given parameters.
      *
-     * @throws ArticleInRequestNotFoundException
-     *
      * @return ArticleResourceItem[]
+     *
+     * @throws ArticleInRequestNotFoundException
      */
     public function loadSimilar(
         int $limit = ArticleViewDocumentRepository::DEFAULT_LIMIT,
-        array $types = null,
+        ?array $types = null,
         ?string $locale = null,
         bool $ignoreWebspaces = false
     ): array {

--- a/composer.json
+++ b/composer.json
@@ -35,12 +35,12 @@
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.1",
-        "friendsofphp/php-cs-fixer": "^3.0",
         "handcraftedinthealps/zendsearch": "^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.3.4",
         "jackalope/jackalope-jackrabbit": "^1.3",
         "jangregor/phpstan-prophecy": "^1.0",
         "massive/build-bundle": "^0.3 || ^0.4 || ^0.5",
+        "php-cs-fixer/shim": "^3.0",
         "phpcr/phpcr-shell": "^1.1",
         "phpspec/prophecy": "^1.15",
         "phpstan/phpstan": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -506,11 +506,6 @@ parameters:
 			path: DependencyInjection/StructureValidatorCompilerPass.php
 
 		-
-			message: "#^Call to function array_key_exists\\(\\) with 'SuluAutomationBundle' and array\\{FrameworkBundle\\: string, TwigBundle\\: string, SuluCoreBundle\\: string, DoctrineBundle\\: string, DoctrinePHPCRBundle\\: string, PhpcrMigrationsBundle\\: string, StofDoctrineExtensionsBundle\\: string, JMSSerializerBundle\\: string, \\.\\.\\.\\} will always evaluate to false\\.$#"
-			count: 1
-			path: DependencyInjection/SuluArticleExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\DependencyInjection\\\\SuluArticleExtension\\:\\:appendDefaultAuthor\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: DependencyInjection/SuluArticleExtension.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Run lint task under PHP 8.3.

#### Why?

Sulu 2.6 atelast requires PHP 8.2 so we need atleast use PHP 8.2 or 8.3 to get latest sulu version in our lint task.
