### PR TITLE
Fix incompatibility with the get_image twig function from sulu/web-twig package

### DIFF
--- a/Document/MediaViewObject.php
+++ b/Document/MediaViewObject.php
@@ -55,6 +55,13 @@ class MediaViewObject
      *
      * @Property(type="keyword")
      */
+    public $mimeType;
+
+    /**
+     * @var string
+     *
+     * @Property(type="keyword")
+     */
     public $url;
 
     /**
@@ -67,6 +74,7 @@ class MediaViewObject
         $this->id = $media->getId();
         $this->title = $media->getTitle();
         $this->setFormats($media->getFormats());
+        $this->mimeType = $media->getMimeType();
         $this->url = $media->getUrl();
         $this->copyright = $media->getCopyright();
 

--- a/Document/MediaViewObject.php
+++ b/Document/MediaViewObject.php
@@ -51,7 +51,7 @@ class MediaViewObject
     protected $formats = '{}';
 
     /**
-     * @var string
+     * @var string|null
      *
      * @Property(type="keyword")
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

We've noticed that icons and images from the article excerpt are not compatible with the twig function `get_image` of the [sulu/web-twig](https://github.com/sulu/web-twig) package. This PR fixes that (a re-index is required after applying the patch).

#### Why?

At the moment every image is treated as a jpeg (including SVG) because the mime type is not indexed in ES.

The `ImageExtension` needs to know the MIME type of the image in order to render the appropriate html tag: https://github.com/sulu/web-twig/blob/4ed8fda8b0632082ebb16a70c4e94131a9ec648f/src/ImageExtension.php#L571
