### PR TITLE
Fix indexer replace-ghost-content query

### DIFF
--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -459,6 +459,8 @@ class ArticleIndexer implements IndexerInterface
         $search = $repository->createSearch();
         $search->addQuery(new TermQuery('localization_state.state', 'ghost'), BoolQuery::MUST);
         $search->addQuery(new TermQuery('localization_state.locale', $locale), BoolQuery::MUST);
+        $search->addQuery(new TermQuery('locale', $locale), BoolQuery::MUST_NOT);
+        $search->addQuery(new TermQuery('uuid', $document->getUuid()), BoolQuery::MUST);
 
         /** @var array<array{locale: string}> $searchResult */
         $searchResult = $repository->findArray($search);

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -459,7 +459,7 @@ class ArticleIndexer implements IndexerInterface
         $search = $repository->createSearch();
         $search->addQuery(new TermQuery('localization_state.state', 'ghost'), BoolQuery::MUST);
         $search->addQuery(new TermQuery('localization_state.locale', $locale), BoolQuery::MUST);
-        $search->addQuery(new TermQuery('locale', $locale), BoolQuery::MUST_NOT);
+        // $search->addQuery(new TermQuery('locale', $locale), BoolQuery::MUST_NOT);
         $search->addQuery(new TermQuery('uuid', $document->getUuid()), BoolQuery::MUST);
 
         /** @var array<array{locale: string}> $searchResult */

--- a/Document/Index/ArticleIndexer.php
+++ b/Document/Index/ArticleIndexer.php
@@ -459,7 +459,7 @@ class ArticleIndexer implements IndexerInterface
         $search = $repository->createSearch();
         $search->addQuery(new TermQuery('localization_state.state', 'ghost'), BoolQuery::MUST);
         $search->addQuery(new TermQuery('localization_state.locale', $locale), BoolQuery::MUST);
-        // $search->addQuery(new TermQuery('locale', $locale), BoolQuery::MUST_NOT);
+        $search->addQuery(new TermQuery('locale', $locale), BoolQuery::MUST_NOT);
         $search->addQuery(new TermQuery('uuid', $document->getUuid()), BoolQuery::MUST);
 
         /** @var array<array{locale: string}> $searchResult */

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\ArticleBundle\Document\Index\ArticleIndexer;
 use Sulu\Bundle\MediaBundle\Content\Types\ImageMapContentType;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -26,6 +27,8 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class ArticleIndexerTest extends SuluTestCase
 {
+    use SetGetPrivatePropertyTrait;
+
     /**
      * @var string
      */
@@ -173,27 +176,25 @@ class ArticleIndexerTest extends SuluTestCase
 
         /** @var ArticleDocument $articleDocument */
         $articleDocument = $this->documentManager->find($article['id']);
+        /** @var ArticleDocument $otherDocument */
         $otherDocument = $this->documentManager->find($otherArticle['id']);
+        static::setPrivateProperty($otherDocument, 'originalLocale', 'de'); // to reproduce https://github.com/sulu/SuluArticleBundle/pull/677 correctly
 
-        // instead of calling replaceWithGhostData directly we go through the document manager to reproduce: https://github.com/sulu/SuluArticleBundle/pull/677 correctly
-        $this->documentManager->removeLocale($articleDocument, 'de');
-        $this->documentManager->removeLocale($otherDocument, 'en');
+        $this->indexer->replaceWithGhostData($articleDocument, 'de');
+        $this->indexer->replaceWithGhostData($otherDocument, 'en');
 
-        $this->documentManager->flush();
+        $this->indexer->flush();
 
         $documentEN = $this->findViewDocument($articleDocument->getUuid(), 'en');
         $documentDE = $this->findViewDocument($articleDocument->getUuid(), 'de');
         $documentFR = $this->findViewDocument($articleDocument->getUuid(), 'fr');
 
-        $this->assertSame('Test Article', $documentEN->getTitle());
         $this->assertSame('localized', $documentEN->getLocalizationState()->state);
         $this->assertNull($documentEN->getLocalizationState()->locale);
 
-        $this->assertSame('Test Article', $documentDE->getTitle());
         $this->assertSame('ghost', $documentDE->getLocalizationState()->state);
         $this->assertSame('en', $documentDE->getLocalizationState()->locale);
 
-        $this->assertSame('Test Article', $documentFR->getTitle());
         $this->assertSame('ghost', $documentFR->getLocalizationState()->state);
         $this->assertSame('en', $documentFR->getLocalizationState()->locale);
 
@@ -202,15 +203,12 @@ class ArticleIndexerTest extends SuluTestCase
         $otherDocumentDE = $this->findViewDocument($otherDocument->getUuid(), 'de');
         $otherDocumentFR = $this->findViewDocument($otherDocument->getUuid(), 'fr');
 
-        $this->assertSame('Anderer Artikel Deutsch', $otherDocumentDE->getTitle());
         $this->assertSame('localized', $otherDocumentDE->getLocalizationState()->state);
         $this->assertNull($otherDocumentDE->getLocalizationState()->locale);
 
-        $this->assertSame('Anderer Artikel Deutsch', $otherDocumentEN->getTitle());
         $this->assertSame('ghost', $otherDocumentEN->getLocalizationState()->state);
         $this->assertSame('de', $otherDocumentEN->getLocalizationState()->locale);
 
-        $this->assertSame('Anderer Artikel Deutsch', $otherDocumentFR->getTitle());
         $this->assertSame('ghost', $otherDocumentFR->getLocalizationState()->state);
         $this->assertSame('de', $otherDocumentFR->getLocalizationState()->locale);
     }

--- a/Tests/Functional/Document/Index/ArticleIndexerTest.php
+++ b/Tests/Functional/Document/Index/ArticleIndexerTest.php
@@ -121,6 +121,32 @@ class ArticleIndexerTest extends SuluTestCase
             'default_with_route'
         );
 
+        $otherArticle = $this->createArticle(
+            [
+                'article' => 'Other content',
+            ],
+            'Other Article',
+            'default_with_route'
+        );
+
+        $articleDocumentUuid = $article['id'];
+
+        $documentDE = $this->findViewDocument($articleDocumentUuid, 'de');
+        $documentEN = $this->findViewDocument($articleDocumentUuid, 'en');
+        $documentFR = $this->findViewDocument($articleDocumentUuid, 'fr');
+
+        $this->assertSame('Test Article', $documentEN->getTitle());
+        $this->assertSame('localized', $documentEN->getLocalizationState()->state);
+        $this->assertNull($documentEN->getLocalizationState()->locale);
+
+        $this->assertSame('Test Article', $documentDE->getTitle());
+        $this->assertSame('ghost', $documentDE->getLocalizationState()->state);
+        $this->assertSame('en', $documentDE->getLocalizationState()->locale);
+
+        $this->assertSame('Test Article', $documentFR->getTitle());
+        $this->assertSame('ghost', $documentFR->getLocalizationState()->state);
+        $this->assertSame('en', $documentFR->getLocalizationState()->locale);
+
         $secondLocale = 'de';
 
         // now add second locale
@@ -134,20 +160,59 @@ class ArticleIndexerTest extends SuluTestCase
             'Test Artikel Deutsch',
             'default_with_route'
         );
+        $this->updateArticle(
+            $otherArticle['id'],
+            $secondLocale,
+            [
+                'id' => $otherArticle['id'],
+                'article' => 'Anderer Inhalt',
+            ],
+            'Anderer Artikel Deutsch',
+            'default_with_route'
+        );
 
         /** @var ArticleDocument $articleDocument */
         $articleDocument = $this->documentManager->find($article['id']);
-        $this->indexer->replaceWithGhostData($articleDocument, 'de');
-        $this->indexer->flush();
+        $otherDocument = $this->documentManager->find($otherArticle['id']);
 
-        $documentDE = $this->findViewDocument($articleDocument->getUuid(), 'de');
+        // instead of calling replaceWithGhostData directly we go through the document manager to reproduce: https://github.com/sulu/SuluArticleBundle/pull/677 correctly
+        $this->documentManager->removeLocale($articleDocument, 'de');
+        $this->documentManager->removeLocale($otherDocument, 'en');
+
+        $this->documentManager->flush();
+
         $documentEN = $this->findViewDocument($articleDocument->getUuid(), 'en');
+        $documentDE = $this->findViewDocument($articleDocument->getUuid(), 'de');
+        $documentFR = $this->findViewDocument($articleDocument->getUuid(), 'fr');
+
+        $this->assertSame('Test Article', $documentEN->getTitle());
+        $this->assertSame('localized', $documentEN->getLocalizationState()->state);
+        $this->assertNull($documentEN->getLocalizationState()->locale);
 
         $this->assertSame('Test Article', $documentDE->getTitle());
         $this->assertSame('ghost', $documentDE->getLocalizationState()->state);
         $this->assertSame('en', $documentDE->getLocalizationState()->locale);
 
-        $this->assertSame('Test Article', $documentEN->getTitle());
+        $this->assertSame('Test Article', $documentFR->getTitle());
+        $this->assertSame('ghost', $documentFR->getLocalizationState()->state);
+        $this->assertSame('en', $documentFR->getLocalizationState()->locale);
+
+        /** @var ArticleDocument $otherDocument */
+        $otherDocumentEN = $this->findViewDocument($otherDocument->getUuid(), 'en');
+        $otherDocumentDE = $this->findViewDocument($otherDocument->getUuid(), 'de');
+        $otherDocumentFR = $this->findViewDocument($otherDocument->getUuid(), 'fr');
+
+        $this->assertSame('Anderer Artikel Deutsch', $otherDocumentDE->getTitle());
+        $this->assertSame('localized', $otherDocumentDE->getLocalizationState()->state);
+        $this->assertNull($otherDocumentDE->getLocalizationState()->locale);
+
+        $this->assertSame('Anderer Artikel Deutsch', $otherDocumentEN->getTitle());
+        $this->assertSame('ghost', $otherDocumentEN->getLocalizationState()->state);
+        $this->assertSame('de', $otherDocumentEN->getLocalizationState()->locale);
+
+        $this->assertSame('Anderer Artikel Deutsch', $otherDocumentFR->getTitle());
+        $this->assertSame('ghost', $otherDocumentFR->getLocalizationState()->state);
+        $this->assertSame('de', $otherDocumentFR->getLocalizationState()->locale);
     }
 
     public function testReplaceWithGhostDataUpdateExistingGhosts()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This fixes the query to replace all ghost contents.

#### Why?

Long loop :)

#### To Do

- [x] Tests
