### PR TITLE
Throw `NotAcceptableHttpException` if template request format does not exists

### DIFF
--- a/Controller/WebsiteArticleController.php
+++ b/Controller/WebsiteArticleController.php
@@ -24,6 +24,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 use Twig\Environment;
 
 /**
@@ -61,6 +62,10 @@ class WebsiteArticleController extends AbstractController
 
         $requestFormat = $request->getRequestFormat();
         $viewTemplate = $view . '.' . $requestFormat . '.twig';
+
+        if (!$this->container->get('twig')->getLoader()->exists($viewTemplate)) {
+            throw new NotAcceptableHttpException(\sprintf('Page does not exist in "%s" format.', $requestFormat));
+        }
 
         $content = $this->resolveArticle($object, $pageNumber);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

A request format for which the template is not available throws a Twig\Error\LoaderError. An HttpException would be better.

See also:
- https://github.com/sulu/sulu/blob/2.6.2/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php#L57-L59
- https://sulu.rocks/en/blog/a-great-song-will-win.invalid-request-format