### PR TITLE
Disable loading ghost content in the ArticleReferenceRefresher

### DIFF
--- a/Document/ArticleDocument.php
+++ b/Document/ArticleDocument.php
@@ -119,7 +119,7 @@ class ArticleDocument implements UuidBehavior,
     protected $originalLocale;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $structureType;
 

--- a/Document/ArticlePageDocument.php
+++ b/Document/ArticlePageDocument.php
@@ -76,7 +76,7 @@ class ArticlePageDocument implements UuidBehavior,
     protected $originalLocale;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $structureType;
 

--- a/Document/Subscriber/RoutableSubscriber.php
+++ b/Document/Subscriber/RoutableSubscriber.php
@@ -301,7 +301,7 @@ class RoutableSubscriber implements EventSubscriberInterface
     private function updateRoute(RoutablePageBehavior $document): void
     {
         $locale = $this->documentInspector->getLocale($document);
-        $propertyName = $this->getRoutePathPropertyName($document->getStructureType(), $locale);
+        $propertyName = $this->getRoutePathPropertyName((string) $document->getStructureType(), $locale);
 
         $route = $this->chainRouteGenerator->generate($document);
         $document->setRoutePath($route->getPath());
@@ -340,7 +340,7 @@ class RoutableSubscriber implements EventSubscriberInterface
             $child->setRoutePath($childRoute->getPath());
             $childNode = $this->documentInspector->getNode($child);
 
-            $propertyName = $this->getRoutePathPropertyName($child->getStructureType(), $locale);
+            $propertyName = $this->getRoutePathPropertyName((string) $child->getStructureType(), $locale);
             $childNode->setProperty($propertyName, $childRoute->getPath());
 
             $routes[] = $childRoute->getPath();

--- a/Reference/Refresh/ArticleReferenceRefresher.php
+++ b/Reference/Refresh/ArticleReferenceRefresher.php
@@ -62,7 +62,13 @@ class ArticleReferenceRefresher implements ReferenceRefresherInterface
                 /** @var string $uuid */
                 $uuid = $row->getValue('jcr:uuid');
                 /** @var (UuidBehavior&TitleBehavior&StructureBehavior)|null $document */
-                $document = $this->documentManager->find($uuid, $locale);
+                $document = $this->documentManager->find(
+                    $uuid,
+                    $locale,
+                    [
+                        'load_ghost_content' => false,
+                    ]
+                );
 
                 if (!$document) {
                     continue;

--- a/Tests/Application/.env
+++ b/Tests/Application/.env
@@ -1,5 +1,5 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=5.7
+DATABASE_URL=mysql://root:root@127.0.0.1:3306/sulu_article_test?serverVersion=5.7
 DATABASE_CHARSET=utf8mb4
 DATABASE_COLLATE=utf8mb4_unicode_ci
 ELASTICSEARCH_HOST=127.0.0.1:9200

--- a/Tests/Application/.env
+++ b/Tests/Application/.env
@@ -1,5 +1,5 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:root@127.0.0.1:3306/sulu_article_test?serverVersion=5.7
+DATABASE_URL=mysql://root:@127.0.0.1:3306/sulu_test?serverVersion=5.7
 DATABASE_CHARSET=utf8mb4
 DATABASE_COLLATE=utf8mb4_unicode_ci
 ELASTICSEARCH_HOST=127.0.0.1:9200

--- a/Tests/Functional/Reference/Provider/ArticleReferenceProviderTest.php
+++ b/Tests/Functional/Reference/Provider/ArticleReferenceProviderTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Functional\Reference\Provider;
+
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
+use Sulu\Bundle\ArticleBundle\Reference\Provider\ArticleReferenceProvider;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\CollectionType;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\ReferenceBundle\Application\Refresh\ReferenceRefresherInterface;
+use Sulu\Bundle\ReferenceBundle\Domain\Model\Reference;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\HttpKernel\SuluKernel;
+use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
+use Sulu\Component\PHPCR\SessionManager\SessionManager;
+
+class ArticleReferenceProviderTest extends SuluTestCase
+{
+    private ArticleReferenceProvider $articleReferenceProvider;
+    private DocumentManagerInterface $documentManager;
+    private SessionManager $sessionManager;
+
+    /**
+     * @var EntityRepository<Reference>
+     */
+    private EntityRepository $referenceRepository;
+
+    public function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->initPhpcr();
+
+        $this->articleReferenceProvider = $this->getContainer()->get('sulu_article.reference_provider');
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
+        $this->referenceRepository = $this->getContainer()->get('sulu.repository.reference');
+    }
+
+    public function testUpdateReferences(): void
+    {
+        if (!\interface_exists(ReferenceRefresherInterface::class)) {
+            $this->markTestSkipped('References did not exist in Sulu <2.6.');
+        }
+
+        $media = $this->createMedia();
+        /** @var \Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument $article */
+        $article = $this->documentManager->create('article');
+        $article->setTitle('Example article');
+        $article->setStructureType('default_image');
+        $article->getStructure()->bind(['image' => ['id' => $media->getId()]]);
+        $this->documentManager->persist($article, 'en');
+        $this->documentManager->publish($article, 'en');
+        $this->documentManager->flush();
+
+        $this->articleReferenceProvider->updateReferences($article, 'en', 'test');
+        $this->getEntityManager()->flush();
+
+        /** @var Reference[] $references */
+        $references = $this->referenceRepository->findBy(['referenceContext' => 'test']);
+        $this->assertCount(1, $references);
+        self::assertSame((string) $media->getId(), $references[0]->getResourceId());
+    }
+
+    public function testUpdateUnpublishedReferences(): void
+    {
+        if (!\interface_exists(ReferenceRefresherInterface::class)) {
+            $this->markTestSkipped('References did not exist in Sulu <2.6.');
+        }
+
+        $media = $this->createMedia();
+        /** @var \Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument $article */
+        $article = $this->documentManager->create('article');
+        $article->setTitle('Example article');
+        $article->setStructureType('default_image');
+        $article->getStructure()->bind(['image' => ['id' => $media->getId()]]);
+        $this->documentManager->persist($article, 'en');
+        $this->documentManager->publish($article, 'en');
+        $this->documentManager->flush();
+
+        $this->documentManager->unpublish($article, 'en');
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+
+        static::ensureKernelShutdown();
+        static::bootKernel(['sulu.context' => SuluKernel::CONTEXT_WEBSITE]);
+        // refresh services from new kernel
+        $this->articleReferenceProvider = $this->getContainer()->get('sulu_article.reference_provider');
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
+        $this->referenceRepository = $this->getContainer()->get('sulu.repository.reference');
+
+        /** @var ArticleDocument $article */
+        $article = $this->documentManager->find($article->getUuid(), 'en', [
+            'load_ghost_content' => false,
+        ]);
+
+        $this->articleReferenceProvider->updateReferences($article, 'en', 'test');
+        $this->getEntityManager()->flush();
+
+        $references = $this->referenceRepository->findBy(['referenceContext' => 'test']);
+        $this->assertCount(0, $references);
+    }
+
+    private function createMedia(): Media
+    {
+        $collectionType = new CollectionType();
+        $collectionType->setName('Default Collection Type');
+        $collectionType->setDescription('Default Collection Type');
+
+        $mediaType = new MediaType();
+        $mediaType->setName('Default Media Type');
+
+        $collection = new Collection();
+        $collection->setType($collectionType);
+
+        $media = new Media();
+        $media->setType($mediaType);
+        $media->setCollection($collection);
+
+        $this->getEntityManager()->persist($collection);
+        $this->getEntityManager()->persist($collectionType);
+        $this->getEntityManager()->persist($mediaType);
+        $this->getEntityManager()->persist($media);
+        $this->getEntityManager()->flush();
+
+        return $media;
+    }
+}

--- a/Tests/Functional/Reference/Provider/ArticleReferenceProviderTest.php
+++ b/Tests/Functional/Reference/Provider/ArticleReferenceProviderTest.php
@@ -23,27 +23,35 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
-use Sulu\Component\PHPCR\SessionManager\SessionManager;
 
 class ArticleReferenceProviderTest extends SuluTestCase
 {
-    private ArticleReferenceProvider $articleReferenceProvider;
-    private DocumentManagerInterface $documentManager;
-    private SessionManager $sessionManager;
+    /**
+     * @var ArticleReferenceProvider
+     */
+    private $articleReferenceProvider;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
 
     /**
      * @var EntityRepository<Reference>
      */
-    private EntityRepository $referenceRepository;
+    private $referenceRepository;
 
     public function setUp(): void
     {
         $this->purgeDatabase();
         $this->initPhpcr();
 
+        if (!\interface_exists(ReferenceRefresherInterface::class)) {
+            return;
+        }
+
         $this->articleReferenceProvider = $this->getContainer()->get('sulu_article.reference_provider');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->referenceRepository = $this->getContainer()->get('sulu.repository.reference');
     }
 
@@ -97,7 +105,6 @@ class ArticleReferenceProviderTest extends SuluTestCase
         // refresh services from new kernel
         $this->articleReferenceProvider = $this->getContainer()->get('sulu_article.reference_provider');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->referenceRepository = $this->getContainer()->get('sulu.repository.reference');
 
         /** @var ArticleDocument $article */

--- a/Tests/Functional/Reference/Refresh/ArticleReferenceRefresherTest.php
+++ b/Tests/Functional/Reference/Refresh/ArticleReferenceRefresherTest.php
@@ -48,6 +48,7 @@ class ArticleReferenceRefresherTest extends SuluTestCase
         if (!\interface_exists(ReferenceRefresherInterface::class)) {
             return;
         }
+
         $this->articleReferenceRefresher = $this->getContainer()->get('sulu_article.article_reference_refresher');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->referenceRepository = $this->getContainer()->get('sulu.repository.reference');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1661,11 +1661,6 @@ parameters:
 			path: Document/Subscriber/ArticleSubscriber.php
 
 		-
-			message: "#^Parameter \\#1 \\$structureType of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setStructureType\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: Document/Subscriber/ArticleSubscriber.php
-
-		-
 			message: "#^Parameter \\#3 \\$originalPages of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Subscriber\\\\ArticleSubscriber\\:\\:loadPageDataForShadow\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: Document/Subscriber/ArticleSubscriber.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Prevents loading ghost content in the `ArticleReferenceRefresher`.

#### Why?

References should not be created for ghost content.
