### PR TITLE
Test CI against Elasticsearch 8 server

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -96,7 +96,7 @@ jobs:
 
                     - php-version: '8.4'
                       composer-options: '--ignore-platform-reqs'
-                      elasticsearch-version: '7.17.2'
+                      elasticsearch-version: '8.14.3'
                       elasticsearch-package-constraint: '~7.17.0'
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Test against Elasticsearch 8 server.

#### Why?

Upgrade to the ES8 client would require some more work. But Elasticsearch 8 server supports client requests from ES7 client via: https://github.com/handcraftedinthealps/ElasticsearchBundle/blob/ab0f1adf3a627faa6b69175445e1e636ccdbbd29/Service/ManagerFactory.php#L141-L148 and so ES8 server can be used.

### Attention ⚠️ 

Keep in mind for Full ES8 usage https://github.com/massiveart/MassiveSearchBundle/pull/170 need also be tackled.