### PR TITLE
Fix for the link provider

### DIFF
--- a/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
+++ b/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
@@ -47,4 +47,9 @@ class ArticleLinkProvider extends ContentLinkProvider
             ->setIcon('su-document')
             ->getLinkConfiguration();
     }
+
+    protected function getEntityIdField(): string
+    {
+        return 'uuid';
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Returns the correct entity id field name for the article entity.

#### Why?

Because the default value is `id` and the article does only have an `uuid`.
