### PR TITLE
Fix PhpCR migration exception for unpublished languages

### DIFF
--- a/Resources/phpcr-migrations/Version202407111600.php
+++ b/Resources/phpcr-migrations/Version202407111600.php
@@ -89,6 +89,9 @@ class Version202407111600 implements VersionInterface, ContainerAwareInterface
             /** @var Row<mixed> $row */
             foreach ($rows as $row) {
                 $node = $row->getNode();
+                if (!$node->hasProperty($templateKey)) {
+                    continue;
+                }
                 $structureType = $node->getPropertyValue($templateKey);
                 $routePathPropertyName = $this->getRoutePathPropertyName($structureType, $locale);
 
@@ -114,6 +117,9 @@ class Version202407111600 implements VersionInterface, ContainerAwareInterface
             foreach ($rows as $row) {
                 $node = $row->getNode();
                 $propertyName = $this->propertyEncoder->localizedContentName(RoutableSubscriber::ROUTE_FIELD_NAME, $locale);
+                if (!$node->hasProperty($propertyName)) {
+                    continue;
+                }
                 $node->setProperty($propertyName, null);
             }
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR checks if the nodes have properties during the migration

#### Why?

Without this, articles which haven't been published cause migrations to fail. 