### PR TITLE
Fix phpcr migrations for Symfony 7 without ContainerAwareInterface

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 $header = <<<EOF
 This file is part of Sulu.
 
@@ -10,8 +19,10 @@ with this source code in the file LICENSE.
 EOF;
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude(['Tests/Application/var/cache'])
-    ->in(__DIR__);
+    ->in(__DIR__)
+    ->ignoreDotFiles(false)
+    ->exclude(['tests/Application/var'])
+;
 
 $config = new PhpCsFixer\Config();
 $config->setRiskyAllowed(true)

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -21,7 +21,7 @@ EOF;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->ignoreDotFiles(false)
-    ->exclude(['tests/Application/var'])
+    ->exclude(['Tests/Application/var'])
 ;
 
 $config = new PhpCsFixer\Config();

--- a/Content/ArticleDataItem.php
+++ b/Content/ArticleDataItem.php
@@ -66,6 +66,6 @@ class ArticleDataItem implements ItemInterface
 
     public function getImage()
     {
-        return;
+        return null;
     }
 }

--- a/Content/ArticleDataProvider.php
+++ b/Content/ArticleDataProvider.php
@@ -225,7 +225,7 @@ class ArticleDataProvider implements DataProviderInterface, DataProviderAliasInt
 
     public function resolveDatasource($datasource, array $propertyParameter, array $options)
     {
-        return;
+        return null;
     }
 
     private function getWebspaceKey(array $propertyParameter, array $options): ?string

--- a/Resources/phpcr-migrations/ContainerAwareInterface.php
+++ b/Resources/phpcr-migrations/ContainerAwareInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sulu\Bundle\ArticleBundle;
+
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface as PhpcrContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface as SymfonyContainerAwareInterface;
+
+if (\interface_exists(PhpcrContainerAwareInterface::class)) {
+    /**
+     * @internal
+     */
+    interface ContainerAwareInterface extends PhpcrContainerAwareInterface
+    {
+    }
+} elseif (\interface_exists(SymfonyContainerAwareInterface::class)) {
+    /**
+     * @internal
+     */
+    interface ContainerAwareInterface extends SymfonyContainerAwareInterface
+    {
+    }
+} else {
+    /**
+     * @internal
+     */
+    interface ContainerAwareInterface
+    {
+    }
+}

--- a/Resources/phpcr-migrations/ContainerAwareInterface.php
+++ b/Resources/phpcr-migrations/ContainerAwareInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface as PhpcrContainerAwareInterface;

--- a/Resources/phpcr-migrations/Version201702211450.php
+++ b/Resources/phpcr-migrations/Version201702211450.php
@@ -14,17 +14,29 @@ namespace Sulu\Bundle\ArticleBundle;
 use Jackalope\Node;
 use Jackalope\Query\Row;
 use PHPCR\Migrations\VersionInterface;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Removes the property `i18n:<locale>-authors` and adds `i18n:<locale>-author`.
  */
 class Version201702211450 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version201702211450.php
+++ b/Resources/phpcr-migrations/Version201702211450.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\ArticleBundle;
 use Jackalope\Node;
 use Jackalope\Query\Row;
 use PHPCR\Migrations\VersionInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/Resources/phpcr-migrations/Version201712041018.php
+++ b/Resources/phpcr-migrations/Version201712041018.php
@@ -17,15 +17,27 @@ use PHPCR\Migrations\VersionInterface;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Removes the property `sulu:author(ed)` and adds `i18n:<locale>-author(ed)`.
  */
 class Version201712041018 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
 
     public const AUTHOR_PROPERTY_NAME = 'sulu:author';
 

--- a/Resources/phpcr-migrations/Version201712041018.php
+++ b/Resources/phpcr-migrations/Version201712041018.php
@@ -17,7 +17,6 @@ use PHPCR\Migrations\VersionInterface;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/Resources/phpcr-migrations/Version201811091000.php
+++ b/Resources/phpcr-migrations/Version201811091000.php
@@ -15,6 +15,7 @@ use Jackalope\Node;
 use Jackalope\Query\Row;
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\NodeInterface;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
 

--- a/Resources/phpcr-migrations/Version201811091000.php
+++ b/Resources/phpcr-migrations/Version201811091000.php
@@ -17,8 +17,8 @@ use PHPCR\Migrations\VersionInterface;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Removes the property `mainWebspace` and adds `i18n:<locale>-mainWebspace`.
@@ -26,7 +26,19 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  */
 class Version201811091000 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
 
     public const MAIN_WEBSPACE_PROPERTY_NAME = 'mainWebspace';
 

--- a/Resources/phpcr-migrations/Version201811091000.php
+++ b/Resources/phpcr-migrations/Version201811091000.php
@@ -15,7 +15,6 @@ use Jackalope\Node;
 use Jackalope\Query\Row;
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\NodeInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
 

--- a/Resources/phpcr-migrations/Version201811091000.php
+++ b/Resources/phpcr-migrations/Version201811091000.php
@@ -17,7 +17,6 @@ use PHPCR\Migrations\VersionInterface;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
-
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/Resources/phpcr-migrations/Version201905071542.php
+++ b/Resources/phpcr-migrations/Version201905071542.php
@@ -13,12 +13,24 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version201905071542 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version201905071542.php
+++ b/Resources/phpcr-migrations/Version201905071542.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version201905071542 implements VersionInterface, ContainerAwareInterface

--- a/Resources/phpcr-migrations/Version202005151141.php
+++ b/Resources/phpcr-migrations/Version202005151141.php
@@ -13,12 +13,25 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202005151141 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
+
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version202005151141.php
+++ b/Resources/phpcr-migrations/Version202005151141.php
@@ -31,7 +31,6 @@ class Version202005151141 implements VersionInterface, ContainerAwareInterface
         $this->container = $container;
     }
 
-
     public function up(SessionInterface $session)
     {
         $liveSession = $this->container->get('sulu_document_manager.live_session');

--- a/Resources/phpcr-migrations/Version202005151141.php
+++ b/Resources/phpcr-migrations/Version202005151141.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202005151141 implements VersionInterface, ContainerAwareInterface

--- a/Resources/phpcr-migrations/Version202005191117.php
+++ b/Resources/phpcr-migrations/Version202005191117.php
@@ -13,12 +13,25 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202005191117 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
+
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version202005191117.php
+++ b/Resources/phpcr-migrations/Version202005191117.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202005191117 implements VersionInterface, ContainerAwareInterface

--- a/Resources/phpcr-migrations/Version202005191117.php
+++ b/Resources/phpcr-migrations/Version202005191117.php
@@ -31,7 +31,6 @@ class Version202005191117 implements VersionInterface, ContainerAwareInterface
         $this->container = $container;
     }
 
-
     public function up(SessionInterface $session)
     {
         $liveSession = $this->container->get('sulu_document_manager.live_session');

--- a/Resources/phpcr-migrations/Version202005250920.php
+++ b/Resources/phpcr-migrations/Version202005250920.php
@@ -13,12 +13,25 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202005250920 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
+
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version202005250920.php
+++ b/Resources/phpcr-migrations/Version202005250920.php
@@ -31,7 +31,6 @@ class Version202005250920 implements VersionInterface, ContainerAwareInterface
         $this->container = $container;
     }
 
-
     public function up(SessionInterface $session)
     {
         $liveSession = $this->container->get('sulu_document_manager.live_session');

--- a/Resources/phpcr-migrations/Version202005250920.php
+++ b/Resources/phpcr-migrations/Version202005250920.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202005250920 implements VersionInterface, ContainerAwareInterface

--- a/Resources/phpcr-migrations/Version202210140922.php
+++ b/Resources/phpcr-migrations/Version202210140922.php
@@ -13,15 +13,28 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
 final class Version202210140922 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
+
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version202210140922.php
+++ b/Resources/phpcr-migrations/Version202210140922.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/Resources/phpcr-migrations/Version202210140922.php
+++ b/Resources/phpcr-migrations/Version202210140922.php
@@ -15,7 +15,6 @@ use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
@@ -34,7 +33,6 @@ final class Version202210140922 implements VersionInterface, ContainerAwareInter
 
         $this->container = $container;
     }
-
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version202210140922.php
+++ b/Resources/phpcr-migrations/Version202210140922.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\ArticleBundle;
 
 use PHPCR\Migrations\VersionInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/Resources/phpcr-migrations/Version202210241106.php
+++ b/Resources/phpcr-migrations/Version202210241106.php
@@ -15,12 +15,25 @@ use Jackalope\Query\Row;
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202210241106 implements VersionInterface, ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
+
 
     public function up(SessionInterface $session)
     {

--- a/Resources/phpcr-migrations/Version202210241106.php
+++ b/Resources/phpcr-migrations/Version202210241106.php
@@ -33,7 +33,6 @@ class Version202210241106 implements VersionInterface, ContainerAwareInterface
         $this->container = $container;
     }
 
-
     public function up(SessionInterface $session)
     {
         $liveSession = $this->container->get('sulu_document_manager.live_session');

--- a/Resources/phpcr-migrations/Version202210241106.php
+++ b/Resources/phpcr-migrations/Version202210241106.php
@@ -15,7 +15,6 @@ use Jackalope\Query\Row;
 use PHPCR\Migrations\VersionInterface;
 use PHPCR\SessionInterface;
 use Sulu\Component\Localization\Localization;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version202210241106 implements VersionInterface, ContainerAwareInterface

--- a/Resources/phpcr-migrations/Version202407111600.php
+++ b/Resources/phpcr-migrations/Version202407111600.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\ArticleBundle;
 
 use Jackalope\Query\Row;
 use PHPCR\Migrations\VersionInterface;
-use PHPCR\PhpcrMigrationsBundle\ContainerAwareInterface;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,11 +81,6 @@ parameters:
 			path: Command/ReindexCommand.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\ArticleDataItem\\:\\:getImage\\(\\) should return string but empty return statement found\\.$#"
-			count: 1
-			path: Content/ArticleDataItem.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\ArticleDataItem\\:\\:getResource\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: Content/ArticleDataItem.php
@@ -171,11 +166,6 @@ parameters:
 			path: Content/ArticleDataProvider.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\ArticleDataProvider\\:\\:resolveDatasource\\(\\) should return Sulu\\\\Component\\\\SmartContent\\\\DatasourceItemInterface but empty return statement found\\.$#"
-			count: 1
-			path: Content/ArticleDataProvider.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: Content/ArticleDataProvider.php
@@ -253,11 +243,6 @@ parameters:
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\PageTreeArticleDataProvider\\:\\:createSearch\\(\\) has parameter \\$filters with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: Content/PageTreeArticleDataProvider.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\PageTreeArticleDataProvider\\:\\:resolveDatasource\\(\\) should return Sulu\\\\Component\\\\SmartContent\\\\DatasourceItemInterface but returns null\\.$#"
-			count: 2
 			path: Content/PageTreeArticleDataProvider.php
 
 		-
@@ -1906,11 +1891,6 @@ parameters:
 			path: Export/ArticleExport.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Export\\\\ArticleExport\\:\\:__construct\\(\\) has parameter \\$formatFilePaths with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Export/ArticleExport.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Export\\\\ArticleExport\\:\\:getDocuments\\(\\) should return Sulu\\\\Component\\\\DocumentManager\\\\Collection\\\\QueryResultCollection but returns mixed\\.$#"
 			count: 1
 			path: Export/ArticleExport.php
@@ -2036,9 +2016,19 @@ parameters:
 			path: Import/ImportResult.php
 
 		-
+			message: "#^Parameter \\#1 \\$articleIds of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Infrastructure\\\\Sulu\\\\Headless\\\\DataProviderResolver\\\\AbstractArticleDataProviderResolver\\:\\:loadArticleStructures\\(\\) expects array\\<string\\>, array\\<int\\<0, max\\>, int\\|string\\> given\\.$#"
+			count: 1
+			path: Infrastructure/Sulu/Headless/DataProviderResolver/AbstractArticleDataProviderResolver.php
+
+		-
 			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Component\\\\SmartContent\\\\DataProviderInterface\\:\\:resolveResourceItems\\(\\) expects array\\{dataSource\\?\\: int\\|string\\|null, sortMethod\\?\\: 'asc'\\|'desc', sortBy\\?\\: string, tags\\?\\: array\\<string\\>, tagOperator\\?\\: 'and'\\|'or', types\\?\\: array\\<string\\>, categories\\?\\: array\\<int\\>, categoryOperator\\?\\: 'and'\\|'or', \\.\\.\\.\\}, array given\\.$#"
 			count: 1
 			path: Infrastructure/Sulu/Headless/DataProviderResolver/AbstractArticleDataProviderResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$articleIds of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Infrastructure\\\\SuluHeadlessBundle\\\\DataProviderResolver\\\\AbstractArticleDataProviderResolver\\:\\:loadArticleStructures\\(\\) expects array\\<string\\>, array\\<int\\<0, max\\>, int\\|string\\> given\\.$#"
+			count: 1
+			path: Infrastructure/SuluHeadlessBundle/DataProviderResolver/AbstractArticleDataProviderResolver.php
 
 		-
 			message: "#^Parameter \\#1 \\$filters of method Sulu\\\\Component\\\\SmartContent\\\\DataProviderInterface\\:\\:resolveResourceItems\\(\\) expects array\\{dataSource\\?\\: int\\|string\\|null, sortMethod\\?\\: 'asc'\\|'desc', sortBy\\?\\: string, tags\\?\\: array\\<string\\>, tagOperator\\?\\: 'and'\\|'or', types\\?\\: array\\<string\\>, categories\\?\\: array\\<int\\>, categoryOperator\\?\\: 'and'\\|'or', \\.\\.\\.\\}, array given\\.$#"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | replaces #697
| License | MIT

#### What's in this PR?

Fix phpcr migrations on Symfony 7 branch.

#### Why?

See 697
