### PR TITLE
Replace ContentBundleLinkProvider with own ArticleLinkProvider

### DIFF
--- a/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
+++ b/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
@@ -157,8 +157,10 @@ class ArticleRepository implements ArticleRepositoryInterface
         $queryBuilder->select('DISTINCT article.uuid');
 
         // we need to select the fields which are used in the order by clause
-        /** @var OrderBy $orderBy */
-        foreach ($queryBuilder->getDQLPart('orderBy') as $orderBy) {
+
+        /** @var OrderBy[] $orderBys */
+        $orderBys = $queryBuilder->getDQLPart('orderBy');
+        foreach ($orderBys as $orderBy) {
             $queryBuilder->addSelect(\explode(' ', $orderBy->getParts()[0])[0]);
         }
 
@@ -198,6 +200,7 @@ class ArticleRepository implements ArticleRepositoryInterface
      * @param array{
      *     uuid?: 'asc'|'desc',
      *     title?: 'asc'|'desc',
+     *     created?: 'asc'|'desc',
      * } $sortBy
      * @param array{
      *     article_admin?: bool,

--- a/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
+++ b/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Content;
 
-use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentManager\ContentManagerInterface;
 use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Link\ContentLinkProvider;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
@@ -26,9 +24,6 @@ use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @extends ContentLinkProvider<ArticleDimensionContentInterface, ArticleInterface>
- */
 class ArticleLinkProvider implements LinkProviderInterface
 {
     public function __construct(
@@ -69,8 +64,9 @@ class ArticleLinkProvider implements LinkProviderInterface
             $dimensionContent = $this->contentManager->resolve($article, $dimensionAttributes);
             $this->articleReferenceStore->add($article->getId());
 
+            /** @var string|null $url */
             $url = $dimensionContent->getTemplateData()['url'] ?? null;
-            if (!$url) {
+            if (null === $url) {
                 // TODO what to do when there is no url?
                 continue;
             }
@@ -78,7 +74,7 @@ class ArticleLinkProvider implements LinkProviderInterface
             $result[] = new LinkItem(
                 $article->getUuid(),
                 (string) $dimensionContent->getTitle(),
-                (string) $dimensionContent->getTemplateData()['url'],
+                $url,
                 $published
             );
         }

--- a/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
+++ b/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
@@ -13,43 +13,76 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Content;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentManager\ContentManagerInterface;
+use Sulu\Bundle\ContentBundle\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Link\ContentLinkProvider;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
-use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @extends ContentLinkProvider<ArticleDimensionContentInterface, ArticleInterface>
  */
-class ArticleLinkProvider extends ContentLinkProvider
+class ArticleLinkProvider implements LinkProviderInterface
 {
     public function __construct(
-        ContentManagerInterface $contentManager,
-        StructureMetadataFactoryInterface $structureMetadataFactory,
-        EntityManagerInterface $entityManager,
+        private readonly ContentManagerInterface $contentManager,
+        private readonly ArticleRepositoryInterface $articleRepository,
+        private readonly ReferenceStoreInterface $articleReferenceStore,
+        private readonly TranslatorInterface $translator,
     ) {
-        parent::__construct($contentManager, $structureMetadataFactory, $entityManager, ArticleInterface::class);
     }
 
     public function getConfiguration(): LinkConfiguration
     {
         return LinkConfigurationBuilder::create()
-            ->setTitle('Example')
+            ->setTitle($this->translator->trans('sulu_article.articles', [], 'admin'))
             ->setResourceKey(ArticleInterface::RESOURCE_KEY)
             ->setListAdapter('table')
             ->setDisplayProperties(['id'])
-            ->setOverlayTitle('Select Example')
-            ->setEmptyText('No example selected')
+            ->setOverlayTitle($this->translator->trans('sulu_article.selection_overlay_title', [], 'admin'))
+            ->setEmptyText($this->translator->trans('sulu_article.no_article_selected', [], 'admin'))
             ->setIcon('su-document')
             ->getLinkConfiguration();
     }
 
-    protected function getEntityIdField(): string
+    public function preload(array $hrefs, $locale, $published = true)
     {
-        return 'uuid';
+        $dimensionAttributes = [
+            'locale' => $locale,
+            'stage' => $published ? DimensionContentInterface::STAGE_LIVE : DimensionContentInterface::STAGE_DRAFT,
+        ];
+
+        $articles = $this->articleRepository->findBy(
+            filters: [...$dimensionAttributes, 'uuids' => $hrefs],
+            selects: [ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_WEBSITE => true]
+        );
+
+        $result = [];
+        foreach ($articles as $article) {
+            $dimensionContent = $this->contentManager->resolve($article, $dimensionAttributes);
+            $this->articleReferenceStore->add($article->getId());
+
+            $url = $dimensionContent->getTemplateData()['url'] ?? null;
+            if (!$url) {
+                // TODO what to do when there is no url?
+                continue;
+            }
+
+            $result[] = new LinkItem(
+                $article->getUuid(),
+                (string) $dimensionContent->getTitle(),
+                (string) $dimensionContent->getTemplateData()['url'],
+                $published
+            );
+        }
+
+        return $result;
     }
 }

--- a/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -227,9 +227,10 @@ final class SuluArticleBundle extends AbstractBundle
         $services->set('sulu_article.article_link_provider')
             ->class(ArticleLinkProvider::class)
             ->args([
-                new Reference('sulu_content.content_manager'), // TODO link provider should not build on manager
-                new Reference('sulu_page.structure.factory'),
-                new Reference('doctrine.orm.entity_manager'),
+                new Reference('sulu_content.content_manager'),
+                new Reference('sulu_article.article_repository'),
+                new Reference('sulu_article.article_reference_store'),
+                new Reference('translator'),
             ])
             ->tag('sulu.link.provider', ['alias' => 'article']);
 

--- a/tests/Traits/AssertSnapshotTrait.php
+++ b/tests/Traits/AssertSnapshotTrait.php
@@ -25,7 +25,7 @@ trait AssertSnapshotTrait
      */
     protected function assertResponseSnapshot(
         string $snapshotPatternFilename,
-               $actualResponse,
+        $actualResponse,
         int $statusCode = 200,
         string $message = ''
     ): void {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Replaces the ArticleLinkProvider inheriting from the AbstractContentBundleLinkProvider with a custom implementation that is specifically for Articles. This improves readability and developer experience.

#### Why?

ContentBundle should not be used for concrete implementations, the ArticleRepository should be used for all queries related to articles.