### PR TITLE
Update installation docs to use Elasticsearch 7.17.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Execute the following [composer](https://getcomposer.org/) commands to add the b
 project:
 
 ```bash
-composer require "elasticsearch/elasticsearch:7.9.*" # should match version of your elasticsearch installation
+composer require "elasticsearch/elasticsearch:7.17.*" # should match version of your elasticsearch installation
 composer require sulu/article-bundle
 ```
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -7,7 +7,7 @@ The SuluArticleBundle requires a running elasticsearch `^5.0`, `^6.0` or `^7.0`.
 ## Install dependencies
 
 ```bash
-composer require "elasticsearch/elasticsearch:7.9.*" # should match version of your elasticsearch installation
+composer require "elasticsearch/elasticsearch:7.17.*" # should match version of your elasticsearch installation
 composer require sulu/article-bundle
 ```
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Update installation docs to use Elasticsearch 7.17.*.

#### Why?

New comers mostly will install the latest Elasticsearch 7 version to get started. The `7.9` version does not support PHP 8 and so is a bad default here.
