### PR TITLE
Fix compatibility to symfony 7 in smart content data item

### DIFF
--- a/Content/ArticleDataItem.php
+++ b/Content/ArticleDataItem.php
@@ -21,6 +21,7 @@ use Sulu\Component\SmartContent\ItemInterface;
  *
  * @ExclusionPolicy("all")
  */
+#[ExclusionPolicy('all')]
 class ArticleDataItem implements ItemInterface
 {
     /**
@@ -28,6 +29,7 @@ class ArticleDataItem implements ItemInterface
      *
      * @Expose
      */
+    #[Expose]
     private $id;
 
     /**
@@ -35,6 +37,7 @@ class ArticleDataItem implements ItemInterface
      *
      * @Expose
      */
+    #[Expose]
     private $title;
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/SuluArticleBundle/issues/703
| License | MIT

#### What's in this PR?

Adds additionally to the JMS Serializer Annotation also the Attributes, because with Symfony 7 the Annotations are ignored by default.

#### Why

This ended up in a serialized `resource` (the `ArticleViewDocument`) and was rendered in the Admin as [Object Object]. Furthermore this could end in some projects in a 500 error, because the extended `ArticleViewDocument` was not serializeable by the JMS Serializer.

![image](https://github.com/user-attachments/assets/acf7e862-b44a-477a-8577-4a9278d46015)
