### PR TITLE
Fix issue with none existing webspace in requestAnalyzer in asnyc processes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -45,6 +45,7 @@ $config->setRiskyAllowed(true)
         'phpdoc_to_comment' => [
             'ignored_tags' => ['todo', 'var', 'see', 'phpstan-ignore-next-line'],
         ],
+        'trailing_comma_in_multiline' => false,
     ])
     ->setFinder($finder);
 

--- a/Document/Structure/ContentProxyFactory.php
+++ b/Document/Structure/ContentProxyFactory.php
@@ -43,7 +43,7 @@ class ContentProxyFactory
     public function __construct(
         ContentTypeManagerInterface $contentTypeManager,
         LazyLoadingValueHolderFactory $proxyFactory,
-        RequestStack $requestStack,
+        RequestStack $requestStack
     ) {
         $this->contentTypeManager = $contentTypeManager;
         $this->proxyFactory = $proxyFactory;
@@ -64,7 +64,7 @@ class ContentProxyFactory
                 LazyLoadingInterface $proxy,
                 $method,
                 array $parameters,
-                &$initializer,
+                &$initializer
             ) use ($structure, $data) {
                 $initializer = null;
                 $wrappedObject = new \ArrayObject($this->resolveContent($structure, $data));
@@ -108,7 +108,7 @@ class ContentProxyFactory
                 LazyLoadingInterface $proxy,
                 $method,
                 array $parameters,
-                &$initializer,
+                &$initializer
             ) use ($structure, $data) {
                 $initializer = null;
                 $wrappedObject = new \ArrayObject($this->resolveView($structure, $data));
@@ -150,17 +150,16 @@ class ContentProxyFactory
             return null;
         }
 
-        if ($attributes->hasAttribute('webspaceKey')) {
-            return $attributes->getAttribute('webspaceKey');
+        $webspaceKey = $attributes->getAttribute('webspaceKey');
+        if (\is_string($webspaceKey) && '' !== $webspaceKey) {
+            return $webspaceKey;
         }
 
-        if ($attributes->hasAttribute('webspace')) {
-            $webspace = $attributes->getAttribute('webspace');
-            if ($webspace instanceof Webspace) {
-                return $webspace->getKey();
-            } elseif (\is_string($webspace) && '' !== $webspace) {
-                return $webspace;
-            }
+        $webspace = $attributes->getAttribute('webspace');
+        if ($webspace instanceof Webspace) {
+            return $webspace->getKey();
+        } elseif (\is_string($webspace) && '' !== $webspace) {
+            return $webspace;
         }
 
         return null;

--- a/Document/Structure/ContentProxyFactory.php
+++ b/Document/Structure/ContentProxyFactory.php
@@ -17,6 +17,7 @@ use ProxyManager\Proxy\VirtualProxyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -42,7 +43,7 @@ class ContentProxyFactory
     public function __construct(
         ContentTypeManagerInterface $contentTypeManager,
         LazyLoadingValueHolderFactory $proxyFactory,
-        RequestStack $requestStack
+        RequestStack $requestStack,
     ) {
         $this->contentTypeManager = $contentTypeManager;
         $this->proxyFactory = $proxyFactory;
@@ -63,7 +64,7 @@ class ContentProxyFactory
                 LazyLoadingInterface $proxy,
                 $method,
                 array $parameters,
-                &$initializer
+                &$initializer,
             ) use ($structure, $data) {
                 $initializer = null;
                 $wrappedObject = new \ArrayObject($this->resolveContent($structure, $data));
@@ -107,7 +108,7 @@ class ContentProxyFactory
                 LazyLoadingInterface $proxy,
                 $method,
                 array $parameters,
-                &$initializer
+                &$initializer,
             ) use ($structure, $data) {
                 $initializer = null;
                 $wrappedObject = new \ArrayObject($this->resolveView($structure, $data));
@@ -144,12 +145,24 @@ class ContentProxyFactory
             return null;
         }
 
-        /** @var RequestAttributes $attributes */
         $attributes = $request->attributes->get('_sulu');
-        if (!$attributes) {
+        if (!$attributes instanceof RequestAttributes) {
             return null;
         }
 
-        return $attributes->getAttribute('webspaceKey') ?? $attributes->getAttribute('webspace')->getKey();
+        if ($attributes->hasAttribute('webspaceKey')) {
+            return $attributes->getAttribute('webspaceKey');
+        }
+
+        if ($attributes->hasAttribute('webspace')) {
+            $webspace = $attributes->getAttribute('webspace');
+            if ($webspace instanceof Webspace) {
+                return $webspace->getKey();
+            } elseif (\is_string($webspace) && '' !== $webspace) {
+                return $webspace;
+            }
+        }
+
+        return null;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1461,11 +1461,6 @@ parameters:
 			path: Document/Structure/ContentProxyFactory.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: Document/Structure/ContentProxyFactory.php
-
-		-
 			message: "#^Parameter \\#1 \\$webspace of method Sulu\\\\Component\\\\Content\\\\Compat\\\\StructureInterface\\:\\:setWebspaceKey\\(\\) expects string, string\\|null given\\.$#"
 			count: 2
 			path: Document/Structure/ContentProxyFactory.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | after upgrade https://github.com/sulu/SuluArticleBundle/pull/635 make other project fail
| License | MIT

#### What's in this PR?

Fix issue with none existing webspace in requestAnalyzer in asnyc processes.

#### Why?

RequestAnalyzer may not be set in async messenger processes.