### PR TITLE
Add clearing of different document manager to reindex command

### DIFF
--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -199,10 +199,22 @@ class ReindexCommand extends Command
         $progressBar = new ProgressBar($output, $count);
         $progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%');
         $progressBar->start();
+        $count = 0;
 
         foreach ($documents as $document) {
             $indexer->index($document);
             $progressBar->advance();
+
+            ++$count;
+
+            if (0 === ($count % 100)) {
+                $indexer->flush();
+                $this->documentManager->clear();
+            }
+
+            if (0 === ($count % 500)) {
+                \gc_collect_cycles();
+            }
         }
 
         $indexer->flush();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Add clearing of different document manager to reindex command.

#### Why?

This should avoid usage of memory. Tested project did decrease memory usage from 970mib -> 480mib. I tried to also clearing the entityManager and disable the sqllogger interesting that ended in more usage of the Memory instead of less so I kept the sqllogger disabling out.