### PR TITLE
fix: ArticleBundle 2.6.x still using forms from config/forms_sulu_25_…

### DIFF
--- a/DependencyInjection/SuluArticleExtension.php
+++ b/DependencyInjection/SuluArticleExtension.php
@@ -189,7 +189,7 @@ class SuluArticleExtension extends Extension implements PrependExtensionInterfac
                     ],
                     'forms' => [
                         'directories' => [
-                            \class_exists(LocalizedLastModifiedBehavior::class)
+                            \interface_exists(LocalizedLastModifiedBehavior::class)
                                 ? __DIR__ . '/../Resources/config/forms'
                                 : __DIR__ . '/../Resources/config/forms_sulu_25_or_lower',
                         ],


### PR DESCRIPTION

…or_lower/article_settings.xml

see: https://github.com/sulu/SuluArticleBundle/issues/705

| Q | A
| --- | ---
| Bug? | yes
| New Feature? | no
| SuluArticleBundle Version | 2.6.3
| Sulu Version | 2.6.4

#### Actual Behavior

At the sulu Backend the lastModified fields for Articles as pushed in https://github.com/sulu/SuluArticleBundle/pull/655 are still not visible.

#### Expected Behavior

lastModified Fields should be visible.

#### Steps to Reproduce

Just look at the article settings on PHP 8.3

#### Possible Solutions

sulu/article-bundle/DependencyInjection/SuluArticleExtension.php:192
replaced \class_exists with \interface_exists as LocalizedLastModifiedBehavior seems to be an interface.
Solved my problem of the not showing lastModified fields.
