### PR TITLE
Return LinkConfigurationBuilder instead of LinkConfiguration in the A…

### DIFF
--- a/Builder/ArticleIndexBuilder.php
+++ b/Builder/ArticleIndexBuilder.php
@@ -31,8 +31,10 @@ class ArticleIndexBuilder extends SuluBuilder
 
     public function build()
     {
-        $this->buildForManager($this->container->get('es.manager.live'), $this->input->getOption('destroy'));
-        $this->buildForManager($this->container->get('es.manager.default'), $this->input->getOption('destroy'));
+        $destroy = (bool) $this->input->getOption('destroy');
+
+        $this->buildForManager($this->container->get('es.manager.live'), $destroy);
+        $this->buildForManager($this->container->get('es.manager.default'), $destroy);
     }
 
     /**

--- a/Markup/ArticleLinkProvider.php
+++ b/Markup/ArticleLinkProvider.php
@@ -101,8 +101,7 @@ class ArticleLinkProvider implements LinkProviderInterface
             ->setDisplayProperties(['title'])
             ->setOverlayTitle($this->translator->trans('sulu_article.single_selection_overlay_title', [], 'admin'))
             ->setEmptyText($this->translator->trans('sulu_article.no_article_selected', [], 'admin'))
-            ->setIcon('su-newspaper')
-            ->getLinkConfiguration();
+            ->setIcon('su-newspaper');
     }
 
     public function preload(array $hrefs, $locale, $published = true)

--- a/Tests/Application/config/webspaces/sulu.io.blog.xml
+++ b/Tests/Application/config/webspaces/sulu.io.blog.xml
@@ -31,7 +31,7 @@
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
-            <key>sulucmf_at</key>
+            <key>sulucmf_blog_at</key>
 
             <environments>
                 <environment type="prod">

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## 2.6.11
+
+### Minimum Sulu 2.6.11 required
+
+The `ArticleLinkProvider` now returns the `LinkConfigurationBuilder` from its `getConfiguration()`
+method instead of the built `LinkConfiguration`, so projects can more easily add custom link
+targets. This requires `sulu/sulu: ^2.6.11`, which is able to handle the returned builder.
+
 ## 2.6.10
 
 ### Minimum PHP 8.2, Sulu 2.6 and Elasticsearch 6 required

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "handcraftedinthealps/elasticsearch-dsl": "^6.2.0.1 || ^7.2.0.1",
         "jms/serializer": "^3.3",
         "jms/serializer-bundle": "^3.3 || ^4.0 || ^5.0",
-        "sulu/sulu": "^2.6",
+        "sulu/sulu": "^2.6.11",
         "symfony/config": "^4.3 || ^5.0 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0 || ^7.0",
         "symfony/http-foundation": "^4.3 || ^5.0 || ^6.0 || ^7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,11 +231,6 @@ parameters:
 			path: Content/ArticleSelectionContentType.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\ArticleSelectionContentType\\:\\:preResolve\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Content/ArticleSelectionContentType.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\PageTreeArticleDataProvider\\:\\:createSearch\\(\\) has parameter \\$filters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Content/PageTreeArticleDataProvider.php
@@ -257,11 +252,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\SingleArticleSelectionContentType\\:\\:getViewDocumentIds\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Content/SingleArticleSelectionContentType.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Content\\\\SingleArticleSelectionContentType\\:\\:preResolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: Content/SingleArticleSelectionContentType.php
 
@@ -561,22 +551,7 @@ parameters:
 			path: Document/ArticleDocument.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument\\:\\:setLocale\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/ArticleDocument.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument\\:\\:setOriginalLocale\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/ArticleDocument.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument\\:\\:setPages\\(\\) has parameter \\$pages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Document/ArticleDocument.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument\\:\\:setParent\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: Document/ArticleDocument.php
 
@@ -592,16 +567,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument\\:\\:setStructureType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/ArticleDocument.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument\\:\\:setTitle\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/ArticleDocument.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticleDocument\\:\\:setVersions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: Document/ArticleDocument.php
 
@@ -676,17 +641,17 @@ parameters:
 			path: Document/ArticlePageDocument.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setLocale\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setLocale\\(\\) with return type void returns \\$this\\(Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\) but should not return anything\\.$#"
 			count: 1
 			path: Document/ArticlePageDocument.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setOriginalLocale\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setOriginalLocale\\(\\) with return type void returns \\$this\\(Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\) but should not return anything\\.$#"
 			count: 1
 			path: Document/ArticlePageDocument.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setParent\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setParent\\(\\) with return type void returns \\$this\\(Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\) but should not return anything\\.$#"
 			count: 1
 			path: Document/ArticlePageDocument.php
 
@@ -706,7 +671,7 @@ parameters:
 			path: Document/ArticlePageDocument.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setTitle\\(\\) has no return type specified\\.$#"
+			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\:\\:setTitle\\(\\) with return type void returns \\$this\\(Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\ArticlePageDocument\\) but should not return anything\\.$#"
 			count: 1
 			path: Document/ArticlePageDocument.php
 
@@ -1094,11 +1059,6 @@ parameters:
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: Document/Index/Factory/TagCollectionFactory.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticleInitializer\\:\\:initialize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Document/Initializer/ArticleInitializer.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Document\\\\Initializer\\\\ArticleInitializer\\:\\:initialize\\(\\) has parameter \\$purge with no type specified\\.$#"


### PR DESCRIPTION
…rticle LinkProvder

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/8044
| License | MIT

#### What's in this PR?

Return LinkConfigurationBuilder instead of LinkConfiguration in the ArticleLinkProvider so it's easier to add custom link targets in projects.
