### PR TITLE
Add new column/filter to article-controller

### DIFF
--- a/Controller/ArticleController.php
+++ b/Controller/ArticleController.php
@@ -50,6 +50,7 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Security\SecuredControllerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -119,6 +120,11 @@ class ArticleController extends AbstractRestController implements ClassResourceI
      */
     private $documentInspector;
 
+    /**
+     * @var WebspaceManagerInterface|null
+     */
+    private $webspaceManager;
+
     public function __construct(
         ViewHandlerInterface $viewHandler,
         DocumentManagerInterface $documentManager,
@@ -132,7 +138,8 @@ class ArticleController extends AbstractRestController implements ClassResourceI
         SecurityCheckerInterface $securityChecker,
         bool $displayTabAll,
         ?TokenStorageInterface $tokenStorage = null,
-        ?DocumentInspector $documentInspector = null
+        ?DocumentInspector $documentInspector = null,
+        ?WebspaceManagerInterface $webspaceManager = null
     ) {
         parent::__construct($viewHandler, $tokenStorage);
 
@@ -147,9 +154,14 @@ class ArticleController extends AbstractRestController implements ClassResourceI
         $this->securityChecker = $securityChecker;
         $this->displayTabAll = $displayTabAll;
         $this->documentInspector = $documentInspector;
+        $this->webspaceManager = $webspaceManager;
 
         if (null === $this->documentInspector) {
             @trigger_deprecation('sulu/article-bundle', '2.5', 'Instantiating the ArticleController without the $documentInspector argument is deprecated!');
+        }
+
+        if (null === $this->webspaceManager) {
+            @trigger_deprecation('sulu/article-bundle', '2.6', 'Instantiating the ArticleController without the $webspaceManager argument is deprecated!');
         }
     }
 
@@ -176,6 +188,9 @@ class ArticleController extends AbstractRestController implements ClassResourceI
                 ->setSortField('title.raw')
                 ->setSearchField('title')
                 ->setSearchability(FieldDescriptor::SEARCHABILITY_YES)
+                ->build(),
+            'mainWebspace' => ElasticSearchFieldDescriptor::create('mainWebspace', 'public.main_webspace')
+                ->setSearchability(FieldDescriptor::SEARCHABILITY_NO)
                 ->build(),
             'creatorFullName' => ElasticSearchFieldDescriptor::create('creatorFullName', 'sulu_article.list.creator')
                 ->setSortField('creatorFullName.raw')
@@ -246,6 +261,7 @@ class ArticleController extends AbstractRestController implements ClassResourceI
          *     tagId?: string,
          *     pageId?: string,
          *     publishedState?: string,
+         *     mainWebspace?: string,
          *  } $filter */
         $filter = $request->query->all()['filter'] ?? [];
 
@@ -312,12 +328,18 @@ class ArticleController extends AbstractRestController implements ClassResourceI
             $search->addQuery(new TermQuery('excerpt.tags.id', $tagId), BoolQuery::MUST);
         }
 
-        if ($pageId = $request->get('pageId', $filter['pageId'] ?? null)) {
-            $search->addQuery(new TermQuery('parent_page_uuid', $pageId), BoolQuery::MUST);
+        $pageIdFilter = $request->get('pageId', $filter['pageId'] ?? null);
+        if (\is_string($pageIdFilter) && '' !== $pageIdFilter) {
+            $search->addQuery(new TermQuery('parent_page_uuid', $pageIdFilter), BoolQuery::MUST);
         }
 
         if ($workflowStage = $request->get('workflowStage', $filter['publishedState'] ?? null)) {
             $search->addQuery(new TermQuery('published_state', 'published' === $workflowStage), BoolQuery::MUST);
+        }
+
+        $mainWebspaceFilter = $request->get('mainWebspace', $filter['mainWebspace'] ?? null);
+        if (\is_string($mainWebspaceFilter) && '' !== $mainWebspaceFilter) {
+            $search->addQuery(new TermQuery('main_webspace', $mainWebspaceFilter), BoolQuery::MUST);
         }
 
         if ($this->getBooleanRequestParameter($request, 'exclude-shadows', false, false)) {
@@ -376,8 +398,18 @@ class ArticleController extends AbstractRestController implements ClassResourceI
         $searchResult = $repository->findRaw($search);
         $result = [];
         foreach ($searchResult as $document) {
-            $documentData = $this->normalize($document['_source'], $fieldDescriptors);
+            if (!\is_array($document) || !isset($document['_source'])) {
+                continue;
+            }
+
+            /** @var array<string, mixed> $source */
+            $source = $document['_source'];
+            $documentData = $this->normalize($source, $fieldDescriptors);
             $documentData['ghostLocale'] = 'ghost' == $documentData['localizationState']['state'] ? $documentData['localizationState']['locale'] : null;
+
+            $mainWebspace = $source['main_webspace'] ?? null;
+            $webspace = $this->webspaceManager && \is_string($mainWebspace) ? $this->webspaceManager->getWebspaceCollection()->getWebspace($mainWebspace) : null;
+            $documentData['mainWebspace'] = $webspace ? $webspace->getName() : $mainWebspace;
 
             if (false !== ($index = \array_search($documentData['id'], $ids))) {
                 $result[$index] = $documentData;

--- a/Metadata/ListMetadataVisitor.php
+++ b/Metadata/ListMetadataVisitor.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataVisitorInterface;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 
 /**
  * @final
@@ -31,6 +32,11 @@ class ListMetadataVisitor implements ListMetadataVisitorInterface
     private $structureManager;
 
     /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
      * @var array<string, array{
      *      translation_key: string,
      * }>
@@ -42,9 +48,13 @@ class ListMetadataVisitor implements ListMetadataVisitorInterface
      *      translation_key: string,
      * }> $articleTypeConfigurations
      */
-    public function __construct(StructureManagerInterface $structureManager, array $articleTypeConfigurations)
-    {
+    public function __construct(
+        StructureManagerInterface $structureManager,
+        WebspaceManagerInterface $webspaceManager,
+        array $articleTypeConfigurations
+    ) {
         $this->structureManager = $structureManager;
+        $this->webspaceManager = $webspaceManager;
         $this->articleTypeConfigurations = $articleTypeConfigurations;
     }
 
@@ -54,6 +64,30 @@ class ListMetadataVisitor implements ListMetadataVisitorInterface
             return;
         }
 
+        $this->addMainWebspaceFilter($listMetadata);
+        $this->adaptTypeFilter($listMetadata);
+    }
+
+    protected function addMainWebspaceFilter(ListMetadata $listMetadata): void
+    {
+        $webspaceField = $listMetadata->getField('mainWebspace');
+
+        $webspaces = [];
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            $webspaces[$webspace->getKey()] = $webspace->getName();
+        }
+
+        if (1 === \count($webspaces)) {
+            $listMetadata->removeField('mainWebspace');
+
+            return;
+        }
+
+        $webspaceField->setFilterTypeParameters(['options' => $webspaces]);
+    }
+
+    protected function adaptTypeFilter(ListMetadata $listMetadata): void
+    {
         $typeField = $listMetadata->getField('type');
 
         $types = $this->getTypes();

--- a/Resources/config/lists/articles.xml
+++ b/Resources/config/lists/articles.xml
@@ -27,6 +27,13 @@
             translation="sulu_admin.title"
         />
         <property
+            name="mainWebspace"
+            visibility="no"
+            translation="sulu_article.main_webspace"
+        >
+            <filter type="select"/>
+        </property>
+        <property
             name="creatorFullName"
             visibility="no"
             translation="sulu_admin.creator"

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -57,6 +57,7 @@
             <argument>%sulu_article.display_tab_all%</argument>
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="sulu_document_manager.document_inspector"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>
@@ -541,6 +542,7 @@
             class="Sulu\Bundle\ArticleBundle\Metadata\ListMetadataVisitor"
         >
             <argument type="service" id="sulu.content.structure_manager"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument>%sulu_article.types%</argument>
 
             <tag name="sulu_admin.list_metadata_visitor"/>

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -1857,4 +1857,92 @@ class ArticleControllerTest extends SuluTestCase
     {
         return '/articles/' . Urlizer::urlize($title);
     }
+
+    public function testCGetFilterByMainWebspace()
+    {
+        // Create article with custom webspace
+        $article1 = $this->testPost('Article in sulu_io');
+        $this->client->jsonRequest(
+            'PUT',
+            '/api/articles/' . $article1['id'] . '?locale=de',
+            [
+                'title' => 'Article in sulu_io',
+                'template' => 'default',
+                'mainWebspace' => 'sulu_io',
+            ]
+        );
+        $this->flush();
+
+        // Create article with test webspace
+        $article2 = $this->testPost('Article in test');
+        $this->client->jsonRequest(
+            'PUT',
+            '/api/articles/' . $article2['id'] . '?locale=de',
+            [
+                'title' => 'Article in test',
+                'template' => 'default',
+                'mainWebspace' => 'test',
+            ]
+        );
+        $this->flush();
+
+        // Filter by sulu_io webspace
+        $this->client->jsonRequest('GET', '/api/articles?locale=de&mainWebspace=sulu_io&fields=title,mainWebspace');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(1, $response['total']);
+        $this->assertCount(1, $response['_embedded']['articles']);
+        $this->assertEquals($article1['id'], $response['_embedded']['articles'][0]['id']);
+
+        // Filter by test webspace
+        $this->client->jsonRequest('GET', '/api/articles?locale=de&mainWebspace=test&fields=title,mainWebspace');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(1, $response['total']);
+        $this->assertCount(1, $response['_embedded']['articles']);
+        $this->assertEquals($article2['id'], $response['_embedded']['articles'][0]['id']);
+    }
+
+    public function testCGetMainWebspaceField()
+    {
+        $article = $this->testPost('Test Article');
+        $this->client->jsonRequest(
+            'PUT',
+            '/api/articles/' . $article['id'] . '?locale=de',
+            [
+                'title' => 'Test Article',
+                'template' => 'default',
+                'mainWebspace' => 'sulu_io',
+            ]
+        );
+        $this->flush();
+
+        // Request with mainWebspace field
+        $this->client->jsonRequest('GET', '/api/articles?locale=de&fields=id,title,mainWebspace');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(1, $response['total']);
+        $this->assertArrayHasKey('mainWebspace', $response['_embedded']['articles'][0]);
+
+        // mainWebspace should contain the webspace name, not the key
+        $this->assertIsString($response['_embedded']['articles'][0]['mainWebspace']);
+    }
+
+    public function testCGetMainWebspaceWithNonExistentWebspace()
+    {
+        // Create article with custom webspace
+        $article = $this->testPost('Test Article');
+        $this->flush();
+
+        // Filter by non-existent webspace
+        $this->client->jsonRequest('GET', '/api/articles?locale=de&mainWebspace=nonexistent&fields=title,mainWebspace');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $response = \json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(0, $response['total']);
+        $this->assertCount(0, $response['_embedded']['articles']);
+    }
 }

--- a/Tests/Unit/Metadata/ListMetadataVisitorTest.php
+++ b/Tests/Unit/Metadata/ListMetadataVisitorTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Metadata;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
+use Sulu\Bundle\ArticleBundle\Metadata\ListMetadataVisitor;
+use Sulu\Component\Content\Compat\Structure\StructureBridge;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+
+class ListMetadataVisitorTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy<StructureManagerInterface>
+     */
+    private $structureManager;
+
+    /**
+     * @var ObjectProphecy<WebspaceManagerInterface>
+     */
+    private $webspaceManager;
+
+    /**
+     * @var ListMetadataVisitor
+     */
+    private $visitor;
+
+    /**
+     * @var array<string, array{translation_key: string}>
+     */
+    private $articleTypeConfigurations;
+
+    public function setUp(): void
+    {
+        $this->structureManager = $this->prophesize(StructureManagerInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+
+        $this->articleTypeConfigurations = [
+            'default' => ['translation_key' => 'sulu_article.type.default'],
+            'blog' => ['translation_key' => 'sulu_article.type.blog'],
+        ];
+
+        $this->visitor = new ListMetadataVisitor(
+            $this->structureManager->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->articleTypeConfigurations
+        );
+    }
+
+    public function testVisitListMetadataWithNonArticlesKey(): void
+    {
+        $listMetadata = $this->prophesize(ListMetadata::class);
+        $listMetadata->getField('mainWebspace')->shouldNotBeCalled();
+        $listMetadata->getField('type')->shouldNotBeCalled();
+
+        $this->visitor->visitListMetadata($listMetadata->reveal(), 'pages', 'en');
+    }
+
+    public function testVisitListMetadataWithArticlesKey(): void
+    {
+        $listMetadata = $this->prophesize(ListMetadata::class);
+        $mainWebspaceField = $this->prophesize(FieldMetadata::class);
+        $typeField = $this->prophesize(FieldMetadata::class);
+
+        // Setup webspace collection
+        $webspace1 = $this->prophesize(Webspace::class);
+        $webspace1->getKey()->willReturn('sulu_io');
+        $webspace1->getName()->willReturn('Sulu.io');
+
+        $webspace2 = $this->prophesize(Webspace::class);
+        $webspace2->getKey()->willReturn('test');
+        $webspace2->getName()->willReturn('Test Webspace');
+
+        $webspaceCollection = new WebspaceCollection([
+            $webspace1->reveal(),
+            $webspace2->reveal(),
+        ]);
+
+        $this->webspaceManager->getWebspaceCollection()->willReturn($webspaceCollection);
+
+        // Setup structure manager
+        $structure1 = $this->prophesize(StructureBridge::class);
+        $structureMetadata1 = $this->prophesize(StructureMetadata::class);
+        $structureMetadata1->getTags()->willReturn([]);
+        $structureMetadata1->hasTag('sulu_article.type')->willReturn(false);
+        $structure1->getStructure()->willReturn($structureMetadata1->reveal());
+
+        $this->structureManager->getStructures('article')->willReturn([$structure1->reveal()]);
+
+        $listMetadata->getField('mainWebspace')->willReturn($mainWebspaceField->reveal());
+        $listMetadata->getField('type')->willReturn($typeField->reveal());
+
+        $mainWebspaceField->setFilterTypeParameters([
+            'options' => [
+                'sulu_io' => 'Sulu.io',
+                'test' => 'Test Webspace',
+            ],
+        ])->shouldBeCalled();
+
+        $typeField->setFilterType(null)->shouldNotBeCalled();
+        $typeField->setFilterTypeParameters([
+            'options' => [
+                'default' => 'sulu_article.type.default',
+                'blog' => 'sulu_article.type.blog',
+            ],
+        ])->shouldBeCalled();
+
+        $this->visitor->visitListMetadata($listMetadata->reveal(), 'articles', 'en');
+    }
+
+    public function testVisitListMetadataWithSingleWebspace(): void
+    {
+        $listMetadata = $this->prophesize(ListMetadata::class);
+        $mainWebspaceField = $this->prophesize(FieldMetadata::class);
+        $typeField = $this->prophesize(FieldMetadata::class);
+
+        // Setup webspace collection with single webspace
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('sulu_io');
+        $webspace->getName()->willReturn('Sulu.io');
+
+        $webspaceCollection = new WebspaceCollection([
+            $webspace->reveal(),
+        ]);
+
+        $this->webspaceManager->getWebspaceCollection()->willReturn($webspaceCollection);
+
+        // Setup structure manager
+        $structure = $this->prophesize(StructureBridge::class);
+        $structureMetadata = $this->prophesize(StructureMetadata::class);
+        $structureMetadata->getTags()->willReturn([]);
+        $structureMetadata->hasTag('sulu_article.type')->willReturn(false);
+        $structure->getStructure()->willReturn($structureMetadata->reveal());
+
+        $this->structureManager->getStructures('article')->willReturn([$structure->reveal()]);
+
+        // With single webspace, the field should be removed and return early
+        $listMetadata->getField('mainWebspace')->willReturn($mainWebspaceField->reveal());
+        $listMetadata->removeField('mainWebspace')->shouldBeCalled();
+
+        $listMetadata->getField('type')->willReturn($typeField->reveal());
+
+        $typeField->setFilterTypeParameters([
+            'options' => [
+                'default' => 'sulu_article.type.default',
+                'blog' => 'sulu_article.type.blog',
+            ],
+        ])->shouldBeCalled();
+
+        $this->visitor->visitListMetadata($listMetadata->reveal(), 'articles', 'en');
+    }
+
+    public function testVisitListMetadataWithSingleType(): void
+    {
+        $listMetadata = $this->prophesize(ListMetadata::class);
+        $mainWebspaceField = $this->prophesize(FieldMetadata::class);
+        $typeField = $this->prophesize(FieldMetadata::class);
+
+        // Setup webspace collection
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('sulu_io');
+        $webspace->getName()->willReturn('Sulu.io');
+
+        $webspaceCollection = new WebspaceCollection([
+            $webspace->reveal(),
+        ]);
+
+        $this->webspaceManager->getWebspaceCollection()->willReturn($webspaceCollection);
+
+        // Setup structure manager with single type
+        $this->articleTypeConfigurations = ['default' => ['translation_key' => 'sulu_article.type.default']];
+
+        $this->visitor = new ListMetadataVisitor(
+            $this->structureManager->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->articleTypeConfigurations
+        );
+
+        $structure = $this->prophesize(StructureBridge::class);
+        $structureMetadata = $this->prophesize(StructureMetadata::class);
+        $structureMetadata->getTags()->willReturn([]);
+        $structureMetadata->hasTag('sulu_article.type')->willReturn(false);
+        $structure->getStructure()->willReturn($structureMetadata->reveal());
+
+        $this->structureManager->getStructures('article')->willReturn([$structure->reveal()]);
+
+        // With single webspace, the field should be removed
+        $listMetadata->getField('mainWebspace')->willReturn($mainWebspaceField->reveal());
+        $listMetadata->removeField('mainWebspace')->shouldBeCalled();
+
+        $listMetadata->getField('type')->willReturn($typeField->reveal());
+
+        // With single type, filter should be removed
+        $typeField->setFilterType(null)->shouldBeCalled();
+        $typeField->setFilterTypeParameters(null)->shouldBeCalled();
+
+        $this->visitor->visitListMetadata($listMetadata->reveal(), 'articles', 'en');
+    }
+
+    public function testVisitListMetadataWithStructureType(): void
+    {
+        $listMetadata = $this->prophesize(ListMetadata::class);
+        $mainWebspaceField = $this->prophesize(FieldMetadata::class);
+        $typeField = $this->prophesize(FieldMetadata::class);
+
+        // Setup webspace collection
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('sulu_io');
+        $webspace->getName()->willReturn('Sulu.io');
+
+        $webspaceCollection = new WebspaceCollection([
+            $webspace->reveal(),
+        ]);
+
+        $this->webspaceManager->getWebspaceCollection()->willReturn($webspaceCollection);
+
+        // Setup structure manager with structure that has a type tag
+        $structure = $this->prophesize(StructureBridge::class);
+        $structureMetadata = $this->prophesize(StructureMetadata::class);
+        $structureMetadata->getTags()->willReturn([
+            ['name' => 'sulu_article.type', 'attributes' => ['type' => 'custom']],
+        ]);
+        $structureMetadata->hasTag('sulu_article.type')->willReturn(true);
+        $structureMetadata->getTag('sulu_article.type')->willReturn([
+            'name' => 'sulu_article.type',
+            'attributes' => ['type' => 'custom'],
+        ]);
+        $structure->getStructure()->willReturn($structureMetadata->reveal());
+
+        $this->structureManager->getStructures('article')->willReturn([$structure->reveal()]);
+
+        // With single webspace, the field should be removed
+        $listMetadata->getField('mainWebspace')->willReturn($mainWebspaceField->reveal());
+        $listMetadata->removeField('mainWebspace')->shouldBeCalled();
+
+        $listMetadata->getField('type')->willReturn($typeField->reveal());
+
+        $typeField->setFilterTypeParameters([
+            'options' => [
+                'default' => 'sulu_article.type.default',
+                'blog' => 'sulu_article.type.blog',
+                'custom' => 'Custom',
+            ],
+        ])->shouldBeCalled();
+
+        $this->visitor->visitListMetadata($listMetadata->reveal(), 'articles', 'en');
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -286,11 +286,6 @@ parameters:
 			path: Controller/ArticleController.php
 
 		-
-			message: "#^Cannot access offset '_source' on mixed\\.$#"
-			count: 1
-			path: Controller/ArticleController.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\ArticleBundle\\\\Controller\\\\ArticleController\\:\\:getViewDocumentIds\\(\\) has parameter \\$uuids with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Controller/ArticleController.php
@@ -326,11 +321,6 @@ parameters:
 			path: Controller/ArticleController.php
 
 		-
-			message: "#^Parameter \\#1 \\$document of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Controller\\\\ArticleController\\:\\:normalize\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: Controller/ArticleController.php
-
-		-
 			message: "#^Parameter \\#1 \\$pages of method Sulu\\\\Bundle\\\\ArticleBundle\\\\Controller\\\\ArticleController\\:\\:orderPages\\(\\) expects array, string given\\.$#"
 			count: 1
 			path: Controller/ArticleController.php
@@ -357,7 +347,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$value of class ONGR\\\\ElasticsearchDSL\\\\Query\\\\TermLevel\\\\TermQuery constructor expects bool\\|float\\|int\\|string, mixed given\\.$#"
-			count: 3
+			count: 2
 			path: Controller/ArticleController.php
 
 		-


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #721 
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This Pr introduces a new column "mainWebspace" for the article-list in the admin.

#### Why?

If the installation has mutliple webspaces this column makes sense as the user can filter the articles by the webspace.