### PR TITLE
Fix routePathName subscriber

### DIFF
--- a/Document/Subscriber/RoutePathNameSubscriber.php
+++ b/Document/Subscriber/RoutePathNameSubscriber.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\Document\Subscriber;
+
+use Sulu\Bundle\ArticleBundle\Document\Behavior\RoutableBehavior;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Writes the routePathName property on article PHPCR nodes.
+ *
+ * This property stores the encoded name of the routePath property so that
+ * the PHPCR migration bundle can resolve the correct route URL for each article.
+ */
+class RoutePathNameSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private PropertyEncoder $propertyEncoder,
+        private StructureMetadataFactoryInterface $metadataFactory,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::PERSIST => ['handlePersist', -2048],
+            Events::PUBLISH => ['handlePublish', -2048],
+        ];
+    }
+
+    public function handlePersist(AbstractMappingEvent $event): void
+    {
+        $this->writeRoutePathName($event);
+    }
+
+    public function handlePublish(AbstractMappingEvent $event): void
+    {
+        $this->writeRoutePathName($event);
+    }
+
+    private function writeRoutePathName(AbstractMappingEvent $event): void
+    {
+        $document = $event->getDocument();
+        if (!$document instanceof RoutableBehavior) {
+            return;
+        }
+
+        $locale = $event->getLocale();
+        $routePathPropertyName = $this->getRoutePathPropertyName((string) $document->getStructureType(), $locale);
+
+        $event->getNode()->setProperty(
+            $this->propertyEncoder->localizedContentName(RoutableSubscriber::ROUTE_FIELD_NAME, $locale),
+            $routePathPropertyName,
+        );
+    }
+
+    private function getRoutePathPropertyName(string $structureType, string $locale): string
+    {
+        $metadata = $this->metadataFactory->getStructureMetadata('article', $structureType);
+
+        if (null !== $metadata && $metadata->hasTag(RoutableSubscriber::TAG_NAME)) {
+            /** @var string $name */
+            $name = $metadata->getPropertyByTagName(RoutableSubscriber::TAG_NAME)->getName();
+
+            return $this->propertyEncoder->localizedSystemName($name, $locale);
+        }
+
+        return $this->propertyEncoder->localizedSystemName(RoutableSubscriber::ROUTE_FIELD, $locale);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -219,6 +219,13 @@
 
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>
+        <service id="sulu_article.subscriber.route_path_name"
+                 class="Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutePathNameSubscriber">
+            <argument type="service" id="sulu_document_manager.property_encoder"/>
+            <argument type="service" id="sulu_page.structure.factory"/>
+
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
 
         <service id="sulu_article.initializer"
                  class="Sulu\Bundle\ArticleBundle\Document\Initializer\ArticleInitializer">

--- a/Resources/phpcr-migrations/Version202603181200.php
+++ b/Resources/phpcr-migrations/Version202603181200.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ArticleBundle\PHPCR\Migrations;
+
+use Jackalope\Query\Row;
+use PHPCR\Migrations\VersionInterface;
+use PHPCR\SessionInterface;
+use Sulu\Bundle\ArticleBundle\ContainerAwareInterface;
+use Sulu\Bundle\ArticleBundle\Document\Subscriber\RoutableSubscriber;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\Localization\Localization;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Version202603181200 implements VersionInterface, ContainerAwareInterface
+{
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var StructureMetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        if (null === $container) {
+            throw new \RuntimeException('Container is required to run this migration.');
+        }
+
+        $this->container = $container;
+    }
+
+    public function up(SessionInterface $session)
+    {
+        $this->propertyEncoder = $this->container->get('sulu_document_manager.property_encoder');
+        $this->metadataFactory = $this->container->get('sulu_page.structure.factory');
+
+        $liveSession = $this->container->get('sulu_document_manager.live_session');
+        $this->upgrade($liveSession);
+        $this->upgrade($session);
+
+        $liveSession->save();
+        $session->save();
+    }
+
+    public function down(SessionInterface $session)
+    {
+        $this->propertyEncoder = $this->container->get('sulu_document_manager.property_encoder');
+        $this->metadataFactory = $this->container->get('sulu_page.structure.factory');
+
+        $liveSession = $this->container->get('sulu_document_manager.live_session');
+        $this->downgrade($liveSession);
+        $this->downgrade($session);
+
+        $liveSession->save();
+        $session->save();
+    }
+
+    private function upgrade(SessionInterface $session): void
+    {
+        $queryManager = $session->getWorkspace()->getQueryManager();
+        $localizations = $this->container->get('sulu_core.webspace.webspace_manager')->getAllLocalizations();
+
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:article" OR [jcr:mixinTypes] = "sulu:articlepage")';
+        $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
+
+        /** @var Localization $localization */
+        foreach ($localizations as $localization) {
+            $locale = $localization->getLocale();
+            $templateKey = $this->propertyEncoder->localizedContentName('template', $locale);
+
+            /** @var Row<mixed> $row */
+            foreach ($rows as $row) {
+                $node = $row->getNode();
+                if (!$node->hasProperty($templateKey)) {
+                    continue;
+                }
+                $structureType = $node->getPropertyValue($templateKey);
+                $routePathPropertyName = $this->getRoutePathPropertyName($structureType, $locale);
+
+                $propertyName = $this->propertyEncoder->localizedContentName(RoutableSubscriber::ROUTE_FIELD_NAME, $locale);
+                $node->setProperty($propertyName, $routePathPropertyName);
+            }
+        }
+    }
+
+    private function downgrade(SessionInterface $session)
+    {
+        $queryManager = $session->getWorkspace()->getQueryManager();
+        $localizations = $this->container->get('sulu_core.webspace.webspace_manager')->getAllLocalizations();
+
+        $query = 'SELECT * FROM [nt:unstructured] WHERE ([jcr:mixinTypes] = "sulu:article" OR [jcr:mixinTypes] = "sulu:articlepage")';
+        $rows = $queryManager->createQuery($query, 'JCR-SQL2')->execute();
+
+        /** @var Localization $localization */
+        foreach ($localizations as $localization) {
+            $locale = $localization->getLocale();
+
+            /** @var Row<mixed> $row */
+            foreach ($rows as $row) {
+                $node = $row->getNode();
+                $propertyName = $this->propertyEncoder->localizedContentName(RoutableSubscriber::ROUTE_FIELD_NAME, $locale);
+                if (!$node->hasProperty($propertyName)) {
+                    continue;
+                }
+                $node->setProperty($propertyName, null);
+            }
+        }
+    }
+
+    private function getRoutePathPropertyName(string $structureType, string $locale): string
+    {
+        $metadata = $this->metadataFactory->getStructureMetadata('article', $structureType);
+
+        if ($metadata->hasPropertyWithTagName(RoutableSubscriber::TAG_NAME)) {
+            return $this->getPropertyName($locale, $metadata->getPropertyByTagName(RoutableSubscriber::TAG_NAME)->getName());
+        }
+
+        return $this->getPropertyName($locale, RoutableSubscriber::ROUTE_FIELD);
+    }
+
+    private function getPropertyName(string $locale, string $field): string
+    {
+        return $this->propertyEncoder->localizedSystemName($field, $locale);
+    }
+}

--- a/Tests/Functional/Controller/ArticleControllerTest.php
+++ b/Tests/Functional/Controller/ArticleControllerTest.php
@@ -1945,4 +1945,37 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertEquals(0, $response['total']);
         $this->assertCount(0, $response['_embedded']['articles']);
     }
+
+    public function testRoutePathNameIsWrittenOnPersist(): void
+    {
+        $document = $this->documentManager->create('article');
+        $document->setTitle('Route-Path-Name-Test');
+        $document->setStructureType('default');
+
+        $this->documentManager->persist($document, 'de');
+        $this->documentManager->flush();
+
+        $session = $this->getContainer()->get('sulu_document_manager.default_session');
+        $node = $session->getNodeByIdentifier($document->getUuid());
+
+        $this->assertTrue($node->hasProperty('i18n:de-routePathName'));
+        $this->assertSame('i18n:de-routePath', $node->getPropertyValue('i18n:de-routePathName'));
+    }
+
+    public function testRoutePathNameIsWrittenOnPublish(): void
+    {
+        $document = $this->documentManager->create('article');
+        $document->setTitle('Route-Path-Name-Publish-Test');
+        $document->setStructureType('default');
+
+        $this->documentManager->persist($document, 'de');
+        $this->documentManager->publish($document, 'de');
+        $this->documentManager->flush();
+
+        $liveSession = $this->getContainer()->get('sulu_document_manager.live_session');
+        $liveNode = $liveSession->getNodeByIdentifier($document->getUuid());
+
+        $this->assertTrue($liveNode->hasProperty('i18n:de-routePathName'));
+        $this->assertSame('i18n:de-routePath', $liveNode->getPropertyValue('i18n:de-routePathName'));
+    }
 }


### PR DESCRIPTION
 | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | License | MIT

  #### What's in this PR?

  - Added new `RoutePathNameSubscriber` that writes the `routePathName` property on article PHPCR nodes during persist and publish
  - Added PHPCR migration `Version202603181200` to backfill `routePathName` on all existing article nodes (both default and live sessions)
  - Added functional tests verifying `routePathName` is written on persist and publish

  #### Why?

  The `routePathName` property was introduced in #683 to store the encoded route path property name on article PHPCR nodes, which is needed by the PHPCR migration bundle to resolve the correct route URLs during
  migration.

  However, the property was not written because the `RoutableSubscriber` (which contained the write logic) had its service registration removed somehow.

  This PR fixes the issue by introducing a dedicated `RoutePathNameSubscriber` that solely handles writing the `routePathName` property. A new PHPCR migration re-runs the backfill for all existing articles since
  the original migration had no effect.

  #### To Do

  - [ ] Create a documentation PR