### PR TITLE
Add new requirements to upgrade.md

### DIFF
--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -2,7 +2,7 @@
 
 ### ElasticSearch
 
-The SuluArticleBundle requires a running elasticsearch `^5.0`, `^6.0` or `^7.0`.
+The SuluArticleBundle requires a running elasticsearch `^6.0` or `^7.0`.
 
 ## Install dependencies
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,23 @@
 # Upgrade
 
+## 2.6.10
+
+### Minimum PHP 8.2, Sulu 2.6 and Elasticsearch 6 required
+
+Support for PHP 7.3, 7.4, 8.0, and 8.1 has been dropped. The bundle now requires PHP `^8.2`,
+`sulu/sulu: ^2.6` and `elasticsearch/elasticsearch: ^6.0 || ^7.0`.
+
+### RoutePathName migration
+
+The `routePathName` property on article PHPCR nodes was not being written correctly.
+A PHPCR migration is included to backfill the property on all existing article nodes.
+
+Run the following command after upgrading:
+
+```bash
+bin/adminconsole phpcr:migrations:migrate
+```
+
 ## 2.5.2
 
 ### Rename WebsiteArticleController::renderBlock to WebsiteArticleController::renderBlockView


### PR DESCRIPTION
 | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Related issues/PRs | #724, #725
  | License | MIT

  #### What's in this PR?

  Added UPGRADE.md entry for 2.6.10 covering:
  - Minimum PHP 8.2, Sulu 2.6, and Elasticsearch 6 requirements
  - PHPCR migration for the `routePathName` property fix