### PR TITLE
Track references for single_article_selection and article_selection content types

### DIFF
--- a/Content/ArticleSelectionContentType.php
+++ b/Content/ArticleSelectionContentType.php
@@ -13,8 +13,11 @@ namespace Sulu\Bundle\ArticleBundle\Content;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
 use ONGR\ElasticsearchDSL\Query\TermLevel\IdsQuery;
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Document\ArticleViewDocumentInterface;
 use Sulu\Bundle\ArticleBundle\Metadata\ArticleViewDocumentIdTrait;
+use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterface;
+use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
@@ -23,7 +26,7 @@ use Sulu\Component\Content\SimpleContentType;
 /**
  * Provides article_selection content-type.
  */
-class ArticleSelectionContentType extends SimpleContentType implements PreResolvableContentTypeInterface
+class ArticleSelectionContentType extends SimpleContentType implements PreResolvableContentTypeInterface, ReferenceContentTypeInterface
 {
     use ArticleViewDocumentIdTrait;
 
@@ -88,6 +91,26 @@ class ArticleSelectionContentType extends SimpleContentType implements PreResolv
 
         foreach ($uuids as $uuid) {
             $this->referenceStore->add($uuid);
+        }
+    }
+
+    public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
+    {
+        $uuids = $property->getValue();
+        if (!\is_array($uuids)) {
+            return;
+        }
+
+        foreach ($uuids as $uuid) {
+            if (!\is_string($uuid) || '' === $uuid) {
+                continue;
+            }
+
+            $referenceCollector->addReference(
+                ArticleDocument::RESOURCE_KEY,
+                $uuid,
+                $propertyPrefix . $property->getName()
+            );
         }
     }
 }

--- a/Content/SingleArticleSelectionContentType.php
+++ b/Content/SingleArticleSelectionContentType.php
@@ -12,7 +12,10 @@
 namespace Sulu\Bundle\ArticleBundle\Content;
 
 use ONGR\ElasticsearchBundle\Service\Manager;
+use Sulu\Bundle\ArticleBundle\Document\ArticleDocument;
 use Sulu\Bundle\ArticleBundle\Metadata\ArticleViewDocumentIdTrait;
+use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterface;
+use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
@@ -21,7 +24,7 @@ use Sulu\Component\Content\SimpleContentType;
 /**
  * Provides article_selection content-type.
  */
-class SingleArticleSelectionContentType extends SimpleContentType implements PreResolvableContentTypeInterface
+class SingleArticleSelectionContentType extends SimpleContentType implements PreResolvableContentTypeInterface, ReferenceContentTypeInterface
 {
     use ArticleViewDocumentIdTrait;
 
@@ -74,5 +77,19 @@ class SingleArticleSelectionContentType extends SimpleContentType implements Pre
         }
 
         $this->referenceStore->add($uuid);
+    }
+
+    public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
+    {
+        $uuid = $property->getValue();
+        if (!\is_string($uuid) || '' === $uuid) {
+            return;
+        }
+
+        $referenceCollector->addReference(
+            ArticleDocument::RESOURCE_KEY,
+            $uuid,
+            $propertyPrefix . $property->getName()
+        );
     }
 }

--- a/Tests/Application/config/templates/articles/default_image.xml
+++ b/Tests/Application/config/templates/articles/default_image.xml
@@ -15,5 +15,7 @@
         <property name="title" type="text_line" mandatory="true"/>
         <property name="pageTitle" type="text_line"/>
         <property name="image" type="single_media_selection"/>
+        <property name="article" type="single_article_selection"/>
+        <property name="articles" type="article_selection"/>
     </properties>
 </template>

--- a/Tests/Functional/Reference/Provider/ArticleReferenceProviderTest.php
+++ b/Tests/Functional/Reference/Provider/ArticleReferenceProviderTest.php
@@ -80,6 +80,46 @@ class ArticleReferenceProviderTest extends SuluTestCase
         self::assertSame((string) $media->getId(), $references[0]->getResourceId());
     }
 
+    public function testUpdateArticleSelectionReferences(): void
+    {
+        if (!\interface_exists(ReferenceRefresherInterface::class)) {
+            $this->markTestSkipped('References did not exist in Sulu <2.6.');
+        }
+
+        /** @var \Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument $targetArticle */
+        $targetArticle = $this->documentManager->create('article');
+        $targetArticle->setTitle('Target article');
+        $targetArticle->setStructureType('default_image');
+        $this->documentManager->persist($targetArticle, 'en');
+        $this->documentManager->publish($targetArticle, 'en');
+        $this->documentManager->flush();
+
+        /** @var \Sulu\Bundle\ArticleBundle\Tests\TestExtendBundle\Document\ArticleDocument $article */
+        $article = $this->documentManager->create('article');
+        $article->setTitle('Example article');
+        $article->setStructureType('default_image');
+        $article->getStructure()->bind([
+            'article' => $targetArticle->getUuid(),
+            'articles' => [$targetArticle->getUuid()],
+        ]);
+        $this->documentManager->persist($article, 'en');
+        $this->documentManager->publish($article, 'en');
+        $this->documentManager->flush();
+
+        $this->articleReferenceProvider->updateReferences($article, 'en', 'test');
+        $this->getEntityManager()->flush();
+
+        /** @var Reference[] $references */
+        $references = $this->referenceRepository->findBy(['referenceContext' => 'test'], ['referenceProperty' => 'ASC']);
+
+        // one reference from the single_article_selection, one from the article_selection, both pointing at the target article
+        $this->assertCount(2, $references);
+        foreach ($references as $reference) {
+            self::assertSame(ArticleDocument::RESOURCE_KEY, $reference->getResourceKey());
+            self::assertSame($targetArticle->getUuid(), $reference->getResourceId());
+        }
+    }
+
     public function testUpdateUnpublishedReferences(): void
     {
         if (!\interface_exists(ReferenceRefresherInterface::class)) {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,18 @@
 # Upgrade
 
+## 2.6.12
+
+### Reference tracking for article selections
+
+The `single_article_selection` and `article_selection` content types now register their selected
+articles in the reference table, like the snippet and media selections in core already do. Content
+that uses these types only gets reference rows on its next publish, so refresh existing content once
+after upgrading:
+
+```bash
+bin/console sulu:reference:refresh
+```
+
 ## 2.6.11
 
 ### Minimum Sulu 2.6.11 required


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | |
| Related issues/PRs | sulu/sulu#9075 |
| License | MIT

#### What's in this PR?

`SingleArticleSelectionContentType` and `ArticleSelectionContentType` now implement `ReferenceContentTypeInterface`, so publishing content that selects an article writes a `Reference` row for it. Includes a functional test covering both content types and an UPGRADE.md entry with a `sulu:reference:refresh` backfill note.

#### Why?

Neither content type tracked references before, so `ReferencePublishSubscriber` never found anything to republish when a selected article changed. Same gap already fixed for `single_page_selection`/`teaser_selection` in sulu/sulu#9075.

#### BC Breaks/Deprecations

None.

#### To Do

- [x] Add documentation page (UPGRADE.md)